### PR TITLE
fix(ui): derive WebSocket URL from window.location (gateway origin check)

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -66,9 +66,7 @@ impl WebApi {
             "https:" => "wss",
             _ => "ws",
         };
-        let url = format!(
-            "{scheme}://{host}/v1/contract/command?encodingProtocol=native"
-        );
+        let url = format!("{scheme}://{host}/v1/contract/command?encodingProtocol=native");
         let conn = web_sys::WebSocket::new(&url).unwrap();
         let (send_host_responses, host_responses) = futures::channel::mpsc::unbounded();
         let (send_half, requests) = futures::channel::mpsc::unbounded();

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -45,10 +45,31 @@ impl WebApi {
     #[cfg(all(target_family = "wasm", feature = "use-node"))]
     fn new() -> Result<Self, String> {
         use futures::SinkExt;
-        let conn = web_sys::WebSocket::new(
-            "ws://localhost:7509/v1/contract/command?encodingProtocol=native",
-        )
-        .unwrap();
+        // Derive the WebSocket URL from the current document origin so the
+        // app talks to whichever gateway served it (production, local
+        // sandbox, alt-port test node). The Freenet gateway shell rejects
+        // `ws://localhost:7509` when served from `http://127.0.0.1:7509`
+        // (origin equality check on `host`, not just port), so a hardcoded
+        // host breaks the moment the user opens the page by IP instead of
+        // by hostname (or vice versa).
+        let location = web_sys::window()
+            .ok_or_else(|| "no window".to_string())?
+            .location();
+        let host = location
+            .host()
+            .map_err(|e| format!("location.host: {e:?}"))?;
+        let scheme = match location
+            .protocol()
+            .map_err(|e| format!("location.protocol: {e:?}"))?
+            .as_str()
+        {
+            "https:" => "wss",
+            _ => "ws",
+        };
+        let url = format!(
+            "{scheme}://{host}/v1/contract/command?encodingProtocol=native"
+        );
+        let conn = web_sys::WebSocket::new(&url).unwrap();
         let (send_host_responses, host_responses) = futures::channel::mpsc::unbounded();
         let (send_half, requests) = futures::channel::mpsc::unbounded();
         let result_handler = move |result: Result<HostResponse, ClientError>| {


### PR DESCRIPTION
## Summary

Replace the hardcoded \`ws://localhost:7509/v1/contract/command\` in \`ui/src/api.rs\` with a URL derived at runtime from \`window.location\` (host + scheme).

## Why

The Freenet gateway shell at \`http://<host>:7509/v1/contract/web/<id>/\` wraps every webapp in a sandboxed iframe and replaces \`window.WebSocket\` with a postMessage proxy. The parent-frame bridge enforces strict same-origin: it compares \`new URL(requested_ws_url).host\` against the page's \`location.origin\` host and rejects any mismatch by firing a synthetic \`error\` Event on the proxy.

\`localhost\` and \`127.0.0.1\` are **different hosts** to that check. The deployed v0.1.1 webapp is loaded by IP (\`http://127.0.0.1:7509/...\`) but tries to connect to \`ws://localhost:7509/...\` → rejected → no node connection at all.

The synthetic \`error\` Event then trips a wasm-bindgen onerror shim bug (issue #31) where the JS shim calls \`event.filename\` on a plain Event that has no such property → wbg panic in the console.

User-visible symptom: clicking "Create new identity" appears to do nothing because the WebSocket never connected in the first place. The form closes but no delegate call is ever made.

## Verification

Reproduced and fixed using chrome-devtools MCP against a local sandbox node on port 7510 with the rebuilt webapp:

- **Before:** ws connect rejected, console shows the wbg \`expected a string argument, found undefined\` error, identity creation does nothing.
- **After:** clean console, ws frames flow, node logs show \`Module cache miss — compiling delegate=…\` for the identity-management delegate (registration is now reaching the node).

## Notes

There is still a follow-up identity-management issue to investigate: even after the ws fix, the new identity doesn't appear in the UI list. The node logs a tight loop of \`Delegate not found in store (expected for migration probes)\` followed by \`Module cache miss — compiling\` for the same delegate, suggesting registration isn't persisting between calls. That's a separate problem (likely in the delegate registration / state-transfer layer) and not blocking this PR.

## Test plan

- [x] Verified ws connection reaches local node after the fix
- [x] Verified delegate request lands in node logs
- [ ] Verify same fix works against the production v0.1.1 contract once republished
- [ ] (separate work) Investigate the persistent "Delegate not found in store" loop blocking identity creation completion