### PR TITLE
feat: phase 1 testability — offline dev loop, inbox integration tests, deser hardening

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -148,11 +148,23 @@ command = "dx"
 args = ["serve", "--features", "use-node"]
 cwd = "./ui"
 
-[tasks.dev-ui-testing]
-description = "Local dev server with UI testing mode"
-dependencies = ["build-contracts"]
+[tasks.dev-example]
+description = "Local dev server with example data, no node sync (offline)"
+# Intentionally no `build-contracts` dependency: the whole point of this
+# target is that it works on a clean clone with zero contract artifacts.
 command = "dx"
-args = ["serve", "--features", "ui-testing", "--no-default-features"]
+args = ["serve", "--features", "example-data,no-sync", "--no-default-features"]
+cwd = "./ui"
+
+[tasks.build-ui-example-no-sync]
+description = "Release build of the UI in offline mode (for CI/Playwright)"
+command = "dx"
+args = [
+    "build",
+    "--${BUILD_PROFILE}",
+    "--features", "example-data,no-sync",
+    "--no-default-features",
+]
 cwd = "./ui"
 
 [tasks.publish]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -185,6 +185,16 @@ description = "Run all tests"
 command = "cargo"
 args = ["test", "--workspace"]
 
+[tasks.test-inbox]
+description = "Run inbox contract integration tests (host build)"
+command = "cargo"
+args = [
+    "test",
+    "-p", "freenet-email-inbox",
+    "--features", "contract",
+    "--test", "integration",
+]
+
 [tasks.clippy]
 description = "Run clippy on all packages"
 command = "cargo"

--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -238,26 +238,7 @@ impl Inbox {
         message
             .token_assignment
             .is_valid(&verifying_key)
-            .map_err(|e| {
-                #[cfg(target_family = "wasm")]
-                {
-                    match &e {
-                        TokenInvalidReason::SignatureMismatch => {
-                            use rsa::pkcs8::EncodePublicKey;
-                            let pk = message
-                                .token_assignment
-                                .generator
-                                .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
-                                .unwrap()
-                                .split_whitespace()
-                                .collect::<String>();
-                            // freenet_stdlib::log::info(&format!("veryifying key inbox: `{pk}`"));
-                        }
-                        _ => {}
-                    }
-                }
-                VerificationError::InvalidToken(e)
-            })?;
+            .map_err(VerificationError::InvalidToken)?;
         self.messages.push(message);
         Ok(())
     }

--- a/contracts/inbox/tests/common/mod.rs
+++ b/contracts/inbox/tests/common/mod.rs
@@ -1,0 +1,198 @@
+//! Reusable crypto + state-construction helpers for inbox integration tests.
+//!
+//! These tests run as native Rust (`--features contract`), driving the
+//! `ContractInterface` impl directly without going through the WASM FFI.
+//! Each test that needs a freshly-signed inbox / token / message reaches in
+//! through this module so the round-trip / validation / token-gating tests
+//! stay focused on the assertion they care about.
+#![allow(dead_code)] // helpers are picked up à la carte by individual test files
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, TimeZone, Utc};
+use freenet_aft_interface::{Tier, TokenAllocationRecord, TokenAssignment};
+use freenet_email_inbox::{InboxParams, InboxSettings, Message, UpdateInbox};
+use freenet_stdlib::prelude::{
+    ContractInstanceId, Parameters, RelatedContracts, State, StateDelta, UpdateData,
+};
+use rsa::{
+    pkcs1v15::SigningKey,
+    rand_core::OsRng,
+    sha2::{Digest, Sha256},
+    signature::Signer,
+    RsaPrivateKey, RsaPublicKey,
+};
+use serde_json::{json, Value};
+
+/// Generate a fresh 2048-bit RSA keypair for use as either an inbox owner or
+/// an AFT token generator. 2048 keeps host-test wall time bearable.
+pub fn make_keypair() -> (RsaPrivateKey, RsaPublicKey) {
+    let sk = RsaPrivateKey::new(&mut OsRng, 2048).expect("rsa keygen");
+    let pk = sk.to_public_key();
+    (sk, pk)
+}
+
+/// Build the serialized [`InboxParams`] (a JSON-encoded `Parameters` blob)
+/// for the given owner public key.
+pub fn make_params(owner_pub: RsaPublicKey) -> Parameters<'static> {
+    InboxParams { pub_key: owner_pub }
+        .try_into()
+        .expect("inbox params -> parameters")
+}
+
+/// Pick a deterministic, valid `Tier::Min1` slot well in the past so that
+/// `is_valid_slot` accepts it. The chosen instant is rounded to second 0 of
+/// minute 0 of hour 0, which is also valid for every coarser tier.
+pub fn fixed_valid_slot() -> DateTime<Utc> {
+    // 2024-01-01T00:00:00Z — round to the start of the day, which is a
+    // valid slot for every Tier (Min1 through Day365 anchored from year 1).
+    Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap()
+}
+
+/// Build a token assignment signed by `generator_sk`. The signed payload is
+/// `(tier_byte, time_slot.timestamp_le_bytes, assignment_hash)` per the
+/// contract documented on [`TokenAssignment::signature_content`].
+///
+/// `token_record` is the contract-instance ID that
+/// [`TokenAllocationRecord`] entries are keyed by — pick any stable value
+/// per test; the helper does not enforce uniqueness.
+pub fn make_token_assignment(
+    generator_sk: &RsaPrivateKey,
+    tier: Tier,
+    time_slot: DateTime<Utc>,
+    assignment_hash: [u8; 32],
+    token_record: ContractInstanceId,
+) -> TokenAssignment {
+    let to_sign =
+        TokenAssignment::signature_content(&time_slot, tier, &assignment_hash);
+    let signing_key = SigningKey::<Sha256>::new(generator_sk.clone());
+    let signature = signing_key.sign(&to_sign);
+    TokenAssignment {
+        tier,
+        time_slot,
+        generator: generator_sk.to_public_key(),
+        signature,
+        assignment_hash,
+        token_record,
+    }
+}
+
+/// Wrap an opaque encrypted blob with a token assignment. The contract does
+/// not introspect `content`, so a placeholder body is fine for tests that
+/// only exercise validation / merge / token gating.
+pub fn make_message(content: Vec<u8>, token: TokenAssignment) -> Message {
+    Message {
+        content,
+        token_assignment: token,
+    }
+}
+
+/// Build an [`Inbox`] signed by `owner_sk` and serialize it as a `State`.
+///
+/// We hand-roll the JSON wire format here because `Inbox::new` and
+/// `inbox_signature` are private to the inbox crate; the integration test
+/// harness lives in a sibling crate and only sees the public API. Matches
+/// the format produced by `Inbox::serialize` (verified by the existing
+/// `validate_test` unit test in `src/lib.rs`).
+pub fn make_inbox_state(
+    owner_sk: &RsaPrivateKey,
+    messages: Vec<Message>,
+    last_update: DateTime<Utc>,
+    settings: InboxSettings,
+) -> State<'static> {
+    // The inbox signs `STATE_UPDATE` (a fixed 8-byte salt) at construction
+    // time. The exact bytes don't need to round-trip because `verify` only
+    // checks the signature, not equality with any stored payload.
+    const STATE_UPDATE: &[u8; 8] = &[168, 7, 13, 64, 168, 123, 142, 215];
+    let signing_key = SigningKey::<Sha256>::new(owner_sk.clone());
+    let signature = signing_key.sign(STATE_UPDATE);
+    let signature_bytes: Box<[u8]> =
+        rsa::signature::SignatureEncoding::to_bytes(&signature);
+
+    let inbox_json: Value = json!({
+        "messages": messages,
+        "last_update": last_update,
+        "settings": settings,
+        "inbox_signature": signature_bytes.as_ref(),
+    });
+    let bytes = serde_json::to_vec(&inbox_json).expect("serialize inbox");
+    State::from(bytes)
+}
+
+/// Same as [`make_inbox_state`] but returns the parsed JSON object so a
+/// caller can flip a single field (e.g. tamper with `last_update`) before
+/// re-serializing. Used by the signature-rejection test.
+pub fn make_inbox_value(
+    owner_sk: &RsaPrivateKey,
+    messages: Vec<Message>,
+    last_update: DateTime<Utc>,
+    settings: InboxSettings,
+) -> Value {
+    const STATE_UPDATE: &[u8; 8] = &[168, 7, 13, 64, 168, 123, 142, 215];
+    let signing_key = SigningKey::<Sha256>::new(owner_sk.clone());
+    let signature = signing_key.sign(STATE_UPDATE);
+    let signature_bytes: Box<[u8]> =
+        rsa::signature::SignatureEncoding::to_bytes(&signature);
+    json!({
+        "messages": messages,
+        "last_update": last_update,
+        "settings": settings,
+        "inbox_signature": signature_bytes.as_ref(),
+    })
+}
+
+/// Build a [`TokenAllocationRecord`] containing the supplied assignment.
+/// `validate_state` / `update_state` look up records in the
+/// [`RelatedContracts`] map by `token_record` instance id, so the helper
+/// returns both the record and the keyed entry to plug into a `RelatedContracts`.
+pub fn make_token_record(assignment: TokenAssignment) -> TokenAllocationRecord {
+    let mut by_tier = HashMap::new();
+    by_tier.insert(assignment.tier, vec![assignment]);
+    TokenAllocationRecord::new(by_tier)
+}
+
+/// Wrap a [`TokenAllocationRecord`] in a `RelatedContracts` keyed by the
+/// supplied `token_record` id. This is what `validate_state` will read.
+pub fn related_contracts_with(
+    token_record_id: ContractInstanceId,
+    record: TokenAllocationRecord,
+) -> RelatedContracts<'static> {
+    let state: State<'static> = TryFrom::try_from(record).expect("record -> state");
+    let mut map: HashMap<ContractInstanceId, Option<State<'static>>> = HashMap::new();
+    map.insert(token_record_id, Some(state));
+    RelatedContracts::from(map)
+}
+
+/// Build an `UpdateData::Delta(AddMessages)` payload for `update_state`.
+pub fn add_messages_delta(messages: Vec<Message>) -> UpdateData<'static> {
+    let delta = UpdateInbox::AddMessages { messages };
+    let bytes = serde_json::to_vec(&delta).expect("serialize delta");
+    UpdateData::Delta(StateDelta::from(bytes))
+}
+
+/// Build an `UpdateData::RelatedState` carrying a token allocation record.
+pub fn related_state_update(
+    token_record_id: ContractInstanceId,
+    record: TokenAllocationRecord,
+) -> UpdateData<'static> {
+    let state: State<'static> = TryFrom::try_from(record).expect("record -> state");
+    UpdateData::RelatedState {
+        related_to: token_record_id,
+        state,
+    }
+}
+
+/// Hash an arbitrary identifier into a 32-byte assignment hash. Useful for
+/// tests that need a stable hash but do not care about its semantic content.
+pub fn assignment_hash_for(seed: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(seed);
+    hasher.finalize().into()
+}
+
+/// Construct a `ContractInstanceId` deterministically from a seed. The
+/// inbox contract treats this as an opaque key, so any 32-byte value works.
+pub fn token_record_id_for(seed: &[u8]) -> ContractInstanceId {
+    let bytes = assignment_hash_for(seed);
+    ContractInstanceId::new(bytes)
+}

--- a/contracts/inbox/tests/integration.rs
+++ b/contracts/inbox/tests/integration.rs
@@ -1,0 +1,305 @@
+//! Integration tests for the inbox contract's `ContractInterface` impl.
+//!
+//! These tests run native Rust against the `contract`-feature build of the
+//! crate, exercising `validate_state`, `update_state`, `summarize_state`,
+//! and `get_state_delta` directly. They are intentionally split from the
+//! single in-file `validate_test` so that the helper module under
+//! `tests/common/` can be reused as the contract grows.
+
+#![cfg(feature = "contract")]
+
+mod common;
+
+use chrono::{Duration, Utc};
+use common::{
+    add_messages_delta, assignment_hash_for, fixed_valid_slot, make_inbox_state,
+    make_inbox_value, make_keypair, make_message, make_params, make_token_assignment,
+    make_token_record, related_state_update, token_record_id_for,
+};
+use freenet_aft_interface::Tier;
+use freenet_email_inbox::{Inbox, InboxSettings};
+use freenet_stdlib::prelude::{
+    ContractInterface, RelatedContracts, State, UpdateModification, ValidateResult,
+};
+
+// ─── validate_state ──────────────────────────────────────────────────────
+
+#[test]
+fn validate_accepts_signed_empty_inbox() {
+    let (owner_sk, owner_pk) = make_keypair();
+    let params = make_params(owner_pk);
+    let state = make_inbox_state(
+        &owner_sk,
+        vec![],
+        Utc::now(),
+        InboxSettings::default(),
+    );
+
+    let result = Inbox::validate_state(params, state, RelatedContracts::new())
+        .expect("validate_state");
+    assert_eq!(
+        result,
+        ValidateResult::Valid,
+        "an empty inbox signed by the owner key must validate"
+    );
+}
+
+#[test]
+fn validate_rejects_tampered_last_update() {
+    let (owner_sk, owner_pk) = make_keypair();
+    let params = make_params(owner_pk);
+
+    // Build a signed inbox, then mutate `last_update` post-signing. The
+    // signature itself doesn't cover `last_update` (it covers a fixed salt),
+    // so the on-the-wire payload still parses — but the test documents the
+    // current behavior of the validator and locks in that we never reach
+    // `Invalid` for a signature mismatch on this field. If/when the contract
+    // is hardened to cover `last_update` in the signature, this test should
+    // flip to `assert_eq!(result, ValidateResult::Invalid)`.
+    let mut value = make_inbox_value(
+        &owner_sk,
+        vec![],
+        Utc::now(),
+        InboxSettings::default(),
+    );
+    value["last_update"] = serde_json::json!("1999-01-01T00:00:00Z");
+    let bytes = serde_json::to_vec(&value).expect("serialize tampered inbox");
+    let state = State::from(bytes);
+
+    let result = Inbox::validate_state(params, state, RelatedContracts::new())
+        .expect("validate_state");
+    // Documented behavior: `last_update` is not part of the signed payload,
+    // so the validator currently accepts the tampered state. The test exists
+    // to make this fact visible and to fail loudly if the contract changes.
+    assert_eq!(result, ValidateResult::Valid);
+}
+
+#[test]
+fn validate_rejects_wrong_owner_signature() {
+    // Sign with `attacker_sk` but advertise `owner_pk` in the parameters —
+    // the verifier should reject.
+    let (_owner_sk, owner_pk) = make_keypair();
+    let (attacker_sk, _attacker_pk) = make_keypair();
+    let params = make_params(owner_pk);
+    let state = make_inbox_state(
+        &attacker_sk,
+        vec![],
+        Utc::now(),
+        InboxSettings::default(),
+    );
+
+    let result = Inbox::validate_state(params, state, RelatedContracts::new());
+    // `verify` returns `Err(VerificationError::WrongSignature)` which the
+    // `From` impl on `ContractError` collapses to `InvalidUpdate`. The outer
+    // `?` in `validate_state` then propagates that as `Err`.
+    assert!(
+        result.is_err(),
+        "a state signed by a non-owner key must not validate; got {result:?}"
+    );
+}
+
+// ─── update_state: AddMessages ───────────────────────────────────────────
+
+#[test]
+fn update_accepts_add_message_with_valid_token() {
+    let (owner_sk, owner_pk) = make_keypair();
+    let (gen_sk, _gen_pk) = make_keypair();
+    let params = make_params(owner_pk);
+
+    let token_record_id = token_record_id_for(b"valid-token-record");
+    let assignment = make_token_assignment(
+        &gen_sk,
+        Tier::Day1,
+        fixed_valid_slot(),
+        assignment_hash_for(b"msg-1"),
+        token_record_id,
+    );
+    let message = make_message(b"opaque-encrypted-payload".to_vec(), assignment.clone());
+    let record = make_token_record(assignment);
+
+    let initial_state = make_inbox_state(
+        &owner_sk,
+        vec![],
+        Utc::now(),
+        InboxSettings::default(),
+    );
+    let updates = vec![
+        add_messages_delta(vec![message]),
+        related_state_update(token_record_id, record),
+    ];
+
+    let modification = Inbox::update_state(params, initial_state, updates)
+        .expect("update_state should succeed");
+    let new_state = unwrap_valid(modification);
+    let parsed: serde_json::Value =
+        serde_json::from_slice(new_state.as_ref()).expect("inbox json");
+    assert_eq!(
+        parsed["messages"]
+            .as_array()
+            .map(|m| m.len())
+            .unwrap_or(0),
+        1,
+        "the new message should be persisted in the inbox state"
+    );
+}
+
+#[test]
+fn update_rejects_message_with_unknown_token_record() {
+    // AddMessages without a corresponding RelatedState carrying the token
+    // allocation record: `update_state` should report the missing record
+    // via `requires(...)` rather than persisting the message.
+    let (owner_sk, owner_pk) = make_keypair();
+    let (gen_sk, _) = make_keypair();
+    let params = make_params(owner_pk);
+
+    let token_record_id = token_record_id_for(b"unknown-record");
+    let assignment = make_token_assignment(
+        &gen_sk,
+        Tier::Day1,
+        fixed_valid_slot(),
+        assignment_hash_for(b"msg-orphan"),
+        token_record_id,
+    );
+    let message = make_message(b"orphan-message".to_vec(), assignment);
+
+    let initial_state = make_inbox_state(
+        &owner_sk,
+        vec![],
+        Utc::now(),
+        InboxSettings::default(),
+    );
+    let updates = vec![add_messages_delta(vec![message])];
+
+    let modification = Inbox::update_state(params, initial_state, updates)
+        .expect("update_state");
+    assert!(
+        is_requires_more(&modification),
+        "missing token allocation record should produce `requires(...)`, got {modification:?}"
+    );
+}
+
+#[test]
+fn update_rejects_token_with_invalid_slot() {
+    // `Tier::Min1` requires the time slot to land on `:00.000`. Use a slot
+    // with a non-zero second to trip `is_valid_slot` inside `add_message`.
+    let (owner_sk, owner_pk) = make_keypair();
+    let (gen_sk, _) = make_keypair();
+    let params = make_params(owner_pk);
+
+    let token_record_id = token_record_id_for(b"bad-slot-record");
+    let bad_slot = fixed_valid_slot() + Duration::seconds(13);
+    let assignment = make_token_assignment(
+        &gen_sk,
+        Tier::Min1,
+        bad_slot,
+        assignment_hash_for(b"msg-bad-slot"),
+        token_record_id,
+    );
+    let message = make_message(b"bad-slot-message".to_vec(), assignment.clone());
+    // Provide the related token-allocation record so the rejection is
+    // attributable to the slot check, not to a missing record.
+    let record = make_token_record(assignment);
+
+    let initial_state = make_inbox_state(
+        &owner_sk,
+        vec![],
+        Utc::now(),
+        InboxSettings::default(),
+    );
+    let updates = vec![
+        add_messages_delta(vec![message]),
+        related_state_update(token_record_id, record),
+    ];
+
+    let result = Inbox::update_state(params, initial_state, updates);
+    assert!(
+        result.is_err(),
+        "an invalid time slot should produce an error from update_state; got {result:?}"
+    );
+}
+
+// ─── summarize_state / get_state_delta round trip ────────────────────────
+
+#[test]
+fn summarize_then_delta_yields_only_new_messages() {
+    let (owner_sk, owner_pk) = make_keypair();
+    let (gen_sk, _) = make_keypair();
+    let params = make_params(owner_pk.clone());
+
+    let token_record_id = token_record_id_for(b"round-trip-record");
+    let assignment_old = make_token_assignment(
+        &gen_sk,
+        Tier::Day1,
+        fixed_valid_slot(),
+        assignment_hash_for(b"msg-old"),
+        token_record_id,
+    );
+    let msg_old = make_message(b"older-message".to_vec(), assignment_old);
+
+    // Build an inbox state that already contains `msg_old`. The inbox's
+    // `add_message` only validates the token, not the record map, when
+    // we hand-roll the state via JSON, so we can skip the related-contracts
+    // dance for `summarize` / `get_state_delta` (those methods don't touch
+    // the related-contracts API).
+    let state = make_inbox_state(
+        &owner_sk,
+        vec![msg_old.clone()],
+        Utc::now(),
+        InboxSettings::default(),
+    );
+
+    // Summarize: returns the set of `assignment_hash` values currently in
+    // the inbox.
+    let summary =
+        Inbox::summarize_state(make_params(owner_pk.clone()), state.clone())
+            .expect("summarize_state");
+
+    // Delta against an empty summary: every message in the state should
+    // appear in the delta.
+    let empty_summary =
+        Inbox::summarize_state(make_params(owner_pk.clone()), make_inbox_state(
+            &owner_sk,
+            vec![],
+            Utc::now(),
+            InboxSettings::default(),
+        ))
+        .expect("summarize empty");
+    let delta_full = Inbox::get_state_delta(params, state, empty_summary)
+        .expect("get_state_delta against empty summary");
+    let delta_full_json: serde_json::Value =
+        serde_json::from_slice(delta_full.as_ref()).expect("delta json");
+    assert_eq!(
+        delta_full_json["messages"]
+            .as_array()
+            .map(|m| m.len())
+            .unwrap_or(0),
+        1,
+        "delta against an empty summary should contain every existing message"
+    );
+
+    // The summary itself should be non-empty (one entry).
+    let summary_json: serde_json::Value =
+        serde_json::from_slice(summary.as_ref()).expect("summary json");
+    // `InboxSummary` is a `HashSet<TokenAssignmentHash>` serialized as a
+    // JSON array of byte arrays. We just want to assert it's non-empty.
+    assert!(
+        summary_json.as_array().is_some_and(|a| !a.is_empty()),
+        "summary should list one assignment hash; got {summary_json}"
+    );
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+fn unwrap_valid(modification: UpdateModification<'static>) -> State<'static> {
+    match modification.new_state {
+        Some(state) => state,
+        None => panic!(
+            "expected a valid state modification, got {:?}",
+            modification.related
+        ),
+    }
+}
+
+fn is_requires_more(modification: &UpdateModification<'static>) -> bool {
+    modification.new_state.is_none() && !modification.related.is_empty()
+}

--- a/modules/antiflood-tokens/interfaces/src/lib.rs
+++ b/modules/antiflood-tokens/interfaces/src/lib.rs
@@ -892,3 +892,66 @@ mod tier_tests {
         assert_eq!(day15_normalized, get_date(2023, 2, 14));
     }
 }
+
+#[cfg(test)]
+mod boundary_tests {
+    //! Regression tests for the deserialization boundaries on this crate.
+    //!
+    //! The Phase 1 audit (#5) initially flagged ~50 chrono `.unwrap()`
+    //! calls in this file, but on inspection they all sit on hardcoded
+    //! constants or post-check arithmetic — none touch network input. The
+    //! only network-facing entry points are the `TryFrom<&[u8]>` /
+    //! `TryFrom<Parameters>` / `TryFrom<StateDelta>` impls below, all of
+    //! which already return `Result`. These tests pin that fact so any
+    //! future regression that swaps a `?` for an `unwrap` trips them.
+
+    use super::*;
+
+    #[test]
+    fn malformed_token_delegate_message_returns_err() {
+        let garbage = [0xffu8; 64];
+        let result = TokenDelegateMessage::try_from(&garbage[..]);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    #[test]
+    fn empty_token_delegate_message_returns_err() {
+        let result = TokenDelegateMessage::try_from(&[][..]);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    #[test]
+    fn malformed_token_assignment_state_delta_returns_err() {
+        let garbage = StateDelta::from(vec![0xffu8; 64]);
+        let result = TokenAssignment::try_from(garbage);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    #[test]
+    fn truncated_token_assignment_json_returns_err() {
+        let truncated = StateDelta::from(br#"{"tier":"min1","#.to_vec());
+        let result = TokenAssignment::try_from(truncated);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    #[test]
+    fn malformed_token_delegate_parameters_returns_err() {
+        let garbage = Parameters::from(vec![0xffu8; 64]);
+        let result = TokenDelegateParameters::try_from(garbage).map(|_| ());
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    #[test]
+    fn malformed_delegate_parameters_returns_err() {
+        let garbage = Parameters::from(vec![0xffu8; 64]);
+        let result = DelegateParameters::try_from(garbage).map(|_| ());
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+
+    #[test]
+    fn malformed_token_allocation_record_state_returns_err() {
+        let garbage = State::from(vec![0xffu8; 64]);
+        let result = TokenAllocationRecord::try_from(garbage);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+    }
+}

--- a/modules/identity-management/src/lib.rs
+++ b/modules/identity-management/src/lib.rs
@@ -105,8 +105,7 @@ impl TryFrom<&[u8]> for IdentityManagement {
     type Error = DelegateError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let deser: Self = serde_json::from_slice(value).unwrap();
-        Ok(deser)
+        serde_json::from_slice(value).map_err(|e| DelegateError::Deser(format!("{e}")))
     }
 }
 
@@ -206,8 +205,7 @@ impl TryFrom<&[u8]> for IdentityMsg {
     type Error = DelegateError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let msg = serde_json::from_slice(value).unwrap();
-        Ok(msg)
+        serde_json::from_slice(value).map_err(|e| DelegateError::Deser(format!("{e}")))
     }
 }
 
@@ -217,5 +215,57 @@ impl TryFrom<&IdentityMsg> for Vec<u8> {
     fn try_from(value: &IdentityMsg) -> Result<Self, Self::Error> {
         let msg = serde_json::to_vec(&value).unwrap();
         Ok(msg)
+    }
+}
+
+#[cfg(test)]
+mod boundary_tests {
+    //! Regression tests for the deserialization boundaries on this crate.
+    //!
+    //! `IdentityManagement` and `IdentityMsg` are reachable from network
+    //! input via the `DelegateInterface::process` path. Both used to call
+    //! `serde_json::from_slice(...).unwrap()`, which would panic the
+    //! delegate on a malformed payload. These tests pin the
+    //! `Result`-returning behavior so any future regression trips them.
+
+    use super::*;
+
+    #[test]
+    fn malformed_identity_management_bytes_returns_err() {
+        let garbage = [0xffu8; 64];
+        let result = IdentityManagement::try_from(&garbage[..]);
+        assert!(
+            matches!(result, Err(DelegateError::Deser(_))),
+            "expected Err(DelegateError::Deser), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn truncated_identity_management_json_returns_err() {
+        let truncated = br#"{"identities": {"alice":"#;
+        let result = IdentityManagement::try_from(&truncated[..]);
+        assert!(
+            matches!(result, Err(DelegateError::Deser(_))),
+            "expected Err(DelegateError::Deser), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_identity_msg_bytes_returns_err() {
+        let garbage = [0xffu8; 64];
+        let result = IdentityMsg::try_from(&garbage[..]).map(|_| ());
+        assert!(
+            matches!(result, Err(DelegateError::Deser(_))),
+            "expected Err(DelegateError::Deser), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn empty_identity_msg_bytes_returns_err() {
+        let result = IdentityMsg::try_from(&[][..]).map(|_| ());
+        assert!(
+            matches!(result, Err(DelegateError::Deser(_))),
+            "expected Err(DelegateError::Deser), got {result:?}"
+        );
     }
 }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -50,5 +50,12 @@ features = [
 
 [features]
 default = ["use-node"]
-ui-testing = []
+# Seed the UI with mock identities and mock messages so it renders without
+# any real Freenet state. Combine with `no-sync` for a fully offline build:
+#   cargo make dev-example
+example-data = []
+# Skip the local-node WebSocket entirely. Orthogonal to `example-data` —
+# enabling `no-sync` alone produces an empty UI; pair with `example-data`
+# (and `--no-default-features`) for the offline dev loop.
+no-sync = []
 use-node = []

--- a/ui/build.rs
+++ b/ui/build.rs
@@ -11,6 +11,21 @@
 use std::path::{Path, PathBuf};
 
 fn main() {
+    // Re-run if features change.
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_USE_NODE");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_NO_SYNC");
+
+    // The artifact checks below only matter for builds that actually embed
+    // contract WASM via `include_bytes!` (i.e. `use-node` is on and `no-sync`
+    // is off). Offline builds — `--no-default-features --features
+    // example-data,no-sync` — must work on a clean clone with no `build/`
+    // directories present, so we skip the check entirely there.
+    let use_node = std::env::var_os("CARGO_FEATURE_USE_NODE").is_some();
+    let no_sync = std::env::var_os("CARGO_FEATURE_NO_SYNC").is_some();
+    if !use_node || no_sync {
+        return;
+    }
+
     let ui_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let root = ui_dir.parent().expect("workspace root");
 

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -20,11 +20,20 @@ use crate::api::{node_response_error_handling, TryNodeAction};
 use crate::inbox::MessageModel;
 use crate::{api::WebApiRequestClient, app::Identity, DynError};
 
+// AFT code hashes are produced by `cargo make build-token-*` and are only
+// dereferenced from `use-node` flows. Under offline builds we fall back to
+// empty placeholders so the artifacts aren't required at compile time.
+#[cfg(feature = "use-node")]
 pub(crate) const TOKEN_RECORD_CODE_HASH: &str =
     include_str!("../../modules/antiflood-tokens/contracts/token-allocation-record/build/token_allocation_record_code_hash");
+#[cfg(not(feature = "use-node"))]
+pub(crate) const TOKEN_RECORD_CODE_HASH: &str = "";
 
+#[cfg(feature = "use-node")]
 pub(crate) const TOKEN_GENERATOR_DELEGATE_CODE_HASH: &str =
     include_str!("../../modules/antiflood-tokens/delegates/token-generator/build/token_generator_code_hash");
+#[cfg(not(feature = "use-node"))]
+pub(crate) const TOKEN_GENERATOR_DELEGATE_CODE_HASH: &str = "";
 
 pub(crate) struct AftRecords {}
 

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -44,7 +44,7 @@ impl WebApi {
 
     #[cfg(all(target_family = "wasm", feature = "use-node"))]
     fn new() -> Result<Self, String> {
-        use futures::{SinkExt, StreamExt};
+        use futures::SinkExt;
         let conn = web_sys::WebSocket::new(
             "ws://localhost:7509/v1/contract/command?encodingProtocol=native",
         )
@@ -66,7 +66,7 @@ impl WebApi {
             let _ = tx.send(());
             crate::log::debug!("connected to websocket");
         };
-        let mut api = freenet_stdlib::client_api::WebApi::start(
+        let api = freenet_stdlib::client_api::WebApi::start(
             conn,
             result_handler,
             |err| {

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -69,7 +69,7 @@ pub(crate) fn app() -> Element {
     use_context_provider(InboxesData::new);
     let inbox_data = use_context::<InboxesData>();
 
-    #[cfg(feature = "use-node")]
+    #[cfg(all(feature = "use-node", not(feature = "no-sync")))]
     {
         let _sync: Coroutine<NodeAction> = use_coroutine(move |rx| {
             let inbox_controller = inbox_controller;
@@ -88,10 +88,14 @@ pub(crate) fn app() -> Element {
             async {}.boxed_local()
         });
     }
-    #[cfg(not(feature = "use-node"))]
+    #[cfg(any(not(feature = "use-node"), feature = "no-sync"))]
     {
-        let _sync = use_coroutine::<NodeAction, _>(move |rx| async {});
+        let _ = inbox_controller;
+        let _ = login_controller;
+        let _ = inbox_data;
+        let _sync: Coroutine<NodeAction> = use_coroutine(move |_rx: UnboundedReceiver<NodeAction>| async {});
     }
+    #[allow(unused_variables)]
     let actions = use_coroutine_handle::<NodeAction>();
 
     // Render login page if user not identified, otherwise render the inbox or identifiers list based on user's logged in state
@@ -100,16 +104,16 @@ pub(crate) fn app() -> Element {
             login::GetOrCreateIdentity {}
         }
     } else if let Some(id) = user.read().logged_id() {
-        #[cfg(feature = "use-node")]
+        #[cfg(all(feature = "use-node", not(feature = "no-sync")))]
         {
             inbox
                 .read()
                 .load_messages(id, &actions)
                 .expect("load messages");
         }
-        #[cfg(all(feature = "ui-testing", not(feature = "use-node")))]
+        #[cfg(feature = "example-data")]
         {
-            inbox_controller.load_messages(id).unwrap();
+            inbox.read().load_example_messages(id).expect("load mock messages");
         }
         rsx! {
            UserInbox {}
@@ -272,58 +276,59 @@ impl InboxView {
         self.remove_messages(client, ids, inbox_data)
     }
 
-    #[cfg(all(feature = "ui-testing", not(feature = "use-node")))]
-    fn load_messages(&self, id: &Identity) -> Result<(), DynError> {
-        let emails = {
-            if id.id == UserId(0) {
-                vec![
-                    Message {
-                        id: 0,
-                        from: "Ian's Other Account".into(),
-                        title: "Email from Ian's Other Account".into(),
-                        content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit..."
-                            .repeat(10)
-                            .into(),
-                        read: false,
-                    },
-                    Message {
-                        id: 1,
-                        from: "Mary".to_string().into(),
-                        title: "Email from Mary".to_string().into(),
-                        content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit..."
-                            .repeat(10)
-                            .into(),
-                        read: false,
-                    },
-                ]
-            } else {
-                vec![
-                    Message {
-                        id: 0,
-                        from: "Ian Clarke".into(),
-                        title: "Email from Ian".into(),
-                        content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit..."
-                            .repeat(10)
-                            .into(),
-                        read: false,
-                    },
-                    Message {
-                        id: 1,
-                        from: "Jane".to_string().into(),
-                        title: "Email from Jane".to_string().into(),
-                        content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit..."
-                            .repeat(10)
-                            .into(),
-                        read: false,
-                    },
-                ]
-            }
+    #[cfg(feature = "example-data")]
+    fn load_example_messages(&self, id: &Identity) -> Result<(), DynError> {
+        let body: Cow<'static, str> =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
+             Sed do eiusmod tempor incidunt ut labore et dolore magna aliqua."
+                .into();
+        let emails = if id.id == UserId(0) {
+            vec![
+                Message {
+                    id: 0,
+                    from: "Ian's Other Account".into(),
+                    title: "Welcome to the offline preview".into(),
+                    content: body.clone(),
+                    read: false,
+                },
+                Message {
+                    id: 1,
+                    from: "Mary".into(),
+                    title: "Lunch tomorrow?".into(),
+                    content: body.clone(),
+                    read: false,
+                },
+                Message {
+                    id: 2,
+                    from: "freenet-bot".into(),
+                    title: "Your weekly digest".into(),
+                    content: body,
+                    read: true,
+                },
+            ]
+        } else {
+            vec![
+                Message {
+                    id: 0,
+                    from: "Ian Clarke".into(),
+                    title: "Welcome to the offline preview".into(),
+                    content: body.clone(),
+                    read: false,
+                },
+                Message {
+                    id: 1,
+                    from: "Jane".into(),
+                    title: "Re: design review".into(),
+                    content: body,
+                    read: false,
+                },
+            ]
         };
         self.messages.replace(emails);
         Ok(())
     }
 
-    #[cfg(feature = "use-node")]
+    #[cfg(all(feature = "use-node", not(feature = "no-sync")))]
     fn load_messages(
         &self,
         id: &Identity,
@@ -342,32 +347,35 @@ pub(crate) struct User {
 }
 
 impl User {
-    #[cfg(all(feature = "ui-testing", not(feature = "use-node")))]
+    #[cfg(feature = "example-data")]
     fn new() -> Self {
         use rand_chacha::rand_core::OsRng;
-        let key0 = RsaPrivateKey::new(&mut OsRng, 4096).unwrap();
-        let key1 = RsaPrivateKey::new(&mut OsRng, 4096).unwrap();
-        let identified = true;
+        // 2048-bit keeps the offline preview snappy in debug builds; the keys
+        // never leave the browser and are regenerated on every page load.
+        let key0 = RsaPrivateKey::new(&mut OsRng, 2048).expect("rsa keygen");
+        let key1 = RsaPrivateKey::new(&mut OsRng, 2048).expect("rsa keygen");
         User {
             logged: false,
-            identified,
+            identified: true,
             active_id: None,
             identities: vec![
                 Identity {
                     alias: "address1".into(),
                     id: UserId(0),
+                    description: "Mock identity (example-data)".into(),
                     key: key0,
                 },
                 Identity {
                     alias: "address2".into(),
                     id: UserId(1),
+                    description: "Mock identity (example-data)".into(),
                     key: key1,
                 },
             ],
         }
     }
 
-    #[cfg(feature = "use-node")]
+    #[cfg(not(feature = "example-data"))]
     fn new() -> Self {
         User {
             logged: false,

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -40,7 +40,16 @@ use crate::{
 
 type InboxContract = ContractKey;
 
+// `inbox_code_hash` is produced by `cargo make build-inbox-contract`. Under
+// `--no-default-features --features example-data,no-sync` it isn't needed
+// (no contract calls happen) and the build artifact may not exist, so we
+// fall back to an empty placeholder. Any attempt to use it offline would
+// fail at `ContractKey::from_params` time, but those code paths are dead
+// when `use-node` is disabled.
+#[cfg(feature = "use-node")]
 pub(crate) const INBOX_CODE_HASH: &str = include_str!("../../build/inbox_code_hash");
+#[cfg(not(feature = "use-node"))]
+pub(crate) const INBOX_CODE_HASH: &str = "";
 
 thread_local! {
     static PENDING_INBOXES_UPDATE: RefCell<HashMap<InboxContract, Vec<DecryptedMessage>>> = RefCell::new(HashMap::new());

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1,3 +1,14 @@
+// Under `--no-default-features --features example-data,no-sync` the
+// `use-node` flag is off, which makes large swathes of the WebSocket /
+// contract-bridge code unreachable. Rather than gate hundreds of items
+// individually, we suppress dead-code / unused-import warnings for the
+// whole crate when running in offline mode. The default `use-node` build
+// is still warning-clean and remains the source of truth for clippy.
+#![cfg_attr(
+    not(feature = "use-node"),
+    allow(dead_code, unused_imports, unused_variables, unused_mut)
+)]
+
 extern crate core;
 
 pub(crate) mod aft;


### PR DESCRIPTION
## Summary

Phase 1 of the productionization plan (#5, part of #1). Three independent workstreams, layered as three commits.

### W1 — Offline UI dev loop (`feat(ui)`)
Replaces the broken `ui-testing` feature flag (it referenced a removed field and called a non-existent method) with two orthogonal flags matching the freenet-river pattern:

- **`example-data`** seeds the UI with 2 mock identities and 2-3 mock messages each.
- **`no-sync`** skips the local-node WebSocket entirely, gated independently of `use-node`.

`cargo make dev-example` runs the offline preview from a clean clone with **zero contract artifacts** required. `ui/build.rs` now short-circuits when `CARGO_FEATURE_NO_SYNC` is set, so the fail-fast artifact check from PR #10 doesn't block. `INBOX_CODE_HASH` and the AFT code hashes collapse to empty placeholders under `not(use-node)` — they're only dereferenced from contract-bridge code paths that are themselves dead in offline mode.

A crate-level `cfg_attr(not(use-node), allow(dead_code, ...))` keeps the offline build clippy-clean without gating hundreds of items individually. The default `use-node` build remains the source of truth and is also clippy-clean.

`build-ui-example-no-sync` cargo-make target added for CI/Playwright (Phase 3).

### W2 — Inbox contract integration tests (`test(inbox)`)
Seven new tests under `contracts/inbox/tests/`, run as native Rust against `--features contract`:

| Test | Coverage |
|---|---|
| `validate_accepts_signed_empty_inbox` | happy path |
| `validate_rejects_tampered_last_update` | documents that `last_update` is **not** part of the signed payload (test asserts current behavior so any future hardening flips it loudly) |
| `validate_rejects_wrong_owner_signature` | signature mismatch |
| `update_accepts_add_message_with_valid_token` | full token + RelatedState round trip |
| `update_rejects_message_with_unknown_token_record` | asserts `requires(...)` not silent accept |
| `update_rejects_token_with_invalid_slot` | `Tier::Min1` with non-zero second |
| `summarize_then_delta_yields_only_new_messages` | summary/delta round trip |

Reusable scaffolding in `contracts/inbox/tests/common/mod.rs`: keypair generation, JSON-wire-format inbox builders, signed `TokenAssignment` construction, `TokenAllocationRecord` + `RelatedContracts` helpers.

`cargo make test-inbox` target added.

### W3 — Deserialization boundary hardening (`fix(deser)`)
The Phase 1 audit cited "~50 chrono unwraps" in `freenet-aft-interface` as the target. Inspection found **all** of them sit on hardcoded constants or post-check arithmetic — none touch network input. The actual network-facing deserialization boundaries:

- ~~`freenet-aft-interface`~~ — already safe (`bincode::deserialize().map_err(...)`, `serde_json::from_slice().map_err(...)` everywhere). No fixes needed.
- **`identity-management`** — 2 real `serde_json::from_slice(...).unwrap()` calls in `TryFrom<&[u8]>` impls (`IdentityManagement` line 108, `IdentityMsg` line 209). **Fixed** to propagate `DelegateError::Deser`.

11 new regression tests pin the boundary behavior so future regressions trip them:
- 4 in `identity-management::boundary_tests` (malformed / truncated bytes for both `TryFrom` impls)
- 7 in `freenet-aft-interface::boundary_tests` (TokenDelegateMessage, TokenAssignment, TokenDelegateParameters, DelegateParameters, TokenAllocationRecord)

## Verification

| Check | Result |
|---|---|
| `cargo check --workspace --all-targets` | ✓ clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✓ clean |
| `cargo test --workspace` | ✓ 28 passed, 1 ignored (was 17 + 1 ignored on main; +11 new) |
| `cargo make test-inbox` | ✓ 7/7 pass |
| `cargo clippy -p freenet-email-ui --no-default-features --features example-data,no-sync --target wasm32-unknown-unknown -- -D warnings` | ✓ clean |
| `cargo test -p identity-management` | ✓ 4 passed |
| `cargo test -p freenet-aft-interface` | ✓ 13 passed |

Drive-by fixes: three pre-existing wasm32-target warnings the host workspace check missed (`pk` unused match arm in inbox contract, `StreamExt` unused import in `api.rs`, `mut api` no-longer-needed-mut in same function).

## Test plan

- [x] `cargo make test-inbox` — all 7 inbox integration tests pass
- [x] `cargo test --workspace` — full suite green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Offline UI clippy clean for `--no-default-features --features example-data,no-sync`
- [ ] Manual: `cargo make dev-example` from a clean clone with no `build/` directories — UI renders, devtools shows zero WebSocket attempts (left for reviewer / follow-up since it requires `dx serve`)
- [ ] Manual: `cargo make dev` against a running node — unchanged behavior

## Out of scope (intentionally deferred)

- Playwright / browser E2E — Phase 3 (#7)
- Unignoring the legacy `token-allocation-record` integration test (needs a state-generation script) — separate follow-up from PR #10
- Reinstating the identity-delegate response path in `api.rs` (the unreachable arm removed in PR #10) — separate follow-up

Closes #5.