### PR TITLE
fix(ui): spawn_forever for send-message (was silently cancelled)

### DIFF
--- a/modules/antiflood-tokens/delegates/token-generator/src/lib.rs
+++ b/modules/antiflood-tokens/delegates/token-generator/src/lib.rs
@@ -69,8 +69,18 @@ impl DelegateInterface for TokenDelegate {
             }) => {
                 let mut context = Context::try_from(context)?;
                 context.waiting_for_user_input.remove(&request_id);
-                let response = serde_json::from_slice(&response)
-                    .map_err(|err| DelegateError::Deser(format!("{err}")))?;
+                // RESPONSES wire format is the raw bytes "true"/"false" (see
+                // RequestUserInput emitted from `allocate_token`). The host
+                // round-trips them verbatim. Map to the Response enum.
+                let response = match response.as_ref() {
+                    b"true" => Response::Allowed,
+                    b"false" => Response::NotAllowed,
+                    other => {
+                        return Err(DelegateError::Deser(format!(
+                            "unrecognised user response: {other:?}"
+                        )));
+                    }
+                };
                 context.user_response.insert(request_id, response);
                 let context: DelegateContext = (&context).try_into()?;
                 Ok(vec![OutboundDelegateMsg::ContextUpdated(context)])

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1209,7 +1209,11 @@ pub(crate) async fn node_comms(
                                         Some(TryNodeAction::SendMessage),
                                     )
                                 }
-                                TokenDelegateMessage::RequestNewToken(_) => unreachable!(),
+                                TokenDelegateMessage::RequestNewToken(_) => {
+                                    // Delegate echoes the original request back to itself
+                                    // (with updated context) while it's waiting on user
+                                    // permission input. Not a UI-side action — ignore.
+                                }
                             }
                         }
                         // NOTE: the original code had a second guarded

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -863,8 +863,14 @@ fn NewMessageWindow() -> Element {
             &content_val,
         ) {
             Ok(futs) => {
+                // spawn_forever, not spawn: the send future outlives the
+                // NewMessageWindow component (we navigate away to inbox
+                // immediately below via at_new_msg). spawn() ties the task
+                // to the current component scope and cancels it on unmount,
+                // which silently killed every send before the AFT request
+                // hit the wire.
                 futs.into_iter().for_each(|f| {
-                    let _ = spawn(f);
+                    let _task = dioxus_core::spawn_forever(f);
                 });
             }
             Err(e) => {

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -90,9 +90,7 @@ pub fn main() {
         // context. Cheap and safe to install at startup.
         std::panic::set_hook(Box::new(|info| {
             let msg = format!("WASM PANIC: {info}");
-            web_sys::console::error_1(
-                &serde_wasm_bindgen::to_value(&msg).unwrap_or_default(),
-            );
+            web_sys::console::error_1(&serde_wasm_bindgen::to_value(&msg).unwrap_or_default());
         }));
     }
 

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -83,6 +83,18 @@ pub fn main() {
             )
             .try_init();
     }
+    #[cfg(target_family = "wasm")]
+    {
+        // Surface panics to devtools console with location + message
+        // instead of the raw `RuntimeError: unreachable` that strips all
+        // context. Cheap and safe to install at startup.
+        std::panic::set_hook(Box::new(|info| {
+            let msg = format!("WASM PANIC: {info}");
+            web_sys::console::error_1(
+                &serde_wasm_bindgen::to_value(&msg).unwrap_or_default(),
+            );
+        }));
+    }
 
     // Log which committed contract ID this UI was built against so that
     // a developer looking at devtools can instantly tell whether


### PR DESCRIPTION
## Summary

Send-message was a silent no-op on real-node deployments. The event handler called `spawn(future)` then immediately navigated away from `NewMessageWindow` via `at_new_msg()`. `spawn()` is component-scoped — when the component unmounts on nav, the task gets cancelled before it can poll.

Switched to `dioxus_core::spawn_forever`, which spawns at root scope and is not affected by component lifecycle.

## Discovery

Followup to #36 / PR #37. Even after the reload-wiring fix landed, real-node send-message still produced **zero** AFT delegate activity, **zero** inbox UpdateRequest at the gateway, **zero** browser-console errors.

Instrumented `send_message`, `start_sending`, `assign_token` with info-level breadcrumbs. (`crate::log::debug!` is `cfg(debug_assertions)`-gated → stripped from release wasm; this is documented in CLAUDE.md memory now.)

Trace showed: send_msg fires → futs.len()=1 → spawn returns task → **never any "future started" log**. Confirmed the future was created but never polled. Reading dioxus-core 0.7.3 source (`global_context.rs` line 105) confirmed: `spawn` "task will automatically be canceled when the component is dropped". `spawn_forever` (line 189) explicitly avoids this.

## Test plan

- [x] cargo build clean (release wasm)
- [x] Manual local-node E2E: alice send → AFT-gen DelegateRequest reaches gateway, delegate executes (verified via gateway log + browser-console info logs during instrumentation pass)
- [ ] Followup: there's a `Uncaught RuntimeError: unreachable` WASM panic AFTER the send returns ok — separate issue, will track. Inbox UPDATE still doesn't reach gateway, likely related to that panic.