### PR TITLE
fix(release): monotonic version source for signed webapp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,26 +241,34 @@ real release.
 
 ### Reproducibility caveats
 
-Two developers building from the same commit will produce the
-**same** `published-contract/contract-id.txt` only when all of these
-match:
+The signed-payload version is the **unix timestamp at signing time**
+(see `sign-webapp` / `sign-webapp-test` in `Makefile.toml`). Two
+developers signing at different moments produce different payloads
+and therefore different contract IDs, so
+`published-contract/contract-id.txt` is **not** reproducible from
+source. The committed snapshot is the authoritative ID for the
+deployed contract; `cargo make update-published-contract*` rewrites
+it on every refresh.
 
-- **rustc version.** Pinned in `rust-toolchain.toml` (stable channel).
-  CI uses the same pin; contributors on stable-latest will match CI
-  automatically.
-- **Cargo release profile.** Pinned in the workspace `Cargo.toml`
-  (`lto=true, codegen-units=1, strip=true, panic=abort`).
-- **GNU tar.** `compress-webapp` uses
-  `tar --sort=name --mtime='2024-01-01 00:00:00 UTC' --owner=0 --group=0`
-  for a reproducible archive. BSD tar (macOS default) **does not**
-  support these flags. Install `gnu-tar`:
-  ```bash
-  brew install gnu-tar   # provides `gtar`
-  ```
-  Without GNU tar the pipeline still works — the archive signs and
-  publishes correctly — but the resulting contract ID will not match
-  across machines and cannot be committed to
-  `published-contract/contract-id.txt` as a source of truth.
+Why timestamp instead of a deterministic-from-source value: the
+on-chain web-container update check requires strictly monotonic
+versions. The previous scheme (commit-hash hex truncated to u32) was
+not monotonic — newer commits could hash lower than the deployed
+state — and broke the v0.1.1 publish. Commit count
+(`git rev-list --count HEAD`) is monotonic per branch but starts at
+~22, far below the version (~1.6e9) the chain already accepted under
+the broken scheme. Timestamp is the simplest source that's always
+above the deployed value.
+
+GNU tar is still required by `compress-webapp` for the
+`--sort=name --mtime=… --owner=0 --group=0` flags; the resulting
+archive is byte-identical across machines (rustc pin and release
+profile are also pinned), but the per-build timestamp injected at
+signing time means the final signed bytes differ. Install GNU tar:
+
+```bash
+brew install gnu-tar   # provides `gtar`
+```
 
 The `cargo make compress-webapp` target detects `gtar` / GNU `tar`
 automatically and emits a loud warning when falling back to BSD tar.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -272,18 +272,20 @@ if [ ! -f "$KEY_FILE" ]; then
     echo "       run \`cargo make generate-web-container-keys\` first" >&2
     exit 1
 fi
-# Deterministic version: short commit hash converted from hex to u32.
-# Two developers on the same commit pick the same version, so the
-# signed payload (version || webapp) is identical and the contract ID
-# is reproducible. We use `printf %d 0x…` (portable across BSD and
-# GNU) rather than GNU-awk `strtonum`.
-short=$(git -C "$ROOT" rev-parse --short=8 HEAD)
-# Mask to the low 31 bits so we stay under i32::MAX (the contract
-# accepts u32 but staying positive keeps the value friendly to any
-# signed-int consumer downstream).
-version=$(( $(printf '%d' "0x$short") & 0x7fffffff ))
-if [ "$version" -eq 0 ]; then version=1; fi
-echo "signing with version $version (from commit $short)"
+# Monotonic version: unix timestamp (seconds). The on-chain
+# web-container update check requires strictly increasing versions;
+# the prior commit-hash-to-u32 scheme was not monotonic and broke at
+# v0.1.1 (a newer commit happened to hash lower than the deployed
+# state). Timestamp is the simplest source that's always monotonic
+# without coordination.
+#
+# Tradeoff: two developers signing at different times produce
+# different signed payloads and therefore different contract IDs.
+# `published-contract/contract-id.txt` is no longer reproducible from
+# source. The committed snapshot is now the authoritative ID, and
+# `update-published-contract*` rewrites it on every refresh.
+version=$(date -u +%s)
+echo "signing with version $version (unix timestamp)"
 cargo run --quiet -p web-container-sign -- sign \
     --input "$ROOT/target/webapp/webapp.tar.xz" \
     --output "$ROOT/target/webapp/webapp.metadata" \
@@ -310,13 +312,11 @@ if [ ! -f "$KEY_FILE" ]; then
     echo "  WEB_CONTAINER_KEY_FILE=/path/to/keys.toml cargo make publish-email" >&2
     exit 1
 fi
-# Deterministic version from the commit hash (same derivation as
-# sign-webapp-test). Uses `printf %d 0x…` instead of GNU-awk strtonum
-# for portability across BSD/macOS.
-short=$(git -C "$ROOT" rev-parse --short=8 HEAD)
-version=$(( $(printf '%d' "0x$short") & 0x7fffffff ))
-if [ "$version" -eq 0 ]; then version=1; fi
-echo "signing with production key at $KEY_FILE, version $version (from commit $short)"
+# Monotonic version: unix timestamp (seconds). See sign-webapp-test
+# for the rationale — short version: the on-chain update check needs
+# strict monotonicity, the prior commit-hash scheme didn't provide it.
+version=$(date -u +%s)
+echo "signing with production key at $KEY_FILE, version $version (unix timestamp)"
 cargo run --quiet -p web-container-sign -- sign \
     --input "$ROOT/target/webapp/webapp.tar.xz" \
     --output "$ROOT/target/webapp/webapp.metadata" \


### PR DESCRIPTION
## Summary

- Replace commit-hash-derived version with unix timestamp in `sign-webapp` and `sign-webapp-test`
- Update AGENTS.md reproducibility section to reflect the tradeoff

## Why

The on-chain web-container update check requires `new_version > current_version`. The previous derivation (`git rev-parse --short=8 HEAD` → hex → u32 mask 31 bits) is **not** monotonic. v0.1.1 publish from commit `ab10686` (version 179373702) was rejected against v0.1.0 from commit `76dcd4d` (version 1646894647):

```
Error: invalid contract update, reason: New state version 722495586 must be higher than current version 1646894647
```

Unix timestamp is always monotonic and currently ~1.78e9 — comfortably above the deployed value.

## Tradeoff

Contract IDs from the same source commit are no longer byte-identical across machines / runs. The committed `published-contract/contract-id.txt` is now the authoritative ID for the deployed contract; `cargo make update-published-contract*` rewrites it on every refresh. Documented in AGENTS.md.

`git rev-list --count HEAD` was considered (reproducible + monotonic) but starts at ~22, far below the ~1.6e9 already accepted under the broken scheme — would require contract rotation or an arbitrary offset.

## Test plan

- [ ] `cargo make test` green
- [ ] `cargo make publish-production` succeeds (will be exercised by `scripts/release.sh 0.1.1` post-merge)
- [ ] Smoke test confirms v0.1.1 webapp loads with vendored CSS