### PR TITLE
Phase 5: docs + release automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,16 @@ cargo make run-node              # Start local Freenet node
 # Publishing pipeline (see "Publishing" section below)
 cargo make publish-email-test    # Sandbox publish with committed test key
 cargo make publish-email         # Production publish with uncommitted key
-cargo make update-published-contract  # Refresh published-contract/ snapshot
+cargo make update-published-contract       # Refresh test snapshot
+cargo make update-published-contract-prod  # Refresh production snapshot
 cargo make publish-all           # End-to-end test publish (build → sign → publish)
+cargo make publish-production    # End-to-end production publish
 cargo make publish               # Alias for publish-email-test
+
+# Release automation (see RELEASING.md)
+scripts/generate-production-key.sh       # One-time: generate prod ed25519 key
+scripts/release.sh <version>             # Full release: build → sign → publish → tag → push
+scripts/smoke-test-production.sh <url>   # Playwright suite against deployed webapp
 ```
 
 ### Repository Structure
@@ -87,6 +94,52 @@ freenet-email/
   Handles identity creation, message composition, encryption, and inbox display.
 - **AFT Integration**: Each sent message requires a token from the Anti-Flood
   Token system, preventing spam while preserving sender privacy.
+
+### Feature flag matrix
+
+The UI crate at `ui/Cargo.toml` exposes four features that compose to
+produce different builds. The cell shows whether that combination is a
+supported build target and what it's used for.
+
+| Flag          | Purpose                                                                                  |
+|---------------|------------------------------------------------------------------------------------------|
+| `use-node`    | Default. Enables the WebSocket bridge to a local Freenet node and all contract calls.    |
+| `example-data`| Seeds the UI with two mock identities (`address1`, `address2`) and mock inboxes.          |
+| `no-sync`     | Disables the WebSocket bridge entirely. Must be combined with `example-data` to be useful.|
+| `contract`    | (inbox crate, not ui) Enables the inbox contract's `ContractInterface` impl.             |
+
+**Supported combinations:**
+
+| Build                                                        | What it's for                                |
+|--------------------------------------------------------------|----------------------------------------------|
+| `cargo make build` (default: `use-node`)                     | Production release, talks to a real node    |
+| `cargo make dev-example` (`example-data,no-sync`)            | Offline dev loop, no node required           |
+| `cargo make build-ui-example-no-sync`                        | CI Playwright builds (same flags as above)   |
+| `cargo test -p freenet-email-inbox --features contract`      | Inbox contract integration tests (host)     |
+
+`example-data + use-node` is technically buildable but has no user —
+the app always reaches for the node when `use-node` is set. Use
+`no-sync` whenever you want offline mode.
+
+### Running a Freenet node
+
+There are two modes depending on what you're doing:
+
+| Mode                 | Command               | When to use                                                   |
+|----------------------|-----------------------|---------------------------------------------------------------|
+| **Local sandbox**    | `freenet local` (or `cargo make run-node`) | Developing contracts, running integration tests, publishing the test contract |
+| **Network-connected**| `freenet network`     | Production publish, smoke-testing the live webapp             |
+
+The local sandbox is entirely self-contained — it spins up a single-node
+network with no peers, so publishing to it doesn't propagate anywhere
+and can't be observed from other machines. It's the right target for
+`publish-email-test`, `publish-all`, and every Phase 3 / Phase 4
+automated test.
+
+The network-connected mode joins the real Freenet network and is the
+target for production publishes: `publish-email`, `publish-production`,
+and `scripts/release.sh`. The first publish takes ~30s to propagate
+before the gateway URL resolves.
 
 ### Testing
 
@@ -153,30 +206,37 @@ freenet-email/
 
 Production uses an **uncommitted** ed25519 keypair at
 `~/.config/freenet-email/web-container-keys.toml` (override with
-`WEB_CONTAINER_KEY_FILE=/path/to/keys.toml`). Generate it out of band
-on the release manager's machine:
+`WEB_CONTAINER_KEY_FILE=/path/to/keys.toml`).
+
+**One-time setup** — generate the key via the release script:
 
 ```bash
-mkdir -p ~/.config/freenet-email
-cargo run -p web-container-sign -- generate \
-  --output ~/.config/freenet-email/web-container-keys.toml
+scripts/generate-production-key.sh
 ```
 
-**Never commit this file.** Back it up offline; losing it means
-rotating the production contract ID.
+This writes the keypair with `chmod 600` and prints a reminder to back
+it up offline. **Never commit this file.** Losing it means rotating the
+production contract ID and every user losing access to the previous
+deployment.
 
-Then:
+**End-to-end release** — use the release driver:
 
 ```bash
-cargo make build
-cargo make publish-email
+scripts/release.sh 0.1.0
 ```
+
+See `RELEASING.md` for the full runbook, preconditions, and recovery
+procedures. Under the hood this runs `cargo make publish-production`,
+which chains `build` → `update-published-contract-prod` →
+`publish-email`.
 
 The production key produces a **different** contract ID than the test
 key, because the ID is `hash(wasm, parameters)` and the 32-byte
-`webapp.parameters` blob is the verifying key itself. Keep production
-`published-contract/` snapshots on a separate branch or tag if you
-need them reproducible.
+`webapp.parameters` blob is the verifying key itself. The committed
+`published-contract/contract-id.txt` is the one signed by the
+*production* key; the test snapshot lives in git history but gets
+overwritten by `cargo make update-published-contract-prod` on every
+real release.
 
 ### Reproducibility caveats
 
@@ -184,11 +244,11 @@ Two developers building from the same commit will produce the
 **same** `published-contract/contract-id.txt` only when all of these
 match:
 
-- **rustc version.** The release-profile WASM is not bit-for-bit
-  stable across rustc versions. Pin via `rust-toolchain.toml` if this
-  matters in your CI.
-- **Cargo release profile.** Already pinned in the workspace
-  `Cargo.toml` (`lto=true, codegen-units=1, strip=true, panic=abort`).
+- **rustc version.** Pinned in `rust-toolchain.toml` (stable channel).
+  CI uses the same pin; contributors on stable-latest will match CI
+  automatically.
+- **Cargo release profile.** Pinned in the workspace `Cargo.toml`
+  (`lto=true, codegen-units=1, strip=true, panic=abort`).
 - **GNU tar.** `compress-webapp` uses
   `tar --sort=name --mtime='2024-01-01 00:00:00 UTC' --owner=0 --group=0`
   for a reproducible archive. BSD tar (macOS default) **does not**
@@ -203,6 +263,7 @@ match:
 
 The `cargo make compress-webapp` target detects `gtar` / GNU `tar`
 automatically and emits a loud warning when falling back to BSD tar.
+`scripts/release.sh` errors out at preflight if GNU tar is missing.
 
 ### Security — committed test key
 
@@ -212,6 +273,37 @@ across clones. Anyone with read access to this repository can sign
 webapps under the test contract ID, but the key grants no access to
 any user data and must never be reused for production. See
 `test-contract/README.md` for the full threat model.
+
+### Regenerating test keys
+
+Two committed test keys live under `test-contract/`:
+
+1. **Web container signer** (`test-contract/web-container-keys.toml`) —
+   ed25519, used to sign test webapps. Produces the test
+   `published-contract/contract-id.txt`.
+2. **Identity delegate** (`test-contract/identity/identity-manager-key.*.pem`) —
+   P-384, used by the `identity-management` delegate. Stable across
+   test runs so generated `identity-manager-params` is reproducible.
+
+**To rotate the web-container test key:**
+
+```bash
+rm test-contract/web-container-keys.toml
+cargo make generate-web-container-keys
+cargo make update-published-contract   # regenerates contract-id.txt
+git add test-contract/web-container-keys.toml published-contract/
+git commit -m "chore: rotate committed web-container test key"
+```
+
+The test contract ID will change. CI `check-contract-wasm.yml` and any
+Phase 3 Playwright tests that embed the contract ID will pick up the
+new value automatically on next run.
+
+**To rotate the identity delegate key:** delete the files under
+`test-contract/identity/` and `modules/identity-management/build/identity-manager-params`,
+then re-run `cargo make generate-identity-params`. This changes the
+identity delegate's on-chain key, which is usually not what you want
+unless you're reproducing a specific upstream change.
 
 ## End-to-end testing
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -304,15 +304,19 @@ if [ ! -f "$KEY_FILE" ]; then
     echo "error: production key file not found at $KEY_FILE" >&2
     echo "" >&2
     echo "generate one out of band with:" >&2
-    echo "  cargo run -p web-container-sign -- generate --output $KEY_FILE" >&2
+    echo "  scripts/generate-production-key.sh" >&2
     echo "" >&2
     echo "or override the location:" >&2
     echo "  WEB_CONTAINER_KEY_FILE=/path/to/keys.toml cargo make publish-email" >&2
     exit 1
 fi
-version=$(git -C "$ROOT" rev-parse --short=8 HEAD | awk '{ printf "%d", strtonum("0x" $1) % 2147483647 }')
+# Deterministic version from the commit hash (same derivation as
+# sign-webapp-test). Uses `printf %d 0x…` instead of GNU-awk strtonum
+# for portability across BSD/macOS.
+short=$(git -C "$ROOT" rev-parse --short=8 HEAD)
+version=$(( $(printf '%d' "0x$short") & 0x7fffffff ))
 if [ "$version" -eq 0 ]; then version=1; fi
-echo "signing with production key at $KEY_FILE, version $version"
+echo "signing with production key at $KEY_FILE, version $version (from commit $short)"
 cargo run --quiet -p web-container-sign -- sign \
     --input "$ROOT/target/webapp/webapp.tar.xz" \
     --output "$ROOT/target/webapp/webapp.metadata" \
@@ -360,6 +364,42 @@ echo "  web_container_contract.wasm = $(wc -c < "$ROOT/published-contract/web_co
 echo "  webapp.parameters           = $(wc -c < "$ROOT/published-contract/webapp.parameters") bytes"
 echo ""
 echo "commit these changes with a message referencing the release in #6 / #9."
+'''
+
+[tasks.update-published-contract-prod]
+description = "Copy the signed PRODUCTION artifacts into published-contract/ and record the contract ID"
+dependencies = ["sign-webapp", "build-web-container"]
+script_runner = "bash"
+script = '''
+set -euo pipefail
+ROOT="${CARGO_MAKE_WORKING_DIRECTORY}"
+WASM="$ROOT/target/wasm32-unknown-unknown/release/freenet_email_app_web.wasm"
+PARAMS="$ROOT/target/webapp/webapp.parameters"
+if [ ! -f "$WASM" ]; then
+    echo "error: $WASM not found (did cargo make build-web-container run?)" >&2
+    exit 1
+fi
+if [ ! -f "$PARAMS" ]; then
+    echo "error: $PARAMS not found (did sign-webapp run?)" >&2
+    exit 1
+fi
+
+contract_id=$(CARGO_TARGET_DIR="$ROOT/target" fdev get-contract-id \
+    --code "$WASM" --parameters "$PARAMS")
+if [ -z "$contract_id" ]; then
+    echo "error: fdev get-contract-id returned an empty ID" >&2
+    exit 1
+fi
+
+mkdir -p "$ROOT/published-contract"
+cp "$WASM"   "$ROOT/published-contract/web_container_contract.wasm"
+cp "$PARAMS" "$ROOT/published-contract/webapp.parameters"
+printf '%s\n' "$contract_id" > "$ROOT/published-contract/contract-id.txt"
+
+echo "published-contract/ updated (PRODUCTION):"
+echo "  contract-id.txt             = $contract_id"
+echo "  web_container_contract.wasm = $(wc -c < "$ROOT/published-contract/web_container_contract.wasm") bytes"
+echo "  webapp.parameters           = $(wc -c < "$ROOT/published-contract/webapp.parameters") bytes"
 '''
 
 [tasks.publish-email-test]
@@ -414,6 +454,14 @@ dependencies = [
     "build",
     "update-published-contract",
     "publish-email-test",
+]
+
+[tasks.publish-production]
+description = "End-to-end PRODUCTION publish: build → sign with prod key → update-published-contract → publish-email"
+dependencies = [
+    "build",
+    "update-published-contract-prod",
+    "publish-email",
 ]
 
 [tasks.publish]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Freenet Email
+
+A decentralized email client that runs on [Freenet](https://freenet.org) —
+no servers, no accounts, end-to-end encrypted, and rate-limited by
+Anti-Flood Tokens instead of a central authority.
+
+Messages are stored in per-user inbox contracts on the Freenet network,
+encrypted with the recipient's RSA public key. The UI is a Dioxus web
+app served from a signed web-container contract under a deterministic,
+reproducible contract id.
+
+> **Status**: pre-alpha. The protocol and contract ids will change.
+> Don't use this for anything you'd mind losing.
+
+## Try it
+
+1. **Install Freenet.** Follow the
+   [Freenet quickstart](https://freenet.org/quickstart/) to get a
+   network-connected node running.
+
+2. **Open the webapp** in a browser at the published contract id:
+
+   ```
+   http://127.0.0.1:50509/contract/web/<contract-id>/
+   ```
+
+   The latest committed contract id lives at
+   [`published-contract/contract-id.txt`](published-contract/contract-id.txt)
+   in this repo. The `50509` port and `/contract/web/` path are the
+   defaults for the Freenet HTTP gateway — adjust for your setup.
+
+3. **Create an identity** in the app. Your private keys never leave the
+   browser.
+
+4. **Send a message.** The first send burns one Anti-Flood Token,
+   minted automatically by your local node.
+
+## How it works
+
+Three contracts and a delegate make up the full system:
+
+- **Web container contract** — hosts the compiled Dioxus UI. Signed
+  with an ed25519 key committed to
+  [`test-contract/`](test-contract/) for sandbox builds, and with an
+  offline-generated production key for real releases.
+- **Inbox contract** — one per user. Stores encrypted messages keyed by
+  an RSA public key, with signature verification for ownership.
+- **Anti-Flood Token contracts** — mint/burn tokens that gate each
+  message send, preventing spam without a central authority.
+- **Identity delegate** — holds the user's private keys inside the
+  Freenet delegate sandbox, never in the browser's localStorage.
+
+## Contributing
+
+See [`AGENTS.md`](AGENTS.md) for the developer guide: build setup,
+feature-flag matrix, publishing pipeline, Playwright tests, and the
+manual E2E checklist.
+
+See [`RELEASING.md`](RELEASING.md) for the release runbook.
+
+## License
+
+TBD (see Cargo.toml).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,222 @@
+# Releasing freenet-email
+
+This document is the runbook for cutting a production release.
+
+## TL;DR
+
+```bash
+# One-time, first release only:
+scripts/generate-production-key.sh
+
+# Every release:
+freenet network   # in another terminal (network-connected node)
+scripts/release.sh 0.1.0
+scripts/smoke-test-production.sh
+```
+
+Everything else is automation around those three commands.
+
+## Overview
+
+A release is a tuple of `(git tag, contract id, signed webapp)`:
+
+1. `scripts/release.sh` builds the webapp, signs it with the production
+   key, publishes the contract to the real Freenet network, commits the
+   updated `published-contract/` snapshot, creates an annotated tag, and
+   pushes both commit and tag to `origin/main`.
+2. `scripts/smoke-test-production.sh` runs the Playwright suite against
+   the deployed webapp via the Freenet gateway to confirm the release
+   actually works end to end.
+
+Steps 3, 4, 5, 6 of `release.sh` (publish, commit, tag, push) are
+irreversible and visible to every user of the project. The script
+prompts before each of those, and aborts on failure of any preflight
+check.
+
+## Preconditions
+
+Before running `scripts/release.sh`:
+
+### 1. Production key (one-time)
+
+Generate the ed25519 keypair that signs every release:
+
+```bash
+scripts/generate-production-key.sh
+```
+
+This writes to `~/.config/freenet-email/web-container-keys.toml` with
+`chmod 600`. Override the path with `WEB_CONTAINER_KEY_FILE=...`.
+
+**Back it up immediately** to somewhere offline and durable. Losing
+this key means rotating the production contract id — every user of the
+old deployment will be orphaned. Suggested backup options (pick at
+least two):
+
+- Password manager with secure notes
+- Encrypted USB in a safe
+- Printed QR code in a fire-safe
+
+### 2. Network-connected Freenet node
+
+Production publishes go to the real Freenet network, not a
+`freenet local` sandbox. In another terminal:
+
+```bash
+freenet network
+```
+
+Wait until it reports connected peers. The release script pings the
+node's HTTP gateway on `127.0.0.1:50509` at preflight and warns if it
+doesn't respond.
+
+See AGENTS.md §"Running a Freenet node" for the local-vs-network
+distinction.
+
+### 3. Clean working tree on `main`
+
+```bash
+git checkout main
+git pull --ff-only
+git status   # must be clean
+```
+
+The release script refuses to run from any other branch or with
+uncommitted changes.
+
+### 4. GNU tar, fdev, dioxus-cli, cargo-make, gh
+
+All preflight-checked by `scripts/release.sh`. On macOS:
+
+```bash
+brew install gnu-tar gh
+cargo install fdev
+cargo binstall --version 0.7.3 dioxus-cli
+cargo binstall cargo-make
+```
+
+On Linux, tar is already GNU tar; install the rest the same way.
+
+## The release
+
+```bash
+scripts/release.sh 0.1.0
+```
+
+What happens, in order:
+
+1. **Preflight checks** — branch, clean tree, tag availability, key
+   present, tools installed, Freenet node reachable.
+2. **Test gate** — `cargo make test`, `test-inbox`, `clippy`. Any
+   failure aborts.
+3. **First confirmation prompt** — summarizes the six irreversible
+   steps about to run. Type `y` to proceed.
+4. **Build + sign + publish** — `cargo make publish-production` chains
+   `build` → `update-published-contract-prod` → `publish-email`. This
+   pushes the signed contract to the live Freenet network via fdev.
+5. **Diff verification** — confirms `published-contract/` actually
+   changed. If not, the script aborts with a diagnostic.
+6. **Second confirmation prompt** — shows the new contract id and
+   diff, asks whether to commit + tag.
+7. **Commit** `published-contract/` with a standard message.
+8. **Annotated tag** `v$VERSION` with auto-generated release notes from
+   the git log since the last tag.
+9. **Third confirmation prompt** — asks whether to push commit + tag
+   to `origin/main`.
+10. **Push** both to origin.
+
+To auto-confirm all prompts (useful for CI or scripting), pass
+`--yes`:
+
+```bash
+scripts/release.sh 0.1.0 --yes
+```
+
+## Post-release smoke test
+
+After `release.sh` succeeds, wait ~30s for the contract to propagate
+through Freenet's routing, then:
+
+```bash
+scripts/smoke-test-production.sh
+```
+
+With no argument, this defaults to
+`http://127.0.0.1:50509/contract/web/<committed-contract-id>/` (the
+local network-connected node serving the just-published contract).
+Pass an explicit gateway URL to test against a remote peer:
+
+```bash
+scripts/smoke-test-production.sh http://some-peer.example:50509/contract/web/<id>/
+```
+
+The script runs the full Playwright spec at `ui/tests/email-app.spec.ts`
+against the deployed webapp, exercising identity rendering, inbox
+display, multi-turn cross-inbox messaging, and sandboxed iframe
+embedding. This is NOT a live-node contract-state test — real AFT
+token mint/burn and real inbox contract round trips are covered by the
+manual checklist in AGENTS.md §"End-to-end testing".
+
+Post the result as a comment on the release tracking issue.
+
+## Recovery
+
+### Publish failed halfway
+
+The script is idempotent up to step 7 (commit). If any step 1-6 fails,
+re-run `scripts/release.sh 0.1.0` — no state persists between runs
+until commit time.
+
+If the publish succeeded but the tag push failed:
+
+```bash
+git tag -d v0.1.0            # drop the local tag
+scripts/release.sh 0.1.0     # start over
+```
+
+If the commit + tag both succeeded but the push failed, you're in an
+inconsistent state between your local and origin. Either:
+
+```bash
+git push origin main
+git push origin v0.1.0
+```
+
+...or unwind:
+
+```bash
+git reset --hard HEAD~1
+git tag -d v0.1.0
+```
+
+Unwinding leaves the published contract on Freenet, but without the
+committed snapshot to pin its id. Re-run `release.sh` to rebuild and
+re-publish (the second publish will likely produce a different id if
+anything about the build environment shifted; that's fine for a failed
+release).
+
+### Production key lost
+
+Generate a new one with `scripts/generate-production-key.sh`. The new
+contract id will differ; every existing user will have to re-point
+their client at the new webapp URL. Announce the rotation loudly.
+
+### Smoke test fails post-publish
+
+The webapp is live but broken for users. Options:
+
+1. **Roll forward** — fix the bug, bump the version, release again.
+   The new contract id replaces the old one for new users; old users
+   keep the broken version until they visit the new URL.
+2. **Temporary rollback** — there is no formal rollback. Publishing an
+   older commit will produce an older contract id, not overwrite the
+   current one. Point users at the older id in the meantime.
+
+## Release cadence and versioning
+
+Semver per `Cargo.toml`. Bump minor for new features, patch for fixes,
+major once the protocol stabilizes (we're not there yet).
+
+Don't squash release commits: the `chore(release): vX.Y.Z` commit is
+the annotated tag's anchor. Its diff is always exactly
+`published-contract/` — any release that touches other files is a bug.

--- a/scripts/generate-production-key.sh
+++ b/scripts/generate-production-key.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Generate the production ed25519 keypair used to sign release webapps.
+#
+# The key is written to the path in $WEB_CONTAINER_KEY_FILE, defaulting to
+# ~/.config/freenet-email/web-container-keys.toml. This file is NEVER
+# committed — losing it means rotating the production contract ID.
+#
+# Usage:
+#     scripts/generate-production-key.sh
+#     WEB_CONTAINER_KEY_FILE=/custom/path.toml scripts/generate-production-key.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KEY_FILE="${WEB_CONTAINER_KEY_FILE:-$HOME/.config/freenet-email/web-container-keys.toml}"
+
+if [ -f "$KEY_FILE" ]; then
+    echo "error: key file already exists at $KEY_FILE" >&2
+    echo "" >&2
+    echo "Overwriting would rotate the production contract ID and invalidate" >&2
+    echo "every previously-signed release. If that's actually what you want:" >&2
+    echo "" >&2
+    echo "  1. Back up the existing file somewhere safe first" >&2
+    echo "  2. Delete it: rm $KEY_FILE" >&2
+    echo "  3. Re-run this script" >&2
+    echo "" >&2
+    exit 1
+fi
+
+KEY_DIR="$(dirname "$KEY_FILE")"
+mkdir -p "$KEY_DIR"
+chmod 700 "$KEY_DIR" 2>/dev/null || true
+
+echo "generating fresh ed25519 keypair at $KEY_FILE..."
+cd "$REPO_ROOT"
+cargo run --quiet -p web-container-sign -- generate --output "$KEY_FILE"
+
+chmod 600 "$KEY_FILE"
+
+echo ""
+echo "✅ wrote $KEY_FILE"
+echo ""
+echo "IMPORTANT: back this file up NOW to somewhere offline and durable."
+echo ""
+echo "The public verifying key becomes part of the production contract ID"
+echo "via hash(wasm, parameters). If you lose this file:"
+echo "  • You cannot sign another release under the same contract ID."
+echo "  • You must rotate: generate a new key, publish the new ID, and"
+echo "    notify every existing user to point their clients at the new one."
+echo ""
+echo "Suggested backup options (pick at least two):"
+echo "  • Password manager with secure notes (1Password, Bitwarden)"
+echo "  • Encrypted USB stored in a safe"
+echo "  • Printed QR code in a fire-safe"
+echo ""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# End-to-end release driver for freenet-email.
+#
+# Runs the entire Phase 5 (#9) production-release workflow as a single
+# command. Stops at each irreversible action and asks for confirmation.
+#
+# Preconditions (checked up front, fail fast):
+#   • Working tree is clean and on `main`
+#   • `cargo make test` passes
+#   • The production ed25519 key exists at
+#     $WEB_CONTAINER_KEY_FILE (default ~/.config/freenet-email/web-container-keys.toml)
+#   • A Freenet network-connected node is running and reachable
+#     (not a `freenet local` sandbox)
+#   • `gh` is authenticated to push tags
+#   • GNU tar is installed (for reproducible archives)
+#
+# Usage:
+#     scripts/release.sh 0.1.0
+#     scripts/release.sh 0.1.0 --yes   # skip the final confirmation prompt
+#
+# The script is idempotent up to the point of committing
+# `published-contract/`: re-running after a failed publish re-runs the
+# build and prompts again, so recovery from a transient network error is
+# just `scripts/release.sh $version` again.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ─── Argument parsing ──────────────────────────────────────────────────────
+
+VERSION="${1:-}"
+SKIP_CONFIRM="${2:-}"
+
+if [ -z "$VERSION" ]; then
+    echo "usage: $0 <version> [--yes]" >&2
+    echo "  e.g. $0 0.1.0" >&2
+    exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+    echo "error: '$VERSION' is not a valid semver version" >&2
+    echo "       expected e.g. 0.1.0 or 0.1.0-rc1" >&2
+    exit 1
+fi
+
+TAG="v$VERSION"
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+confirm() {
+    local prompt="$1"
+    if [ "$SKIP_CONFIRM" = "--yes" ]; then
+        echo "$prompt (auto-confirmed via --yes)"
+        return 0
+    fi
+    read -r -p "$prompt [y/N] " reply
+    case "$reply" in
+        y|Y|yes|YES) return 0 ;;
+        *) echo "aborted."; exit 1 ;;
+    esac
+}
+
+# ─── Preflight ─────────────────────────────────────────────────────────────
+
+echo "═══ Preflight ══════════════════════════════════════════════════════"
+
+# Git state
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    die "not on main (current branch: $CURRENT_BRANCH)"
+fi
+if [ -n "$(git status --porcelain)" ]; then
+    die "working tree is dirty. Commit or stash first."
+fi
+
+# Tag must not already exist
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    die "tag $TAG already exists locally. Delete with 'git tag -d $TAG' first if re-running."
+fi
+if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+    die "tag $TAG already exists on origin. Either bump the version or delete it remotely."
+fi
+
+# Production key
+KEY_FILE="${WEB_CONTAINER_KEY_FILE:-$HOME/.config/freenet-email/web-container-keys.toml}"
+if [ ! -f "$KEY_FILE" ]; then
+    die "production key not found at $KEY_FILE
+
+Run scripts/generate-production-key.sh first."
+fi
+echo "  ✓ production key at $KEY_FILE"
+
+# Required tools
+command -v fdev >/dev/null || die "fdev not in PATH (cargo install fdev)"
+command -v dx >/dev/null || die "dx (dioxus-cli) not in PATH"
+command -v cargo-make >/dev/null || die "cargo-make not in PATH"
+command -v gh >/dev/null || die "gh (GitHub CLI) not in PATH"
+
+# GNU tar — required for reproducible archive
+if command -v gtar >/dev/null 2>&1; then
+    echo "  ✓ GNU tar available (gtar)"
+elif tar --version 2>/dev/null | grep -qi 'gnu tar'; then
+    echo "  ✓ GNU tar available (tar)"
+else
+    die "GNU tar not found. Install it:
+  macOS: brew install gnu-tar
+  linux: already default"
+fi
+
+# Freenet node — check the UI gateway port (50509 is the default for
+# `freenet network`; the exact check depends on your node's HTTP gateway).
+if ! curl -sf -o /dev/null "http://127.0.0.1:50509/contract/web/" 2>/dev/null; then
+    echo "  ⚠️  could not reach a Freenet node at http://127.0.0.1:50509"
+    echo "     Make sure \`freenet network\` (NOT \`freenet local\`) is running"
+    echo "     in another terminal and is connected to the network."
+    confirm "Continue anyway?"
+else
+    echo "  ✓ Freenet node reachable on :50509"
+fi
+
+echo "  ✓ clean tree on main"
+echo "  ✓ tag $TAG available"
+
+# Tests
+echo ""
+echo "═══ Running tests ══════════════════════════════════════════════════"
+cargo make test
+cargo make test-inbox
+cargo make clippy
+echo "  ✓ cargo make test, test-inbox, clippy green"
+
+# ─── Confirmation ──────────────────────────────────────────────────────────
+
+echo ""
+echo "═══ About to release $TAG ════════════════════════════════════════════"
+echo ""
+echo "This will:"
+echo "  1. Build the UI and contracts in release mode"
+echo "  2. Sign the webapp with the PRODUCTION key at $KEY_FILE"
+echo "  3. Publish the contract to the real Freenet network via fdev"
+echo "  4. Commit the new published-contract/ snapshot"
+echo "  5. Create an annotated tag $TAG"
+echo "  6. Push the commit AND tag to origin/main"
+echo ""
+echo "Steps 3, 4, 5, 6 are PUBLICLY VISIBLE and hard to undo."
+confirm "Proceed?"
+
+# ─── Build + publish ───────────────────────────────────────────────────────
+
+echo ""
+echo "═══ Building and publishing ═══════════════════════════════════════"
+cargo make publish-production
+
+# ─── Verify the commit-worthy diff ─────────────────────────────────────────
+
+if [ -z "$(git status --porcelain -- published-contract/)" ]; then
+    die "expected published-contract/ to change but git status shows no diff.
+Something went wrong in the build — the committed snapshot may already
+match the current build output (unusual for a first production publish)."
+fi
+
+CONTRACT_ID=$(cat published-contract/contract-id.txt)
+echo ""
+echo "  ✓ published contract id: $CONTRACT_ID"
+echo ""
+echo "Diff in published-contract/:"
+git status --short -- published-contract/
+echo ""
+
+confirm "Commit this snapshot and tag as $TAG?"
+
+# ─── Commit ────────────────────────────────────────────────────────────────
+
+git add published-contract/
+git commit -m "chore(release): $TAG — production publish
+
+Contract ID: $CONTRACT_ID
+
+Signed with the uncommitted production key at
+~/.config/freenet-email/web-container-keys.toml.
+"
+
+COMMIT=$(git rev-parse HEAD)
+
+# ─── Tag ───────────────────────────────────────────────────────────────────
+
+# Pull the changelog from the last tag (if any) for the annotated message.
+PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$PREV_TAG" ]; then
+    CHANGELOG=$(git log --pretty=format:'  - %s' "$PREV_TAG..HEAD")
+    RANGE="since $PREV_TAG"
+else
+    CHANGELOG=$(git log --pretty=format:'  - %s')
+    RANGE="initial release"
+fi
+
+git tag -a "$TAG" -m "freenet-email $TAG
+
+Production webapp contract id: $CONTRACT_ID
+
+Changes $RANGE:
+$CHANGELOG
+"
+
+echo "  ✓ tagged $TAG at $COMMIT"
+
+# ─── Push ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══ Pushing to origin ══════════════════════════════════════════════"
+confirm "Push the commit AND tag to origin/main?"
+
+git push origin main
+git push origin "$TAG"
+
+echo ""
+echo "✅ released $TAG"
+echo ""
+echo "Next steps:"
+echo "  1. Wait ~30s for the contract to propagate"
+echo "  2. Run: scripts/smoke-test-production.sh <gateway-url>"
+echo "     (the gateway URL will look like"
+echo "      http://<gateway-host>:<port>/contract/web/$CONTRACT_ID/)"
+echo "  3. Post the smoke-test result as a comment on issue #9"
+echo ""

--- a/scripts/smoke-test-production.sh
+++ b/scripts/smoke-test-production.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Run the Playwright E2E suite against a deployed freenet-email webapp.
+#
+# Usage:
+#     scripts/smoke-test-production.sh <gateway-url>
+#
+# Example:
+#     scripts/smoke-test-production.sh http://127.0.0.1:50509/contract/web/<contract-id>/
+#
+# Defaults the gateway URL to the local `freenet network` node serving
+# the contract id from `published-contract/contract-id.txt` if no argument
+# is provided.
+#
+# What this exercises:
+#   • The Playwright spec at ui/tests/email-app.spec.ts (same 7 scenarios
+#     that run against the local dev server in offline mode), pointed at
+#     the real gateway instead of a dx serve on localhost:8082.
+#   • Rendering, identity seeding, compose, and in-memory cross-inbox
+#     messaging — i.e., the full offline UI contract, as served by the
+#     real webapp contract. Does NOT exercise real AFT token mint/burn or
+#     real inbox contract state (that's the manual live-node checklist in
+#     AGENTS.md §End-to-end testing).
+#
+# Exit code: non-zero if any Playwright test fails.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+GATEWAY_URL="${1:-}"
+
+if [ -z "$GATEWAY_URL" ]; then
+    if [ ! -f "published-contract/contract-id.txt" ]; then
+        echo "usage: $0 <gateway-url>" >&2
+        echo "       (no published-contract/contract-id.txt to auto-derive from)" >&2
+        exit 1
+    fi
+    CONTRACT_ID=$(cat published-contract/contract-id.txt)
+    GATEWAY_URL="http://127.0.0.1:50509/contract/web/$CONTRACT_ID/"
+    echo "no URL supplied; defaulting to local freenet network gateway:"
+    echo "  $GATEWAY_URL"
+fi
+
+# Sanity check: the gateway should return SOMETHING.
+if ! curl -sf -o /dev/null "$GATEWAY_URL" 2>/dev/null; then
+    echo "error: $GATEWAY_URL is not responding" >&2
+    echo "" >&2
+    echo "Make sure:" >&2
+    echo "  1. \`freenet network\` is running and connected" >&2
+    echo "  2. The contract has propagated (wait ~30s after publish)" >&2
+    echo "  3. The gateway URL is correct (default port 50509)" >&2
+    exit 1
+fi
+
+# Playwright browsers must be installed.
+if [ ! -d "ui/tests/node_modules" ]; then
+    echo "error: ui/tests/node_modules missing. Run:" >&2
+    echo "  cargo make test-ui-playwright-setup" >&2
+    exit 1
+fi
+
+echo ""
+echo "═══ Running Playwright smoke tests against production ═════════════"
+echo "  baseURL: $GATEWAY_URL"
+echo ""
+
+cd "$REPO_ROOT/ui/tests"
+FREENET_EMAIL_BASE_URL="$GATEWAY_URL" npx playwright test
+
+echo ""
+echo "✅ smoke test passed against $GATEWAY_URL"

--- a/ui/tests/playwright.config.ts
+++ b/ui/tests/playwright.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
   timeout: 120_000,
   retries: 2,
   use: {
-    baseURL: "http://127.0.0.1:8082",
+    // Override with FREENET_EMAIL_BASE_URL to run against a deployed
+    // webapp (e.g., scripts/smoke-test-production.sh points this at the
+    // Freenet gateway URL for the published contract id).
+    baseURL: process.env.FREENET_EMAIL_BASE_URL || "http://127.0.0.1:8082",
     navigationTimeout: 30_000,
     actionTimeout: 10_000,
   },


### PR DESCRIPTION
## Summary

- **`cargo make publish-production`** — new target chaining `build` → `update-published-contract-prod` → `publish-email` (production analog of `publish-all`)
- **`scripts/release.sh`** — end-to-end release driver with preflight checks, confirmation prompts, and recovery-friendly idempotency
- **`scripts/generate-production-key.sh`** — one-time production key generation with overwrite guard and backup instructions
- **`scripts/smoke-test-production.sh`** — Playwright suite pointed at a deployed gateway via `FREENET_EMAIL_BASE_URL`
- **`README.md`** (new) — end-user facing
- **`RELEASING.md`** (new) — release runbook
- **`AGENTS.md`** — feature flag matrix, local vs network node, regenerating test keys

## Why a script, not a checklist

Phase 5 (#9) has four sub-tasks: docs, tag `v0.1.0`, production publish, smoke test. The last three are traditionally manual steps where checklists rot and mistakes are expensive (losing a production key, tagging the wrong commit, forgetting to back up). Wrapping them in `scripts/release.sh` with explicit preflight and confirmation prompts makes the process reproducible and safer.

The script is idempotent up to the commit step — if the publish fails halfway, just re-run it. The release manager's mental model is "one command per release" instead of "eight coordinated commands".

## What's in each script

### `release.sh <version> [--yes]`

Preflight:
- Branch is `main`, tree is clean
- Tag doesn't already exist locally or on origin
- Production key exists at `$WEB_CONTAINER_KEY_FILE` (default `~/.config/freenet-email/web-container-keys.toml`)
- `fdev`, `dx`, `cargo-make`, `gh`, GNU tar all on PATH
- Freenet node reachable on `127.0.0.1:50509` (warning if not)

Flow:
1. `cargo make test` + `test-inbox` + `clippy`
2. **Confirmation 1** — summarizes the six irreversible steps
3. `cargo make publish-production` (build + sign with prod key + publish to real Freenet)
4. Verify `published-contract/` actually changed
5. **Confirmation 2** — shows new contract id + diff
6. Commit + create annotated tag with auto-generated changelog
7. **Confirmation 3** — push commit and tag
8. `git push origin main && git push origin v$VERSION`

`--yes` auto-confirms all three prompts (for CI or scripting).

### `generate-production-key.sh`

- Refuses to overwrite existing key
- `chmod 700` dir, `chmod 600` file
- Prints backup-location suggestions (password manager, encrypted USB, printed QR in fire-safe)

### `smoke-test-production.sh [url]`

- Defaults URL to `http://127.0.0.1:50509/contract/web/<committed-id>/`
- Curls the gateway before launching Playwright (fast failure on unreachable)
- Runs `npx playwright test` with `FREENET_EMAIL_BASE_URL` set, reusing the existing `ui/tests/email-app.spec.ts` across all 5 browser profiles

## Docs

- **`README.md`** is end-user facing — what it is, how to try it, architecture summary, pointers to AGENTS.md and RELEASING.md
- **`RELEASING.md`** documents preconditions, the three-command TL;DR, the step-by-step flow, recovery procedures for each failure mode (mid-publish failure, lost production key, broken post-release webapp), versioning
- **`AGENTS.md`** gains a feature-flag matrix, a local-vs-network node table, and a "Regenerating test keys" section. The Publishing section is rewritten to point at `scripts/release.sh` and `RELEASING.md` instead of the old manual `cargo run` invocation. Also drops the stale "rustc pin as TODO" note now that `rust-toolchain.toml` exists (added in #15).

## What still needs human hands

Everything gated by real Freenet network I/O:

1. `scripts/generate-production-key.sh` (on the release manager's machine)
2. Start `freenet network` (a real network-connected node)
3. `scripts/release.sh 0.1.0`
4. Wait ~30s for propagation
5. `scripts/smoke-test-production.sh`
6. Post result as a comment on #9

Happy to drive steps 3-6 interactively once the key is in place — the scripts are written so the release manager doesn't need to know any of the internal `cargo make` plumbing.

Part of #1, closes the docs + scripting half of #9.

## Test plan

- [x] `cargo make test` + `test-inbox` + `clippy` green
- [x] `cargo make --list-all-steps` shows `publish-production` and `update-published-contract-prod`
- [x] `bash -n scripts/*.sh` — syntax clean
- [ ] CI workflows green on this PR (automatic)
- [ ] Dry-run of `scripts/release.sh` on a test version (manual, needs freenet network node — planned as the follow-up)