### PR TITLE
docs: refresh README + AGENTS for PQ migration and Mail rebrand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,15 +79,16 @@ freenet-email/
 |-----------|---------|
 | `freenet-stdlib` | Freenet contract/delegate SDK |
 | `dioxus` | Web UI framework (WASM) |
-| `rsa` | RSA encryption for message security |
-| `chacha20poly1305` | Symmetric encryption for message content |
+| `ml-kem` | ML-KEM-768 (NIST FIPS 203) post-quantum key encapsulation for message encryption |
+| `ml-dsa` | ML-DSA-65 (NIST FIPS 204) post-quantum signatures for inbox state deltas and AFT |
+| `chacha20poly1305` | Symmetric encryption for message content (key from ML-KEM) |
 | `freenet-aft-interface` | Anti-Flood Token protocol |
 | `identity-management` | Identity delegate for alias management |
 
 ### Architecture
 
-- **Inbox Contract**: Stores encrypted messages on Freenet. Uses RSA signatures
-  to verify ownership. Messages are gated by AFT tokens to prevent spam.
+- **Inbox Contract**: Stores encrypted messages on Freenet. ML-DSA-65 signatures
+  verify ownership of state deltas. Messages are gated by AFT tokens to prevent spam.
 - **Web Container**: Minimal contract that hosts the compiled Dioxus UI as a
   Freenet webapp.
 - **UI**: Dioxus WASM app communicating with a local Freenet node via WebSocket.
@@ -352,7 +353,8 @@ scope and the rationale.
 
 This checklist validates the pieces that unit tests and Playwright
 can't cover: real WebSocket framing, real AFT token mint/burn, real
-RSA encrypt/decrypt round trip through the inbox contract state.
+ML-KEM encapsulation + ChaCha20-Poly1305 round trip through the inbox
+contract state.
 
 1. `cargo make run-node` in one terminal
 2. `cargo make publish-email-test` in another

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# Freenet Email
+# Mail
 
 A decentralized email client that runs on [Freenet](https://freenet.org) —
 no servers, no accounts, end-to-end encrypted, and rate-limited by
 Anti-Flood Tokens instead of a central authority.
 
 Messages are stored in per-user inbox contracts on the Freenet network,
-encrypted with the recipient's RSA public key. The UI is a Dioxus web
-app served from a signed web-container contract under a deterministic,
-reproducible contract id.
+encrypted with post-quantum ML-KEM-768 (NIST FIPS 203) and authenticated
+with ML-DSA-65 (NIST FIPS 204). The UI is a Dioxus web app served from
+a signed web-container contract under a deterministic, reproducible
+contract id.
 
 > **Status**: pre-alpha. The protocol and contract ids will change.
 > Don't use this for anything you'd mind losing.
@@ -29,8 +30,9 @@ reproducible contract id.
    in this repo. The `50509` port and `/contract/web/` path are the
    defaults for the Freenet HTTP gateway — adjust for your setup.
 
-3. **Create an identity** in the app. Your private keys never leave the
-   browser.
+3. **Create an identity** in the app. Your private keys are held by the
+   identity delegate inside the Freenet node sandbox, never in browser
+   storage.
 
 4. **Send a message.** The first send burns one Anti-Flood Token,
    minted automatically by your local node.
@@ -43,12 +45,13 @@ Three contracts and a delegate make up the full system:
   with an ed25519 key committed to
   [`test-contract/`](test-contract/) for sandbox builds, and with an
   offline-generated production key for real releases.
-- **Inbox contract** — one per user. Stores encrypted messages keyed by
-  an RSA public key, with signature verification for ownership.
+- **Inbox contract** — one per user. Stores ML-KEM-encapsulated,
+  ChaCha20-Poly1305-encrypted messages, with ML-DSA-65 signatures
+  on every state delta for ownership verification.
 - **Anti-Flood Token contracts** — mint/burn tokens that gate each
   message send, preventing spam without a central authority.
 - **Identity delegate** — holds the user's private keys inside the
-  Freenet delegate sandbox, never in the browser's localStorage.
+  Freenet delegate sandbox, never exposed to the webapp.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- README rewritten for consumer-facing "Mail" name (per ce60ab5) and PQ crypto (ML-KEM-768 / ML-DSA-65) replacing stale RSA description
- AGENTS.md key-dependency table and inbox-contract architecture note swapped from `rsa` to `ml-kem` / `ml-dsa`; manual E2E checklist updated to describe ML-KEM + ChaCha20-Poly1305 round trip
- Closes the documentation tasks under #9; tag `v0.1.0` + production publish remain (tracked separately)

## Test plan
- [ ] `cargo make build` still green (docs-only change, no code touched)
- [ ] Verify rendered README on GitHub shows "Mail" branding and PQ crypto description
- [ ] AGENTS.md still readable as the agent entry point referenced from CLAUDE.md