### PR TITLE
Phase 4: CI/CD (GitHub Actions + hooks)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Pre-commit hook: block stray WASM commits outside published-contract/.
+#
+# The only committed WASMs in this repo live at
+# `published-contract/web_container_contract.wasm`, and they should only
+# change alongside `published-contract/contract-id.txt`. Any other .wasm
+# file showing up in a commit is almost certainly an accidental `target/`
+# or `build/` artifact that slipped past .gitignore.
+
+set -euo pipefail
+
+# All staged .wasm files.
+WASM_FILES=$(git diff --cached --name-only --diff-filter=ACMR -- '*.wasm' 2>/dev/null || true)
+
+if [ -z "$WASM_FILES" ]; then
+    exit 0
+fi
+
+# Filter out the one file we allow: published-contract/web_container_contract.wasm.
+STRAY=$(echo "$WASM_FILES" | grep -v '^published-contract/web_container_contract\.wasm$' || true)
+
+if [ -z "$STRAY" ]; then
+    # Only the allowlisted WASM is staged. Require contract-id.txt to be
+    # staged alongside — otherwise we'd commit a new WASM without refreshing
+    # the contract ID, leaving the snapshot inconsistent.
+    CONTRACT_ID_STAGED=$(git diff --cached --name-only -- published-contract/contract-id.txt 2>/dev/null || true)
+    if [ -z "$CONTRACT_ID_STAGED" ]; then
+        echo ""
+        echo "🚫 BLOCKED: published-contract/web_container_contract.wasm is staged"
+        echo "   without published-contract/contract-id.txt."
+        echo ""
+        echo "The contract ID is hash(wasm, parameters); updating the WASM"
+        echo "without refreshing contract-id.txt leaves the snapshot in a"
+        echo "state where the committed ID no longer matches the committed WASM."
+        echo ""
+        echo "To fix:"
+        echo "  cargo make update-published-contract"
+        echo "  git add published-contract/"
+        echo ""
+        exit 1
+    fi
+    exit 0
+fi
+
+echo ""
+echo "🚫 BLOCKED: stray .wasm files are staged for commit outside published-contract/."
+echo ""
+echo "Staged stray WASM files:"
+echo "$STRAY" | sed 's/^/  /'
+echo ""
+echo "The only WASM file checked into this repo is"
+echo "published-contract/web_container_contract.wasm. Everything else is a"
+echo "build artifact that should stay in target/ or build/ (ignored by git)."
+echo ""
+echo "To unstage:"
+echo "  git restore --staged <file>"
+echo ""
+exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,126 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install cargo-make and fdev
+        run: |
+          cargo binstall -y cargo-make
+          cargo binstall -y --force freenet-fdev || cargo install fdev
+
+      - name: Install Dioxus CLI
+        run: cargo binstall -y dioxus-cli
+
+      - name: Install GNU tar (for reproducible webapp archive)
+        run: sudo apt-get update && sudo apt-get install -y tar
+
+      - name: Build all contracts and UI
+        run: cargo make build
+
+      - name: Run workspace tests
+        run: cargo make test
+
+      - name: Run inbox integration tests
+        run: cargo make test-inbox
+
+      - name: Clippy
+        run: cargo make clippy
+
+  ui-playwright-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install cargo-make
+        run: cargo binstall -y cargo-make
+
+      - name: Install Dioxus CLI
+        run: cargo binstall -y dioxus-cli
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Playwright test dependencies
+        run: npm install
+        working-directory: ./ui/tests
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox webkit
+        working-directory: ./ui/tests
+
+      - name: Build UI in offline mode
+        run: cargo make build-ui-example-no-sync
+
+      - name: Start dev server and wait for readiness
+        run: |
+          cd ui && dx serve --port 8082 --features example-data,no-sync --no-default-features &
+          echo "Waiting for dev server..."
+          SERVER_READY=false
+          for i in $(seq 1 90); do
+            if curl -s http://127.0.0.1:8082 2>/dev/null | grep -q 'id="main"'; then
+              echo "Server ready after $((i * 3))s"
+              sleep 5
+              SERVER_READY=true
+              break
+            fi
+            sleep 3
+          done
+          if [ "$SERVER_READY" != "true" ]; then
+            echo "ERROR: Dev server failed to start within 270s"
+            exit 1
+          fi
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        working-directory: ./ui/tests
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            ui/tests/test-results/
+            ui/tests/playwright-report/

--- a/.github/workflows/check-contract-wasm.yml
+++ b/.github/workflows/check-contract-wasm.yml
@@ -1,0 +1,75 @@
+name: Check Published Contract Drift
+
+on:
+  pull_request:
+    paths:
+      - 'contracts/web-container/**'
+      - 'common/**'
+      - 'ui/**'
+      - 'published-contract/**'
+      - 'test-contract/web-container-keys.toml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+  push:
+    branches: [main]
+    paths:
+      - 'contracts/web-container/**'
+      - 'common/**'
+      - 'ui/**'
+      - 'published-contract/**'
+      - 'test-contract/web-container-keys.toml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install GNU tar
+        run: sudo apt-get update && sudo apt-get install -y tar
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install cargo-make and dioxus-cli
+        run: |
+          cargo binstall -y cargo-make
+          cargo binstall -y dioxus-cli
+
+      - name: Install fdev
+        run: cargo install fdev
+
+      - name: Rebuild published contract from source
+        run: cargo make update-published-contract
+
+      - name: Compare rebuilt snapshot against committed
+        run: |
+          if ! git diff --exit-code -- published-contract/contract-id.txt; then
+            echo "❌ ERROR: published-contract/contract-id.txt drifted from source."
+            echo ""
+            echo "Contract sources (contracts/web-container, ui/, common/) or"
+            echo "the committed test key changed, but published-contract/ was"
+            echo "not refreshed. Run locally:"
+            echo ""
+            echo "  cargo make update-published-contract"
+            echo "  git add published-contract/"
+            echo "  git commit --amend --no-edit   # or a fresh commit"
+            echo ""
+            exit 1
+          fi
+          echo "✅ published-contract/ is in sync with source."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,16 @@
 Decentralized email application built on Freenet. Uses Dioxus for the web UI,
 WASM contracts for inbox storage, and Anti-Flood Tokens (AFT) for rate limiting.
 
+## One-time setup
+
+```bash
+git config core.hooksPath .githooks   # Enable repo-local git hooks
+```
+
+The pre-commit hook blocks stray `.wasm` commits outside
+`published-contract/` and requires `contract-id.txt` to be staged
+alongside any WASM change.
+
 ## Quick Reference
 
 ### Commands

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- `rust-toolchain.toml` — pin stable with wasm32 + rustfmt + clippy
- `.github/workflows/build.yml` — build/test/clippy + Playwright job
- `.github/workflows/check-contract-wasm.yml` — fail PRs that would drift `published-contract/`
- `.githooks/pre-commit` — block stray WASM commits and half-updated contract snapshots

## Details

### Toolchain pin
Two developers on two machines only derive a byte-identical `published-contract/contract-id.txt` when rustc, the cargo release profile, and tar behavior all match. AGENTS.md already called out the rustc pin as an open requirement — this lands it.

### build.yml
Two jobs:
- **`build`**: full `cargo make build` → `cargo make test` → `cargo make test-inbox` → `cargo make clippy`, with `Swatinem/rust-cache` + `cargo binstall` for fast warm CI.
- **`ui-playwright-tests`** (needs: build): installs Node 20, installs Playwright browsers with deps, builds the offline UI (`cargo make build-ui-example-no-sync`), starts `dx serve --features example-data,no-sync --no-default-features`, polls for readiness, runs `npx playwright test` across all 5 browser profiles, uploads `test-results/` and `playwright-report/` on failure.

### check-contract-wasm.yml
Runs on any PR that touches contract sources (`contracts/web-container/**`, `common/**`, `ui/**`), the committed test key, `Cargo.{toml,lock}`, `rust-toolchain.toml`, or `published-contract/` itself. It rebuilds the published-contract snapshot from source and fails if `contract-id.txt` would shift without the PR already committing that shift. This is the freenet-email analog of river's `check-cli-wasm.yml`.

### Pre-commit hook
Blocks two failure modes:
1. Stray `.wasm` files anywhere outside `published-contract/` (almost always accidental `target/` or `build/` spill)
2. `published-contract/web_container_contract.wasm` staged *without* `published-contract/contract-id.txt` — the WASM and the ID must move together or the snapshot is inconsistent

I verified both branches locally:
- Tried to stage `ui/stray.wasm` → hook blocked with a specific error message
- Tried to stage a (dirty) `published-contract/web_container_contract.wasm` *with* `contract-id.txt` → hook allowed
- Staged WASM *without* `contract-id.txt` → hook blocked with the "staged without contract-id.txt" error

## Branch strategy

Based on `phase-3-e2e-testing` (not `main`), because the `ui-playwright-tests` job in build.yml requires the Playwright harness from #13. Merge #13 first, then this rebases onto main cleanly.

Part of #1, closes #8.

## Test plan

- [x] `git config core.hooksPath .githooks` enables the hook locally
- [x] Hook blocks stray WASM and half-updated published-contract/ commits
- [x] Hook allows updates that stage WASM + contract-id.txt together
- [ ] CI workflows turn green on this PR (full validation only possible after push)