### PR TITLE
fix(smoke-test): liveness-only spec for production webapp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,13 @@ between them — no Freenet node required. The Playwright tests
 exercise multi-turn cross-inbox messaging (compose → send → switch
 identity → verify delivery → reply).
 
+There's also `ui/tests/production-liveness.spec.ts`, a minimal
+browser-loads-and-mounts check used by
+`scripts/smoke-test-production.sh` against a deployed `use-node`
+webapp. It deliberately doesn't exercise identity creation or
+messaging — see `RELEASING.md` §"Post-release smoke test" for the
+scope and the rationale.
+
 ### Manual E2E checklist (against a local node)
 
 This checklist validates the pieces that unit tests and Playwright

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -150,14 +150,45 @@ Pass an explicit gateway URL to test against a remote peer:
 scripts/smoke-test-production.sh http://some-peer.example:50509/contract/web/<id>/
 ```
 
-The script runs the full Playwright spec at `ui/tests/email-app.spec.ts`
-against the deployed webapp, exercising identity rendering, inbox
-display, multi-turn cross-inbox messaging, and sandboxed iframe
-embedding. This is NOT a live-node contract-state test — real AFT
-token mint/burn and real inbox contract round trips are covered by the
-manual checklist in AGENTS.md §"End-to-end testing".
+### What the smoke test covers
 
-Post the result as a comment on the release tracking issue.
+`smoke-test-production.sh` runs
+`ui/tests/production-liveness.spec.ts` against the deployed webapp
+across all five browser profiles. The spec is intentionally minimal:
+
+- The gateway serves the webapp
+- The WASM bundle loads
+- Dioxus mounts and renders the "Freenet Email" header
+- The login screen shows the "Create new identity" link
+
+What it catches: every failure mode in the publish pipeline that
+results in a webapp that won't boot — corrupted tar archive, wrong
+signature, stale contract id, routing misconfiguration.
+
+### What the smoke test does NOT cover
+
+The production webapp is a `use-node` build and can only do
+user-facing work (create an identity, send a message, receive a
+message) when attached to a real Freenet node that has the inbox,
+AFT, and identity-management contracts published. Exercising that
+flow requires spinning up a disposable `freenet local` node alongside
+the test, which is out of scope for `smoke-test-production.sh`.
+
+There are two ways to cover the real round trip:
+
+1. **Automated**: `cargo make test-ui-live` runs
+   `ui/tests/live-node.spec.ts` against a fresh `freenet local` node
+   with a disposable data directory. This exercises real RSA keygen,
+   real inbox contract puts, real AFT token burn, and real decrypted
+   message delivery between two identities in a single browser
+   session. Safe to run on every CI build because it's fully
+   isolated from the real network.
+2. **Manual**: the 7-step checklist in AGENTS.md §"End-to-end
+   testing", run against a real `freenet network` node. This is the
+   canonical acceptance gate for a real release.
+
+Post the liveness result and whichever of (1) or (2) you ran as a
+comment on the release tracking issue.
 
 ## Recovery
 

--- a/scripts/smoke-test-production.sh
+++ b/scripts/smoke-test-production.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run the Playwright E2E suite against a deployed freenet-email webapp.
+# Production liveness check for a deployed freenet-email webapp.
 #
 # Usage:
 #     scripts/smoke-test-production.sh <gateway-url>
@@ -7,21 +7,35 @@
 # Example:
 #     scripts/smoke-test-production.sh http://127.0.0.1:50509/contract/web/<contract-id>/
 #
-# Defaults the gateway URL to the local `freenet network` node serving
-# the contract id from `published-contract/contract-id.txt` if no argument
-# is provided.
+# With no argument, defaults to the local `freenet network` gateway
+# serving the contract id from `published-contract/contract-id.txt`.
 #
-# What this exercises:
-#   • The Playwright spec at ui/tests/email-app.spec.ts (same 7 scenarios
-#     that run against the local dev server in offline mode), pointed at
-#     the real gateway instead of a dx serve on localhost:8082.
-#   • Rendering, identity seeding, compose, and in-memory cross-inbox
-#     messaging — i.e., the full offline UI contract, as served by the
-#     real webapp contract. Does NOT exercise real AFT token mint/burn or
-#     real inbox contract state (that's the manual live-node checklist in
-#     AGENTS.md §End-to-end testing).
+# ─── Scope ─────────────────────────────────────────────────────────────────
 #
-# Exit code: non-zero if any Playwright test fails.
+# This runs `ui/tests/production-liveness.spec.ts` against the deployed
+# webapp. The spec is intentionally MINIMAL:
+#
+#   • Proves the publish pipeline didn't corrupt bytes (gateway serves
+#     the webapp, WASM loads, Dioxus mounts, login screen renders).
+#   • Runs in ~15s across all five browser profiles.
+#
+# What it explicitly does NOT cover:
+#
+#   • Real identity creation (RSA keygen + inbox contract put)
+#   • Real AFT token mint/burn
+#   • Real message send/receive round trip
+#
+# The production webapp is a `use-node` build — it expects a running
+# Freenet node to do anything user-facing — so a Playwright test that
+# loads it from a gateway and clicks "Create new identity" would need
+# to also spin up a disposable `freenet local` node, publish the test
+# contract to it, and wait through RSA-4096 keygen + contract-put
+# propagation. That's what `ui/tests/live-node.spec.ts` + `cargo make
+# test-ui-live` do (see Phase 5 PR B).
+#
+# The manual 7-step checklist in AGENTS.md §"End-to-end testing" is
+# the human-driven equivalent of the live-node test and is still the
+# canonical acceptance gate for a real release.
 
 set -euo pipefail
 
@@ -42,7 +56,7 @@ if [ -z "$GATEWAY_URL" ]; then
     echo "  $GATEWAY_URL"
 fi
 
-# Sanity check: the gateway should return SOMETHING.
+# Sanity check: the gateway should return something.
 if ! curl -sf -o /dev/null "$GATEWAY_URL" 2>/dev/null; then
     echo "error: $GATEWAY_URL is not responding" >&2
     echo "" >&2
@@ -61,12 +75,18 @@ if [ ! -d "ui/tests/node_modules" ]; then
 fi
 
 echo ""
-echo "═══ Running Playwright smoke tests against production ═════════════"
+echo "═══ Production liveness check ═════════════════════════════════════"
 echo "  baseURL: $GATEWAY_URL"
+echo "  spec:    ui/tests/production-liveness.spec.ts"
 echo ""
 
 cd "$REPO_ROOT/ui/tests"
-FREENET_EMAIL_BASE_URL="$GATEWAY_URL" npx playwright test
+FREENET_EMAIL_BASE_URL="$GATEWAY_URL" npx playwright test production-liveness.spec.ts
 
 echo ""
-echo "✅ smoke test passed against $GATEWAY_URL"
+echo "✅ liveness check passed against $GATEWAY_URL"
+echo ""
+echo "For the full end-to-end round trip (create identities, send,"
+echo "receive, burn AFT tokens), run the manual checklist in"
+echo "AGENTS.md §\"End-to-end testing\" or wait for the automated"
+echo "live-node test landing in Phase 5 PR B."

--- a/ui/tests/production-liveness.spec.ts
+++ b/ui/tests/production-liveness.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+// Production liveness check.
+//
+// This spec runs against a *deployed* `use-node` webapp served through
+// a Freenet gateway. Unlike `email-app.spec.ts`, which assumes the
+// offline `example-data,no-sync` build with pre-seeded mock
+// identities, the production build starts with an empty identity list
+// and requires a running Freenet node to do anything useful. That
+// means we can't exercise compose, send, or multi-inbox delivery from
+// Playwright alone — the real end-to-end round trip is covered by
+// `live-node.spec.ts` (PR B) and the manual 7-step checklist in
+// AGENTS.md §"End-to-end testing".
+//
+// What this spec IS for: proving that the publish pipeline
+// (`compress-webapp` → `sign-webapp` → `publish-email` → gateway
+// routing) produced a webapp that a browser can load, mount, and
+// render the login screen for. It's the fastest check that catches
+// the "did we corrupt bytes along the way" class of failures without
+// needing a node, identities, or contract state.
+//
+// baseURL is read from FREENET_EMAIL_BASE_URL by playwright.config.ts
+// and pointed at the deployed gateway URL by
+// `scripts/smoke-test-production.sh`.
+
+test.describe("Production liveness", () => {
+  test("webapp loads and renders the login screen", async ({ page }) => {
+    await page.goto("/");
+
+    // The Dioxus root mounts into <div id="main">. The "Freenet Email"
+    // heading is part of the LoginHeader component and is the first
+    // user-visible proof that the WASM loaded and the app's root
+    // component mounted successfully.
+    await expect(page.locator("h1")).toContainText("Freenet Email", {
+      timeout: 60_000,
+    });
+
+    // The "Create new identity" link is rendered by `CreateLinks` when
+    // the user has no identified state, which is the initial state on
+    // a fresh production build (no localStorage, no mock seeding).
+    await expect(page.getByText("Create new identity")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The smoke test script shipped in #16 was aimed at `email-app.spec.ts`, which assumes the offline `example-data,no-sync` build with pre-seeded mock identities. But `scripts/release.sh` publishes a `use-node` build — every test in `email-app.spec.ts` would fail against it because the production webapp starts with an empty identity list, not `address1` / `address2`.

This PR replaces the smoke test target with a minimal liveness spec (`ui/tests/production-liveness.spec.ts`) that matches what the production webapp actually renders on first load.

## What the new liveness spec checks

- The \"Freenet Email\" h1 from LoginHeader
- The \"Create new identity\" link from CreateLinks

Across all five browser profiles. Completes in ~20s.

## What it catches

- Gateway serving the wrong contract id
- Publish pipeline corrupting the tar archive, signature, or metadata
- WASM bundle failing to load or hydrate
- Dioxus mount-point regressions (like the one we fixed in #13)

## What it explicitly does NOT cover

Identity creation, AFT mint/burn, and real messaging round-trip need a running Freenet node — they can't be exercised by a Playwright spec loading a production webapp from a gateway.

Those are covered by:

1. **Automated** (landing in follow-up PR B): `cargo make test-ui-live` + `ui/tests/live-node.spec.ts`, which spin up a disposable `freenet local` with `--data-dir \$(mktemp -d)` and exercise the full round-trip in total isolation from the real network.
2. **Manual**: the 7-step checklist in AGENTS.md §\"End-to-end testing\".

## Why a two-PR split

PR A (this one) is small, safe, and unblocks the actual production release — without it, \`scripts/smoke-test-production.sh\` fails against every release. PR B is a larger undertaking (disposable-node lifecycle, RSA-keygen wait timing, CI integration) and has unknown-unknowns that shouldn't gate getting the release pipeline working.

## Verified

- [x] \`bash -n scripts/smoke-test-production.sh\` clean
- [x] \`production-liveness.spec.ts\` passes 5/5 browser profiles locally against \`dx serve --features example-data,no-sync\` (which has the same h1 + \"Create new identity\" render as a fresh \`use-node\` load)

## Docs

- **\`RELEASING.md\` §\"Post-release smoke test\"** rewritten to document what the smoke test covers, what's out of scope, and the two escape hatches (automated live-node test, manual checklist).
- **\`AGENTS.md\`** gains a mention of \`production-liveness.spec.ts\` alongside the existing Playwright section.

Part of #1, #9.