### PR TITLE
PQ Stage 1: ML-DSA-65 signatures for inbox state deltas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -275,8 +275,8 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -286,6 +286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -365,7 +374,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -438,7 +447,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -484,6 +493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +519,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-serialize"
@@ -651,6 +672,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,15 +710,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -786,8 +834,18 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -841,10 +899,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1322,13 +1390,13 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
+ "der 0.7.10",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "serdect",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1337,9 +1405,9 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "serde",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1365,13 +1433,13 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "serdect",
@@ -1479,6 +1547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1605,8 @@ dependencies = [
  "chrono",
  "freenet-aft-interface",
  "freenet-stdlib",
+ "getrandom 0.4.2",
+ "ml-dsa",
  "rsa",
  "serde",
  "serde_json",
@@ -1552,6 +1628,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "identity-management",
+ "ml-dsa",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rsa",
@@ -1770,9 +1847,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1851,6 +1942,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -1912,7 +2012,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1959,6 +2059,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2127,6 +2236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2393,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2425,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2483,6 +2614,31 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b2bb0ad6fa2b40396775bd56f51345171490fef993f46f91a876ecdbdaea55"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0-rc.11",
+ "rand_core 0.10.0",
+ "sha3",
+ "signature 3.0.0-rc.10",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164eb3faeaecbd14b0b2a917c1b4d0c035097a9c559b0bed85c2cdd032bc8faa"
+dependencies = [
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -2729,9 +2885,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2740,8 +2896,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2750,7 +2916,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2777,6 +2943,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2905,6 +3081,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +3144,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "raw-window-handle"
@@ -3089,18 +3277,18 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "serde",
  "sha2",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -3232,9 +3420,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serdect",
  "subtle",
  "zeroize",
@@ -3411,8 +3599,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3422,8 +3610,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
 ]
 
 [[package]]
@@ -3447,8 +3645,18 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3525,7 +3733,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -4066,7 +4284,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -4185,6 +4403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,6 +4473,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,6 +4505,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -4542,6 +4803,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,12 @@ bincode = "1"
 bs58 = "0.5"
 chrono = "0.4"
 rsa = { version = "0.9.2", default-features = false, features = ["serde", "pem", "sha2"] }
+# ML-DSA (CRYSTALS-Dilithium), NIST FIPS 204, level-3 parameter set (ML-DSA-65).
+# Replacing RSA-PKCS#1 v1.5 signatures on inbox state deltas. See issue #18.
+# 0.1.0-rc is the latest RustCrypto release; pinned here pending a 1.0.
+# Uses rand_core 0.10 / signature 3.0 internally; do not add an older
+# `signature = "2"` workspace dep — the trait versions won't match.
+ml-dsa = { version = "0.1.0-rc.8", default-features = false, features = ["alloc", "rand_core"] }
 serde = "1"
 serde_json = "1"
 strum = { version = "0.24", features = ["derive"] }

--- a/contracts/inbox/Cargo.toml
+++ b/contracts/inbox/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 chrono = { version = "0.4.23", default-features = false, features = ["alloc", "serde"] }
 freenet-stdlib = { workspace = true }
 rsa = { workspace = true }
+ml-dsa = { workspace = true }
 freenet-aft-interface = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -18,6 +19,11 @@ thiserror = { workspace = true }
 # so `rsa::rand_core::OsRng` resolves. The library build keeps
 # `default-features = false` because the wasm32 target has no `OsRng`.
 rsa = { version = "0.9.2", features = ["std"] }
+# ML-DSA keygen needs a `rand_core 0.10`-compatible `CryptoRng`. The
+# easiest source is `getrandom::SysRng` wrapped in `UnwrapErr` to turn
+# the fallible `TryRng` into an infallible `RngCore`. This is also the
+# form ml-dsa's own docs use. `sys_rng` is behind a feature flag.
+getrandom = { version = "0.4", features = ["sys_rng"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -17,21 +17,56 @@ use freenet_aft_interface::{
     TokenAssignmentHash,
 };
 use freenet_stdlib::prelude::*;
-use rsa::{
-    pkcs1v15::{SigningKey, VerifyingKey},
-    sha2::Sha256,
-    signature::{Signer, Verifier},
-    RsaPrivateKey, RsaPublicKey,
+// ML-DSA-65 (FIPS 204, NIST level 3) is used for inbox-owner signatures
+// on state deltas. RSA remains only for message *encryption* (Stage 2 of
+// #18 will rip that out too) and for the AFT token system's own crypto,
+// which is a separate concern from this epic.
+//
+// Note on trait naming: `ml_dsa` re-exports `signature::{Signer, Verifier,
+// Keypair}`, and so does the `rsa` crate. We import the ml-dsa aliases
+// under prefixed names and keep the rsa `Verifier` under an alias so the
+// two don't collide at method-resolution time for `.verify()` /
+// `.sign()`.
+use ml_dsa::{
+    signature::{Signer as MlDsaSigner, Verifier as MlDsaVerifier},
+    EncodedVerifyingKey, MlDsa65, SigningKey as MlDsaSigningKey,
+    VerifyingKey as MlDsaVerifyingKey,
 };
+use rsa::{pkcs1v15::VerifyingKey as RsaVerifyingKey, sha2::Sha256};
 use serde::{Deserialize, Serialize};
 
-/// Sign this byte array and include the signature in the `inbox_signature` so this inbox can be verified on updates.
+/// Sign this byte array and include the signature in the `inbox_signature` so
+/// this inbox can be verified on updates. Value is arbitrary but must stay
+/// constant across versions — it's part of the signed-payload convention, so
+/// changing it would invalidate every existing inbox signature.
 const STATE_UPDATE: &[u8; 8] = &[168, 7, 13, 64, 168, 123, 142, 215];
 
-#[derive(Serialize, Deserialize)]
+/// The owner's ML-DSA-65 verifying key. Stored on-wire as the FIPS 204
+/// encoded byte array (1952 bytes for ML-DSA-65) to avoid a custom serde
+/// impl on the typed key. `pub_key_decoded()` reconstructs the typed
+/// `VerifyingKey<MlDsa65>` on demand.
+///
+/// This field is part of the contract parameters, so it participates in
+/// `hash(code, params)` and every bit change rotates the contract id.
+#[derive(Serialize, Deserialize, Clone)]
 pub struct InboxParams {
-    // The public key of the inbox owner message.
-    pub pub_key: RsaPublicKey,
+    pub pub_key: Vec<u8>,
+}
+
+impl InboxParams {
+    /// Convenience constructor from a typed ML-DSA verifying key.
+    pub fn from_verifying_key(vk: &MlDsaVerifyingKey<MlDsa65>) -> Self {
+        Self {
+            pub_key: vk.encode().to_vec(),
+        }
+    }
+
+    /// Decode `pub_key` back into the typed ML-DSA verifying key. Returns
+    /// `None` if the byte array isn't the right length for ML-DSA-65.
+    pub fn pub_key_decoded(&self) -> Option<MlDsaVerifyingKey<MlDsa65>> {
+        let encoded: EncodedVerifyingKey<MlDsa65> = (&*self.pub_key).try_into().ok()?;
+        Some(MlDsaVerifyingKey::<MlDsa65>::decode(&encoded))
+    }
 }
 
 impl TryFrom<InboxParams> for Parameters<'_> {
@@ -150,7 +185,11 @@ impl Display for VerificationError {
 
 impl Inbox {
     #[cfg(feature = "wasmbind")]
-    pub fn new(key: &RsaPrivateKey, settings: InboxSettings, messages: Vec<Message>) -> Self {
+    pub fn new(
+        key: &MlDsaSigningKey<MlDsa65>,
+        settings: InboxSettings,
+        messages: Vec<Message>,
+    ) -> Self {
         let inbox_signature = Self::sign(key);
         Self {
             settings,
@@ -164,18 +203,21 @@ impl Inbox {
         serde_json::to_vec(self).map_err(|err| ContractError::Deser(format!("{err}")))
     }
 
-    pub fn sign(key: &RsaPrivateKey) -> Signature {
-        let signing_key = SigningKey::<Sha256>::new(key.clone());
-        signing_key.sign(STATE_UPDATE).into()
+    /// Sign the fixed `STATE_UPDATE` salt with the inbox owner's ML-DSA-65
+    /// signing key. The resulting signature is stored in
+    /// `Inbox::inbox_signature` and verified on every state update.
+    pub fn sign(key: &MlDsaSigningKey<MlDsa65>) -> Signature {
+        let sig: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(key, STATE_UPDATE);
+        sig.encode().to_vec().into_boxed_slice()
     }
 
     fn verify(&self, params: &InboxParams) -> Result<(), VerificationError> {
-        let verifying_key = VerifyingKey::<Sha256>::new(params.pub_key.clone());
-        verifying_key
-            .verify(
-                STATE_UPDATE,
-                &rsa::pkcs1v15::Signature::try_from(&*self.inbox_signature).unwrap(),
-            )
+        let verifying_key = params
+            .pub_key_decoded()
+            .ok_or(VerificationError::WrongSignature)?;
+        let sig = decode_ml_dsa_signature(&self.inbox_signature)
+            .map_err(|_| VerificationError::WrongSignature)?;
+        MlDsaVerifier::verify(&verifying_key, STATE_UPDATE, &sig)
             .map_err(|_e| VerificationError::WrongSignature)?;
         Ok(())
     }
@@ -221,7 +263,7 @@ impl Inbox {
                 return Err(VerificationError::TokenAssignmentMismatch);
             }
             let verifying_key =
-                VerifyingKey::<Sha256>::new(message.token_assignment.generator.clone());
+                RsaVerifyingKey::<Sha256>::new(message.token_assignment.generator.clone());
             message
                 .token_assignment
                 .is_valid(&verifying_key)
@@ -234,7 +276,8 @@ impl Inbox {
     }
 
     fn add_message(&mut self, message: Message) -> Result<(), VerificationError> {
-        let verifying_key = VerifyingKey::<Sha256>::new(message.token_assignment.generator.clone());
+        let verifying_key =
+            RsaVerifyingKey::<Sha256>::new(message.token_assignment.generator.clone());
         message
             .token_assignment
             .is_valid(&verifying_key)
@@ -313,7 +356,19 @@ impl TryFrom<StateSummary<'static>> for InboxSummary {
     }
 }
 
-/// Whether this messages can be added/removed from the inbox.
+/// Helper: decode a stored `Signature` byte blob into a typed ML-DSA-65
+/// signature. Returns `ContractError::InvalidUpdate` on any decode failure
+/// so the caller can propagate cleanly.
+fn decode_ml_dsa_signature(signature: &Signature) -> Result<ml_dsa::Signature<MlDsa65>, ContractError> {
+    let encoded: ml_dsa::EncodedSignature<MlDsa65> = (&**signature)
+        .try_into()
+        .map_err(|_| ContractError::InvalidUpdate)?;
+    ml_dsa::Signature::<MlDsa65>::decode(&encoded).ok_or(ContractError::InvalidUpdate)
+}
+
+/// Whether the given `signature` authorises removal of the given token
+/// assignment hashes from the inbox. The signed payload is the
+/// concatenation of those hashes.
 fn can_reemove_messages<'a>(
     params: &InboxParams,
     signature: &Signature,
@@ -323,12 +378,11 @@ fn can_reemove_messages<'a>(
     for hash in hashes {
         signed.extend(hash);
     }
-    let verifying_key = VerifyingKey::<Sha256>::new(params.pub_key.clone());
-    verifying_key
-        .verify(
-            signed.as_ref(),
-            &rsa::pkcs1v15::Signature::try_from(&**signature).unwrap(),
-        )
+    let verifying_key = params
+        .pub_key_decoded()
+        .ok_or(ContractError::InvalidUpdate)?;
+    let sig = decode_ml_dsa_signature(signature)?;
+    MlDsaVerifier::verify(&verifying_key, signed.as_ref(), &sig)
         .map_err(|_err| ContractError::InvalidUpdate)?;
     Ok(())
 }
@@ -340,12 +394,11 @@ fn can_update_settings(
 ) -> Result<(), ContractError> {
     let serialized =
         serde_json::to_vec(settings).map_err(|e| ContractError::Deser(format!("{e}")))?;
-    let verifying_key = VerifyingKey::<Sha256>::from(params.pub_key.clone());
-    verifying_key
-        .verify(
-            &serialized,
-            &rsa::pkcs1v15::Signature::try_from(&**signature).unwrap(),
-        )
+    let verifying_key = params
+        .pub_key_decoded()
+        .ok_or(ContractError::InvalidUpdate)?;
+    let sig = decode_ml_dsa_signature(signature)?;
+    MlDsaVerifier::verify(&verifying_key, &serialized, &sig)
         .map_err(|_err| ContractError::InvalidUpdate)?;
     Ok(())
 }
@@ -480,26 +533,45 @@ impl ContractInterface for Inbox {
 #[cfg(all(feature = "contract", test))]
 mod tests {
     use super::*;
-    use rsa::{rand_core::OsRng, Pkcs1v15Sign, RsaPrivateKey};
+    use getrandom::SysRng;
+    use ml_dsa::{
+        signature::{rand_core::UnwrapErr, Keypair as MlDsaKeypair},
+        KeyGen,
+    };
 
     #[test]
     fn validate_test() -> Result<(), Box<dyn std::error::Error>> {
-        let private_key = RsaPrivateKey::new(&mut OsRng, 2048).unwrap();
-        let public_key = private_key.to_public_key();
+        // Generate a fresh ML-DSA-65 keypair for the inbox owner.
+        // `MlDsa65::key_gen` returns an `MlDsaSigningKey<MlDsa65>`, which
+        // is both the signer (via `Signer`) and the keypair (via
+        // `signature::Keypair` → `.verifying_key()`).
+        //
+        // `UnwrapErr<SysRng>` bridges getrandom's fallible `TryRng` API
+        // to rand_core's infallible `RngCore`, which is what
+        // `KeyGen::key_gen` takes.
+        let mut rng = UnwrapErr(SysRng);
+        let signing_key = MlDsa65::key_gen(&mut rng);
+        let verifying_key = MlDsaKeypair::verifying_key(&signing_key);
 
-        let params: Parameters = InboxParams {
-            pub_key: public_key.clone(),
-        }
-        .try_into()
-        .map_err(|e| format!("{e}"))
-        .unwrap();
-
-        use freenet_stdlib::prelude::blake3::traits::digest::Digest;
-        let digest = Sha256::digest(STATE_UPDATE).to_vec();
-        let signature = private_key
-            .sign(Pkcs1v15Sign::new::<Sha256>(), &digest)
+        let params: Parameters = InboxParams::from_verifying_key(&verifying_key)
+            .try_into()
+            .map_err(|e| format!("{e}"))
             .unwrap();
 
+        // Sign the fixed STATE_UPDATE salt — same payload the contract
+        // verifies on every state update.
+        let signature: ml_dsa::Signature<MlDsa65> =
+            MlDsaSigner::sign(&signing_key, STATE_UPDATE);
+        let signature_bytes = signature.encode().to_vec();
+
+        // Sanity-check the signature round-trips before we hand it to
+        // validate_state, so test failures point at the right layer.
+        MlDsaVerifier::verify(&verifying_key, STATE_UPDATE, &signature)
+            .expect("ML-DSA sanity check: sign/verify round trip");
+
+        // Construct a valid empty-inbox state, with the signature
+        // inlined as a JSON byte array (matching how `Signature =
+        // Box<[u8]>` serialises via serde_json).
         let state_bytes = format!(
             r#"{{
             "messages": [],
@@ -510,18 +582,10 @@ mod tests {
             }},
             "inbox_signature": {}
         }}"#,
-            serde_json::to_string(&signature).unwrap()
+            serde_json::to_string(&signature_bytes).unwrap()
         )
         .as_bytes()
         .to_vec();
-
-        let verifying_key = VerifyingKey::<Sha256>::new(public_key);
-        let sign = &rsa::pkcs1v15::Signature::try_from(signature.as_slice()).unwrap();
-
-        match verifying_key.verify(STATE_UPDATE, sign) {
-            Ok(_) => println!("successful verification"),
-            Err(e) => println!("verification error: {:?}", e),
-        };
 
         let is_valid = Inbox::validate_state(params, State::from(state_bytes), Default::default())?;
         assert!(is_valid == ValidateResult::Valid);

--- a/contracts/inbox/tests/common/mod.rs
+++ b/contracts/inbox/tests/common/mod.rs
@@ -5,6 +5,13 @@
 //! Each test that needs a freshly-signed inbox / token / message reaches in
 //! through this module so the round-trip / validation / token-gating tests
 //! stay focused on the assertion they care about.
+//!
+//! Crypto note: this module uses **two** signature schemes side by side:
+//! - **ML-DSA-65** (FIPS 204, NIST level 3) for inbox-owner signatures.
+//!   This is what the contract verifies on every state update. See #18.
+//! - **RSA-PKCS#1 v1.5** for AFT token generator signatures. The
+//!   anti-flood-token system has its own crypto that's orthogonal to the
+//!   inbox migration and stays on RSA for now.
 #![allow(dead_code)] // helpers are picked up à la carte by individual test files
 
 use std::collections::HashMap;
@@ -15,27 +22,53 @@ use freenet_email_inbox::{InboxParams, InboxSettings, Message, UpdateInbox};
 use freenet_stdlib::prelude::{
     ContractInstanceId, Parameters, RelatedContracts, State, StateDelta, UpdateData,
 };
+use getrandom::SysRng;
+use ml_dsa::{
+    signature::{
+        rand_core::UnwrapErr, Keypair as MlDsaKeypair, Signer as MlDsaSigner,
+    },
+    KeyGen, MlDsa65, SigningKey as MlDsaSigningKey, VerifyingKey as MlDsaVerifyingKey,
+};
 use rsa::{
-    pkcs1v15::SigningKey,
-    rand_core::OsRng,
+    pkcs1v15::SigningKey as RsaSigningKey,
+    rand_core::OsRng as RsaOsRng,
     sha2::{Digest, Sha256},
-    signature::Signer,
+    signature::Signer as RsaSigner,
     RsaPrivateKey, RsaPublicKey,
 };
 use serde_json::{json, Value};
 
-/// Generate a fresh 2048-bit RSA keypair for use as either an inbox owner or
-/// an AFT token generator. 2048 keeps host-test wall time bearable.
-pub fn make_keypair() -> (RsaPrivateKey, RsaPublicKey) {
-    let sk = RsaPrivateKey::new(&mut OsRng, 2048).expect("rsa keygen");
+/// The fixed 8-byte salt the inbox contract signs at construction time.
+/// Must match the `STATE_UPDATE` constant in `contracts/inbox/src/lib.rs`.
+const STATE_UPDATE: &[u8; 8] = &[168, 7, 13, 64, 168, 123, 142, 215];
+
+/// Generate a fresh ML-DSA-65 keypair for use as an inbox owner. Keygen is
+/// <10ms for ML-DSA-65, so tests can afford to generate one per test without
+/// the wall-time pain RSA-4096 used to impose.
+pub fn make_inbox_keypair() -> MlDsaSigningKey<MlDsa65> {
+    let mut rng = UnwrapErr(SysRng);
+    MlDsa65::key_gen(&mut rng)
+}
+
+/// Extract the verifying key from an inbox signing key. Small helper so
+/// individual tests don't have to pull in the `Keypair` trait.
+pub fn inbox_verifying_key(sk: &MlDsaSigningKey<MlDsa65>) -> MlDsaVerifyingKey<MlDsa65> {
+    MlDsaKeypair::verifying_key(sk)
+}
+
+/// Generate a fresh 2048-bit RSA keypair for use as an AFT token generator.
+/// 2048 keeps host-test wall time bearable. Inbox owners do NOT use RSA any
+/// more — call `make_inbox_keypair()` for those.
+pub fn make_token_generator_keypair() -> (RsaPrivateKey, RsaPublicKey) {
+    let sk = RsaPrivateKey::new(&mut RsaOsRng, 2048).expect("rsa keygen");
     let pk = sk.to_public_key();
     (sk, pk)
 }
 
 /// Build the serialized [`InboxParams`] (a JSON-encoded `Parameters` blob)
-/// for the given owner public key.
-pub fn make_params(owner_pub: RsaPublicKey) -> Parameters<'static> {
-    InboxParams { pub_key: owner_pub }
+/// for the given inbox owner's ML-DSA verifying key.
+pub fn make_params(owner_vk: &MlDsaVerifyingKey<MlDsa65>) -> Parameters<'static> {
+    InboxParams::from_verifying_key(owner_vk)
         .try_into()
         .expect("inbox params -> parameters")
 }
@@ -49,9 +82,9 @@ pub fn fixed_valid_slot() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap()
 }
 
-/// Build a token assignment signed by `generator_sk`. The signed payload is
-/// `(tier_byte, time_slot.timestamp_le_bytes, assignment_hash)` per the
-/// contract documented on [`TokenAssignment::signature_content`].
+/// Build a token assignment signed by `generator_sk` (RSA). The signed
+/// payload is `(tier_byte, time_slot.timestamp_le_bytes, assignment_hash)`
+/// per the contract documented on [`TokenAssignment::signature_content`].
 ///
 /// `token_record` is the contract-instance ID that
 /// [`TokenAllocationRecord`] entries are keyed by — pick any stable value
@@ -63,10 +96,9 @@ pub fn make_token_assignment(
     assignment_hash: [u8; 32],
     token_record: ContractInstanceId,
 ) -> TokenAssignment {
-    let to_sign =
-        TokenAssignment::signature_content(&time_slot, tier, &assignment_hash);
-    let signing_key = SigningKey::<Sha256>::new(generator_sk.clone());
-    let signature = signing_key.sign(&to_sign);
+    let to_sign = TokenAssignment::signature_content(&time_slot, tier, &assignment_hash);
+    let signing_key = RsaSigningKey::<Sha256>::new(generator_sk.clone());
+    let signature = RsaSigner::sign(&signing_key, &to_sign);
     TokenAssignment {
         tier,
         time_slot,
@@ -87,7 +119,8 @@ pub fn make_message(content: Vec<u8>, token: TokenAssignment) -> Message {
     }
 }
 
-/// Build an [`Inbox`] signed by `owner_sk` and serialize it as a `State`.
+/// Build an [`Inbox`] signed by `owner_sk` (ML-DSA-65) and serialize it as
+/// a `State`.
 ///
 /// We hand-roll the JSON wire format here because `Inbox::new` and
 /// `inbox_signature` are private to the inbox crate; the integration test
@@ -95,25 +128,19 @@ pub fn make_message(content: Vec<u8>, token: TokenAssignment) -> Message {
 /// the format produced by `Inbox::serialize` (verified by the existing
 /// `validate_test` unit test in `src/lib.rs`).
 pub fn make_inbox_state(
-    owner_sk: &RsaPrivateKey,
+    owner_sk: &MlDsaSigningKey<MlDsa65>,
     messages: Vec<Message>,
     last_update: DateTime<Utc>,
     settings: InboxSettings,
 ) -> State<'static> {
-    // The inbox signs `STATE_UPDATE` (a fixed 8-byte salt) at construction
-    // time. The exact bytes don't need to round-trip because `verify` only
-    // checks the signature, not equality with any stored payload.
-    const STATE_UPDATE: &[u8; 8] = &[168, 7, 13, 64, 168, 123, 142, 215];
-    let signing_key = SigningKey::<Sha256>::new(owner_sk.clone());
-    let signature = signing_key.sign(STATE_UPDATE);
-    let signature_bytes: Box<[u8]> =
-        rsa::signature::SignatureEncoding::to_bytes(&signature);
+    let signature: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(owner_sk, STATE_UPDATE);
+    let signature_bytes: Vec<u8> = signature.encode().to_vec();
 
     let inbox_json: Value = json!({
         "messages": messages,
         "last_update": last_update,
         "settings": settings,
-        "inbox_signature": signature_bytes.as_ref(),
+        "inbox_signature": signature_bytes,
     });
     let bytes = serde_json::to_vec(&inbox_json).expect("serialize inbox");
     State::from(bytes)
@@ -123,21 +150,18 @@ pub fn make_inbox_state(
 /// caller can flip a single field (e.g. tamper with `last_update`) before
 /// re-serializing. Used by the signature-rejection test.
 pub fn make_inbox_value(
-    owner_sk: &RsaPrivateKey,
+    owner_sk: &MlDsaSigningKey<MlDsa65>,
     messages: Vec<Message>,
     last_update: DateTime<Utc>,
     settings: InboxSettings,
 ) -> Value {
-    const STATE_UPDATE: &[u8; 8] = &[168, 7, 13, 64, 168, 123, 142, 215];
-    let signing_key = SigningKey::<Sha256>::new(owner_sk.clone());
-    let signature = signing_key.sign(STATE_UPDATE);
-    let signature_bytes: Box<[u8]> =
-        rsa::signature::SignatureEncoding::to_bytes(&signature);
+    let signature: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(owner_sk, STATE_UPDATE);
+    let signature_bytes: Vec<u8> = signature.encode().to_vec();
     json!({
         "messages": messages,
         "last_update": last_update,
         "settings": settings,
-        "inbox_signature": signature_bytes.as_ref(),
+        "inbox_signature": signature_bytes,
     })
 }
 

--- a/contracts/inbox/tests/integration.rs
+++ b/contracts/inbox/tests/integration.rs
@@ -12,9 +12,10 @@ mod common;
 
 use chrono::{Duration, Utc};
 use common::{
-    add_messages_delta, assignment_hash_for, fixed_valid_slot, make_inbox_state,
-    make_inbox_value, make_keypair, make_message, make_params, make_token_assignment,
-    make_token_record, related_state_update, token_record_id_for,
+    add_messages_delta, assignment_hash_for, fixed_valid_slot, inbox_verifying_key,
+    make_inbox_keypair, make_inbox_state, make_inbox_value, make_message, make_params,
+    make_token_assignment, make_token_generator_keypair, make_token_record,
+    related_state_update, token_record_id_for,
 };
 use freenet_aft_interface::Tier;
 use freenet_email_inbox::{Inbox, InboxSettings};
@@ -26,8 +27,9 @@ use freenet_stdlib::prelude::{
 
 #[test]
 fn validate_accepts_signed_empty_inbox() {
-    let (owner_sk, owner_pk) = make_keypair();
-    let params = make_params(owner_pk);
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let params = make_params(&owner_vk);
     let state = make_inbox_state(
         &owner_sk,
         vec![],
@@ -46,8 +48,9 @@ fn validate_accepts_signed_empty_inbox() {
 
 #[test]
 fn validate_rejects_tampered_last_update() {
-    let (owner_sk, owner_pk) = make_keypair();
-    let params = make_params(owner_pk);
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let params = make_params(&owner_vk);
 
     // Build a signed inbox, then mutate `last_update` post-signing. The
     // signature itself doesn't cover `last_update` (it covers a fixed salt),
@@ -76,11 +79,12 @@ fn validate_rejects_tampered_last_update() {
 
 #[test]
 fn validate_rejects_wrong_owner_signature() {
-    // Sign with `attacker_sk` but advertise `owner_pk` in the parameters —
-    // the verifier should reject.
-    let (_owner_sk, owner_pk) = make_keypair();
-    let (attacker_sk, _attacker_pk) = make_keypair();
-    let params = make_params(owner_pk);
+    // Sign with `attacker_sk` but advertise the real owner's verifying
+    // key in the parameters — the verifier should reject.
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let attacker_sk = make_inbox_keypair();
+    let params = make_params(&owner_vk);
     let state = make_inbox_state(
         &attacker_sk,
         vec![],
@@ -102,9 +106,10 @@ fn validate_rejects_wrong_owner_signature() {
 
 #[test]
 fn update_accepts_add_message_with_valid_token() {
-    let (owner_sk, owner_pk) = make_keypair();
-    let (gen_sk, _gen_pk) = make_keypair();
-    let params = make_params(owner_pk);
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let (gen_sk, _gen_pk) = make_token_generator_keypair();
+    let params = make_params(&owner_vk);
 
     let token_record_id = token_record_id_for(b"valid-token-record");
     let assignment = make_token_assignment(
@@ -148,9 +153,10 @@ fn update_rejects_message_with_unknown_token_record() {
     // AddMessages without a corresponding RelatedState carrying the token
     // allocation record: `update_state` should report the missing record
     // via `requires(...)` rather than persisting the message.
-    let (owner_sk, owner_pk) = make_keypair();
-    let (gen_sk, _) = make_keypair();
-    let params = make_params(owner_pk);
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let (gen_sk, _) = make_token_generator_keypair();
+    let params = make_params(&owner_vk);
 
     let token_record_id = token_record_id_for(b"unknown-record");
     let assignment = make_token_assignment(
@@ -182,9 +188,10 @@ fn update_rejects_message_with_unknown_token_record() {
 fn update_rejects_token_with_invalid_slot() {
     // `Tier::Min1` requires the time slot to land on `:00.000`. Use a slot
     // with a non-zero second to trip `is_valid_slot` inside `add_message`.
-    let (owner_sk, owner_pk) = make_keypair();
-    let (gen_sk, _) = make_keypair();
-    let params = make_params(owner_pk);
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let (gen_sk, _) = make_token_generator_keypair();
+    let params = make_params(&owner_vk);
 
     let token_record_id = token_record_id_for(b"bad-slot-record");
     let bad_slot = fixed_valid_slot() + Duration::seconds(13);
@@ -222,9 +229,10 @@ fn update_rejects_token_with_invalid_slot() {
 
 #[test]
 fn summarize_then_delta_yields_only_new_messages() {
-    let (owner_sk, owner_pk) = make_keypair();
-    let (gen_sk, _) = make_keypair();
-    let params = make_params(owner_pk.clone());
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let (gen_sk, _) = make_token_generator_keypair();
+    let params = make_params(&owner_vk);
 
     let token_record_id = token_record_id_for(b"round-trip-record");
     let assignment_old = make_token_assignment(
@@ -251,13 +259,13 @@ fn summarize_then_delta_yields_only_new_messages() {
     // Summarize: returns the set of `assignment_hash` values currently in
     // the inbox.
     let summary =
-        Inbox::summarize_state(make_params(owner_pk.clone()), state.clone())
+        Inbox::summarize_state(make_params(&owner_vk), state.clone())
             .expect("summarize_state");
 
     // Delta against an empty summary: every message in the state should
     // appear in the delta.
     let empty_summary =
-        Inbox::summarize_state(make_params(owner_pk.clone()), make_inbox_state(
+        Inbox::summarize_state(make_params(&owner_vk), make_inbox_state(
             &owner_sk,
             vec![],
             Utc::now(),

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { workspace = true, features = ["wasmbind"] }
 dioxus = { workspace = true, features = ["web"] }
 futures = "0.3"
 rsa = { workspace = true }
+ml-dsa = { workspace = true }
 chacha20poly1305 = "0.10"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -206,7 +206,7 @@ impl AftRecords {
         )?;
 
         let inbox_params: Parameters = InboxParams {
-            pub_key: recipient_key.clone(),
+            pub_key: crate::inbox::inbox_params_pub_key_bytes(&recipient_key),
         }
         .try_into()?;
         let inbox_key =

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -224,10 +224,19 @@ mod inbox_management {
         private_key: RsaPrivateKey,
     ) -> Result<ContractKey, DynError> {
         let pub_key = private_key.to_public_key();
-        let params: Parameters = InboxParams { pub_key }.try_into()?;
+        // Stage 1 (#18) bridge: derive an ML-DSA-65 signing key from the
+        // RSA public key via BLAKE3 so the contract id (`hash(wasm,
+        // params)`) is stable for this identity without touching the
+        // identity-management delegate's RSA-only schema. See the helpers
+        // in `crate::inbox`.
+        let params: Parameters = InboxParams {
+            pub_key: crate::inbox::inbox_params_pub_key_bytes(&pub_key),
+        }
+        .try_into()?;
+        let ml_dsa_key = crate::inbox::ml_dsa_signing_key_from_rsa(&private_key);
         let state = {
             let inbox =
-                freenet_email_inbox::Inbox::new(&private_key, InboxSettings::default(), Vec::new());
+                freenet_email_inbox::Inbox::new(&ml_dsa_key, InboxSettings::default(), Vec::new());
             inbox.serialize()?
         };
         let contract_key =

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -20,16 +20,74 @@ use freenet_stdlib::{
 };
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
-use rsa::{
-    pkcs1v15::SigningKey, sha2::Sha256, signature::Signer, Pkcs1v15Encrypt, RsaPrivateKey,
-    RsaPublicKey,
+use ml_dsa::{
+    signature::{Keypair as MlDsaKeypair, Signer as MlDsaSigner},
+    KeyGen, MlDsa65, SigningKey as MlDsaSigningKey,
 };
+use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
 use serde::{Deserialize, Serialize};
 
 use freenet_email_inbox::{
     Inbox as StoredInbox, InboxParams, InboxSettings as StoredSettings, Message as StoredMessage,
     UpdateInbox,
 };
+
+/// Derive an ML-DSA-65 seed deterministically from the RSA *public* key.
+///
+/// The seed is `BLAKE3(DER(RsaPublicKey))`. Using the public key (not the
+/// private key) means both the inbox owner (who holds the private key,
+/// extracts the public half, derives) and anyone sending to them (who
+/// only knows the public key) compute the **same** seed, which means the
+/// **same** ML-DSA verifying key, which means the **same** inbox contract
+/// id via `hash(wasm, params)`.
+///
+/// This is a **Stage 1 bridge** (#18). Stage 2 rewrites identity
+/// provisioning to generate a real dual keypair (ML-KEM + ML-DSA) at
+/// identity-creation time and stores both in the identity-management
+/// delegate, retiring this derivation. The goal of Stage 1 is to migrate
+/// the on-chain signature scheme without touching the identity storage
+/// layer or the UI identity-creation flow.
+///
+/// Security note: an RSA public key has far more than 32 bytes of
+/// entropy, so BLAKE3 produces a random-oracle-quality seed. The
+/// derivation is not "one-way" in any useful sense — anyone who knows
+/// the RSA public key can compute the ML-DSA verifying key — but that's
+/// fine: the verifying key is public by construction.
+pub(crate) fn ml_dsa_seed_from_rsa_pub(rsa_pub: &RsaPublicKey) -> [u8; 32] {
+    use rsa::pkcs1::EncodeRsaPublicKey;
+    let der = rsa_pub
+        .to_pkcs1_der()
+        .expect("RSA public key → PKCS#1 DER round-trip should never fail");
+    // `freenet_stdlib::prelude::blake3` produces a `GenericArray<u8, U32>`
+    // with an `as_slice()` → `&[u8]` view rather than an `as_bytes() →
+    // &[u8; 32]` method. Take the first 32 bytes explicitly.
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(der.as_bytes());
+    let out = hasher.finalize();
+    let slice = out.as_slice();
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&slice[..32]);
+    seed
+}
+
+/// The owner-side derivation: compute the ML-DSA signing key for the
+/// inbox whose RSA private key is `rsa_key`. Extracts the public half
+/// and uses the shared seed derivation.
+pub(crate) fn ml_dsa_signing_key_from_rsa(rsa_key: &RsaPrivateKey) -> MlDsaSigningKey<MlDsa65> {
+    let seed = ml_dsa_seed_from_rsa_pub(&rsa_key.to_public_key());
+    <MlDsa65 as KeyGen>::from_seed(&seed.into())
+}
+
+/// The encoded `InboxParams.pub_key` bytes for the inbox owned by an
+/// identity whose RSA public key is `rsa_pub`. Used by both senders
+/// (who only have the recipient's public key) and the owner (who
+/// passes in `self.private_key.to_public_key()`).
+pub(crate) fn inbox_params_pub_key_bytes(rsa_pub: &RsaPublicKey) -> Vec<u8> {
+    let seed = ml_dsa_seed_from_rsa_pub(rsa_pub);
+    let signing_key: MlDsaSigningKey<MlDsa65> = <MlDsa65 as KeyGen>::from_seed(&seed.into());
+    let verifying_key = MlDsaKeypair::verifying_key(&signing_key);
+    verifying_key.encode().to_vec()
+}
 
 use crate::{
     aft::AftRecords,
@@ -189,7 +247,7 @@ impl DecryptedMessage {
         let delegate_key =
             AftRecords::assign_token(client, recipient_key.clone(), from, hash).await?;
         let params = InboxParams {
-            pub_key: recipient_key,
+            pub_key: inbox_params_pub_key_bytes(&recipient_key),
         }
         .try_into()
         .map_err(|e| format!("{e}"))?;
@@ -308,7 +366,7 @@ impl InboxModel {
         }
 
         fn get_key(identity: &Identity) -> Result<ContractKey, DynError> {
-            let pub_key = identity.key.to_public_key();
+            let pub_key = inbox_params_pub_key_bytes(&identity.key.to_public_key());
             let params = freenet_email_inbox::InboxParams { pub_key }
                 .try_into()
                 .map_err(|e| format!("{e}"))?;
@@ -350,7 +408,7 @@ impl InboxModel {
         id: &Identity,
     ) -> Result<ContractKey, DynError> {
         let params = InboxParams {
-            pub_key: id.key.to_public_key(),
+            pub_key: inbox_params_pub_key_bytes(&id.key.to_public_key()),
         }
         .try_into()
         .map_err(|e| format!("{e}"))?;
@@ -397,8 +455,9 @@ impl InboxModel {
         self.remove_received_message(ids);
         #[cfg(feature = "use-node")]
         {
-            let signing_key = SigningKey::<Sha256>::new(self.settings.private_key.clone());
-            let signature: Box<[u8]> = signing_key.sign(&signed).into();
+            let signing_key = ml_dsa_signing_key_from_rsa(&self.settings.private_key);
+            let ml_sig: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(&signing_key, &signed);
+            let signature: Box<[u8]> = ml_sig.encode().to_vec().into_boxed_slice();
             let delta: UpdateInbox = UpdateInbox::RemoveMessages {
                 signature,
                 ids: to_rm_message_id,
@@ -445,7 +504,8 @@ impl InboxModel {
             .iter()
             .map(|m| m.to_stored(&self.settings.private_key))
             .collect::<Result<Vec<_>, _>>()?;
-        let inbox = StoredInbox::new(&self.settings.private_key, settings, messages);
+        let ml_dsa_key = ml_dsa_signing_key_from_rsa(&self.settings.private_key);
+        let inbox = StoredInbox::new(&ml_dsa_key, settings, messages);
         let serialized = serde_json::to_vec(&inbox)?;
         Ok(serialized.into())
     }
@@ -514,8 +574,9 @@ impl InboxModel {
     ) -> Result<(), DynError> {
         let settings = self.settings.to_stored()?;
         let serialized = serde_json::to_vec(&settings)?;
-        let signing_key = SigningKey::<Sha256>::new(self.settings.private_key.clone());
-        let signature = signing_key.sign(&serialized).into();
+        let signing_key = ml_dsa_signing_key_from_rsa(&self.settings.private_key);
+        let ml_sig: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(&signing_key, &serialized);
+        let signature: Box<[u8]> = ml_sig.encode().to_vec().into_boxed_slice();
         let delta = UpdateInbox::ModifySettings {
             signature,
             settings,
@@ -563,7 +624,7 @@ mod tests {
     impl InboxModel {
         fn new(private_key: RsaPrivateKey) -> Result<Self, DynError> {
             let params = InboxParams {
-                pub_key: private_key.to_public_key(),
+                pub_key: inbox_params_pub_key_bytes(&private_key.to_public_key()),
             };
             Ok(Self {
                 messages: vec![],


### PR DESCRIPTION
## Summary

First stage of the post-quantum crypto migration (#18). Replaces every RSA-PKCS#1 v1.5 signature on inbox state deltas with **ML-DSA-65** (FIPS 204, NIST level 3). The on-chain signature scheme is now post-quantum safe, signing/verification latency drops by orders of magnitude in WASM, and existing identity provisioning (RSA keypair, identity-management delegate, PEM import) is untouched.

Per-message overhead grows from ~512 B (RSA sig) to ~3309 B (ML-DSA sig). Contract parameters grow from 512 B to 1952 B. Contract IDs stay the same size (still hashes). These are the expected level-3 numbers.

## What moves to ML-DSA

- `Inbox::sign` / `Inbox::verify` (the fixed \`STATE_UPDATE\` salt signed at inbox construction time)
- \`can_reemove_messages\` (signs concatenated token-assignment hashes to authorise \`RemoveMessages\`)
- \`can_update_settings\` (signs the serialized \`InboxSettings\` to authorise \`ModifySettings\`)

## What stays on RSA (for now)

- **Message content encryption** (\`Pkcs1v15Encrypt\` wrapping the per-message XChaCha20Poly1305 key). Stage 2 replaces this with ML-KEM-768.
- **AFT token generator signatures** (the \`token_assignment.generator\` path). The anti-flood-token scheme is explicitly out of scope for #18.

## The Stage 1 bridge

Rather than overhaul identity provisioning end-to-end in a single PR, this stage uses a deterministic derivation:

\`\`\`
seed = BLAKE3(DER(RsaPublicKey))
(sk, vk) = MlDsa65::from_seed(seed)
\`\`\`

Both the owner (who holds the RSA private key, extracts the public half) and senders (who know only the public key) compute the **same** seed, so they derive the **same** ML-DSA verifying key, and therefore the **same** inbox contract id via \`hash(wasm, params)\`. The RSA key has far more than 32 bytes of entropy, and BLAKE3 acts as a random oracle, so the derived seed is cryptographically sound for ML-DSA keygen.

This lets us avoid touching \`app.rs\` / \`login.rs\` / \`api.rs\` key-generation code, the identity-management delegate schema, PEM import, and every other identity-provisioning site. Stage 2 replaces the bridge with a real dual keypair (ML-KEM + ML-DSA) generated at identity-creation time and stored in the delegate.

See \`ml_dsa_seed_from_rsa_pub\` + \`ml_dsa_signing_key_from_rsa\` + \`inbox_params_pub_key_bytes\` in \`ui/src/inbox.rs\` for the derivation code and security argument.

## Files touched

- \`Cargo.toml\` (workspace) — add \`ml-dsa = \"0.1.0-rc.8\"\` with \`alloc\` + \`rand_core\`
- \`contracts/inbox/Cargo.toml\` — add \`ml-dsa\`, add \`getrandom\` with \`sys_rng\` as dev-dep
- \`contracts/inbox/src/lib.rs\` — \`InboxParams\` schema, \`Inbox::sign\`/\`verify\`, \`can_reemove_messages\`, \`can_update_settings\`, unit test
- \`contracts/inbox/tests/common/mod.rs\` — split \`make_keypair\` into \`make_inbox_keypair\` (ML-DSA) + \`make_token_generator_keypair\` (RSA), retarget \`make_params\`/\`make_inbox_state\`/\`make_inbox_value\` to ML-DSA
- \`contracts/inbox/tests/integration.rs\` — all 6 integration tests updated to the new fixtures
- \`ui/Cargo.toml\` — add \`ml-dsa\`
- \`ui/src/inbox.rs\` — the derivation helpers, all \`InboxParams\` and signing call sites
- \`ui/src/api.rs\` — \`inbox_management::create_contract\` (uses derived ML-DSA key for \`Inbox::new\` and derived verifying key for params)
- \`ui/src/aft.rs\` — \`InboxParams\` build in \`assign_token\`

## Verification (local)

- [x] \`cargo check --workspace\` — clean
- [x] \`cargo check -p freenet-email-ui --target wasm32-unknown-unknown\` — clean
- [x] \`cargo check -p freenet-email-ui --target wasm32-unknown-unknown --no-default-features --features example-data,no-sync\` — clean
- [x] \`cargo test --workspace\` — 32 passed, 1 ignored
- [x] \`cargo make test-inbox\` — 7 inbox integration tests pass
- [x] \`cargo make clippy\` — clean
- [x] \`cargo make build-ui-example-no-sync\` — builds
- [x] Playwright offline suite — 40/40 across 5 browser profiles (Chromium, Firefox, WebKit, Mobile Chrome, Mobile Safari)

## What's NOT validated end-to-end

The \`use-node\` signing path — i.e., a real browser session talking to a real \`freenet local\` node, creating an identity, signing a real \`RemoveMessages\` or \`ModifySettings\` delta — is exercised only by the contract-side integration tests (which drive \`ContractInterface\` directly with ML-DSA fixtures) and the host-side clippy/check. There's no automated live-node test yet; that's the Stage 4 work to resurrect the abandoned \`live-node.spec.ts\` PR against the new primitives.

## Next

**Stage 2**: replace \`Pkcs1v15Encrypt\` for message content with ML-KEM-768 encapsulate/decapsulate. Requires splitting identities into a real dual keypair at creation time — touches \`app.rs\` / \`login.rs\` / \`api.rs\` / the identity-management delegate.

Part of #18. Blocks #9.