### PR TITLE
fix(scripts,docs): update Freenet gateway port from 50509 to 7509

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ contract id.
 2. **Open the webapp** in a browser at the published contract id:
 
    ```
-   http://127.0.0.1:50509/contract/web/<contract-id>/
+   http://127.0.0.1:7509/v1/contract/web/<contract-id>/
    ```
 
    The latest committed contract id lives at
    [`published-contract/contract-id.txt`](published-contract/contract-id.txt)
-   in this repo. The `50509` port and `/contract/web/` path are the
-   defaults for the Freenet HTTP gateway — adjust for your setup.
+   in this repo. The `7509` port and `/v1/contract/web/` path are the
+   defaults for the Freenet HTTP/WebSocket gateway in current builds —
+   adjust for your setup.
 
 3. **Create an identity** in the app. Your private keys are held by the
    identity delegate inside the Freenet node sandbox, never in browser

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,8 +67,9 @@ freenet network
 ```
 
 Wait until it reports connected peers. The release script pings the
-node's HTTP gateway on `127.0.0.1:50509` at preflight and warns if it
-doesn't respond.
+node's HTTP gateway on `127.0.0.1:7509` at preflight and warns if it
+doesn't respond. Override with `FREENET_PORT=...` if your node binds
+elsewhere.
 
 See AGENTS.md §"Running a Freenet node" for the local-vs-network
 distinction.
@@ -142,12 +143,13 @@ scripts/smoke-test-production.sh
 ```
 
 With no argument, this defaults to
-`http://127.0.0.1:50509/contract/web/<committed-contract-id>/` (the
+`http://127.0.0.1:7509/v1/contract/web/<committed-contract-id>/` (the
 local network-connected node serving the just-published contract).
-Pass an explicit gateway URL to test against a remote peer:
+Override the port with `FREENET_PORT=...`. Pass an explicit gateway
+URL to test against a remote peer:
 
 ```bash
-scripts/smoke-test-production.sh http://some-peer.example:50509/contract/web/<id>/
+scripts/smoke-test-production.sh http://some-peer.example:7509/v1/contract/web/<id>/
 ```
 
 ### What the smoke test covers

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -114,15 +114,18 @@ else
   linux: already default"
 fi
 
-# Freenet node — check the UI gateway port (50509 is the default for
-# `freenet network`; the exact check depends on your node's HTTP gateway).
-if ! curl -sf -o /dev/null "http://127.0.0.1:50509/contract/web/" 2>/dev/null; then
-    echo "  ⚠️  could not reach a Freenet node at http://127.0.0.1:50509"
+# Freenet node — probe the WS API / HTTP gateway port (7509 is the
+# default for current freenet builds; pre-0.2 builds used 50509).
+# Override with FREENET_PORT=... if your node binds elsewhere.
+FREENET_PORT="${FREENET_PORT:-7509}"
+if ! curl -sf -o /dev/null "http://127.0.0.1:${FREENET_PORT}/" 2>/dev/null; then
+    echo "  ⚠️  could not reach a Freenet node at http://127.0.0.1:${FREENET_PORT}"
     echo "     Make sure \`freenet network\` (NOT \`freenet local\`) is running"
     echo "     in another terminal and is connected to the network."
+    echo "     Override the probe port with FREENET_PORT=... if needed."
     confirm "Continue anyway?"
 else
-    echo "  ✓ Freenet node reachable on :50509"
+    echo "  ✓ Freenet node reachable on :${FREENET_PORT}"
 fi
 
 echo "  ✓ clean tree on main"

--- a/scripts/smoke-test-production.sh
+++ b/scripts/smoke-test-production.sh
@@ -5,7 +5,7 @@
 #     scripts/smoke-test-production.sh <gateway-url>
 #
 # Example:
-#     scripts/smoke-test-production.sh http://127.0.0.1:50509/contract/web/<contract-id>/
+#     scripts/smoke-test-production.sh http://127.0.0.1:7509/v1/contract/web/<contract-id>/
 #
 # With no argument, defaults to the local `freenet network` gateway
 # serving the contract id from `published-contract/contract-id.txt`.
@@ -21,7 +21,7 @@
 #
 # What it explicitly does NOT cover:
 #
-#   • Real identity creation (RSA keygen + inbox contract put)
+#   • Real identity creation (ML-DSA / ML-KEM keygen + inbox contract put)
 #   • Real AFT token mint/burn
 #   • Real message send/receive round trip
 #
@@ -29,7 +29,7 @@
 # Freenet node to do anything user-facing — so a Playwright test that
 # loads it from a gateway and clicks "Create new identity" would need
 # to also spin up a disposable `freenet local` node, publish the test
-# contract to it, and wait through RSA-4096 keygen + contract-put
+# contract to it, and wait through PQ keygen + contract-put
 # propagation. That's what `ui/tests/live-node.spec.ts` + `cargo make
 # test-ui-live` do (see Phase 5 PR B).
 #
@@ -51,7 +51,8 @@ if [ -z "$GATEWAY_URL" ]; then
         exit 1
     fi
     CONTRACT_ID=$(cat published-contract/contract-id.txt)
-    GATEWAY_URL="http://127.0.0.1:50509/contract/web/$CONTRACT_ID/"
+    FREENET_PORT="${FREENET_PORT:-7509}"
+    GATEWAY_URL="http://127.0.0.1:${FREENET_PORT}/v1/contract/web/$CONTRACT_ID/"
     echo "no URL supplied; defaulting to local freenet network gateway:"
     echo "  $GATEWAY_URL"
 fi
@@ -63,7 +64,7 @@ if ! curl -sf -o /dev/null "$GATEWAY_URL" 2>/dev/null; then
     echo "Make sure:" >&2
     echo "  1. \`freenet network\` is running and connected" >&2
     echo "  2. The contract has propagated (wait ~30s after publish)" >&2
-    echo "  3. The gateway URL is correct (default port 50509)" >&2
+    echo "  3. The gateway URL is correct (default port 7509; override with FREENET_PORT=...)" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Current freenet builds (verified 0.2.50) bind the combined HTTP + WebSocket API on port `7509` by default; the older `50509` no longer applies. The release-script preflight probe at `:50509` returned a false negative against a healthy local node, blocking `scripts/release.sh`.
- `scripts/release.sh` and `scripts/smoke-test-production.sh` now probe `:7509` by default with a `FREENET_PORT=...` override.
- `README.md` Try-It URL and `RELEASING.md` preflight description updated to match.
- Smoke-test script also updated to use the current `/v1/contract/web/` gateway path prefix and to drop a stale RSA-keygen reference left over from before the PQ migration.

## Test plan
- [ ] Run `bash scripts/release.sh 0.1.0` against a local `freenet network` node and confirm preflight reports `✓ Freenet node reachable on :7509`.
- [ ] Verify `FREENET_PORT=12345 bash scripts/release.sh 0.1.0` switches the probe to the override port.
- [ ] After release, run `bash scripts/smoke-test-production.sh` with no args and confirm it constructs a `:7509/v1/contract/web/<id>/` URL.

Blocks the v0.1.0 production release tracked in #9.