### PR TITLE
fix(aft): resume allocation on UserResponse via SecretStore stash

### DIFF
--- a/modules/antiflood-tokens/delegates/token-generator/src/lib.rs
+++ b/modules/antiflood-tokens/delegates/token-generator/src/lib.rs
@@ -27,10 +27,16 @@ mod tests;
 
 struct TokenDelegate;
 
+fn pending_secret_key(request_id: u32) -> Vec<u8> {
+    let mut key = b"pending_request_".to_vec();
+    key.extend_from_slice(&request_id.to_le_bytes());
+    key
+}
+
 #[delegate]
 impl DelegateInterface for TokenDelegate {
     fn process(
-        _ctx: &mut DelegateCtx,
+        ctx: &mut DelegateCtx,
         params: Parameters<'static>,
         _origin: Option<MessageOrigin>,
         message: InboundDelegateMsg,
@@ -52,6 +58,16 @@ impl DelegateInterface for TokenDelegate {
                 let params = DelegateParameters::try_from(params)?;
                 match msg {
                     TokenDelegateMessage::RequestNewToken(req) => {
+                        // Persist the request payload across the
+                        // RequestUserInput round-trip via the SecretStore
+                        // (the message-level context doesn't survive the
+                        // host's separate-conversation re-entry on
+                        // UserResponse). The UserResponse arm reads the
+                        // secret and resumes allocation.
+                        let key = pending_secret_key(req.request_id);
+                        let serialized = bincode::serialize(&req)
+                            .map_err(|e| DelegateError::Deser(format!("{e}")))?;
+                        ctx.set_secret(&key, &serialized);
                         allocate_token(params, &mut context, req)
                     }
                     TokenDelegateMessage::Failure(reason) => Err(DelegateError::Other(format!(
@@ -65,14 +81,12 @@ impl DelegateInterface for TokenDelegate {
             InboundDelegateMsg::UserResponse(UserInputResponse {
                 request_id,
                 response,
-                context,
+                context: _,
             }) => {
-                let mut context = Context::try_from(context)?;
-                context.waiting_for_user_input.remove(&request_id);
                 // RESPONSES wire format is the raw bytes "true"/"false" (see
                 // RequestUserInput emitted from `allocate_token`). The host
                 // round-trips them verbatim. Map to the Response enum.
-                let response = match response.as_ref() {
+                let response_enum = match response.as_ref() {
                     b"true" => Response::Allowed,
                     b"false" => Response::NotAllowed,
                     other => {
@@ -81,9 +95,27 @@ impl DelegateInterface for TokenDelegate {
                         )));
                     }
                 };
-                context.user_response.insert(request_id, response);
-                let context: DelegateContext = (&context).try_into()?;
-                Ok(vec![OutboundDelegateMsg::ContextUpdated(context)])
+                // The original RequestNewToken was persisted in the secret
+                // store under `pending_<request_id>` during the first
+                // RequestNewToken call. Pull it back out, build a fresh
+                // Context with `user_response` populated, and re-run
+                // `allocate_token` to hit the (_, Some(response)) arm.
+                // Without this, the response would be saved into a
+                // throwaway context and `allocate_token` would never run
+                // again — the original request payload is lost otherwise.
+                let key = pending_secret_key(request_id);
+                let Some(stashed_bytes) = ctx.get_secret(&key) else {
+                    // No stashed request — either timed out or not ours.
+                    let context: DelegateContext = (&Context::default()).try_into()?;
+                    return Ok(vec![OutboundDelegateMsg::ContextUpdated(context)]);
+                };
+                let req: RequestNewToken = bincode::deserialize(&stashed_bytes)
+                    .map_err(|e| DelegateError::Deser(format!("{e}")))?;
+                ctx.remove_secret(&key);
+                let mut context = Context::default();
+                context.user_response.insert(request_id, response_enum);
+                let params = DelegateParameters::try_from(params)?;
+                allocate_token(params, &mut context, req)
             }
             _ => Err(DelegateError::Other("unexpected message type".into())),
         }
@@ -130,18 +162,24 @@ fn allocate_token(
         (None, None) => {
             // request user input and add to waiting queue
             context.waiting_for_user_input.insert(request_id);
-            let context: DelegateContext = (&*context).try_into()?;
             let message = user_input(&criteria, &verifying_key_bytes);
+            // Stash the original RequestNewToken so the UserResponse arm
+            // can resume allocation once the user grants/denies — without
+            // it the inputs (criteria, records, assignment_hash) are lost
+            // by the time the user-response inbound arrives.
+            let stashed = RequestNewToken {
+                request_id,
+                delegate_id,
+                criteria,
+                records,
+                assignment_hash,
+            };
+            context.pending_requests.insert(request_id, stashed.clone());
+            let context_serialized: DelegateContext = (&*context).try_into()?;
             let req_allocation = {
-                let msg = TokenDelegateMessage::RequestNewToken(RequestNewToken {
-                    request_id,
-                    delegate_id,
-                    criteria,
-                    records,
-                    assignment_hash,
-                });
+                let msg = TokenDelegateMessage::RequestNewToken(stashed);
                 OutboundDelegateMsg::ApplicationMessage(
-                    ApplicationMessage::new(msg.serialize()?).with_context(context),
+                    ApplicationMessage::new(msg.serialize()?).with_context(context_serialized),
                 )
             };
             let request_user_input = OutboundDelegateMsg::RequestUserInput(UserInputRequest {
@@ -219,6 +257,13 @@ fn allocate_token(
 struct Context {
     waiting_for_user_input: HashSet<u32>,
     user_response: HashMap<u32, Response>,
+    /// RequestNewToken payloads stashed when we emit a RequestUserInput.
+    /// On the matching UserResponse arm we pull the original request out
+    /// and complete `allocate_token`. Without this, the response would be
+    /// recorded but never acted on — the original RequestNewToken never
+    /// arrives a second time.
+    #[serde(default)]
+    pending_requests: HashMap<u32, RequestNewToken>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/modules/antiflood-tokens/interfaces/src/lib.rs
+++ b/modules/antiflood-tokens/interfaces/src/lib.rs
@@ -79,7 +79,7 @@ impl Display for FailureReason {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequestNewToken {
     pub request_id: u32,
     pub delegate_id: SecretsId,
@@ -467,7 +467,7 @@ enum AllocationErrorInner {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AllocationCriteria {
     pub frequency: Tier,
     /// Maximum age of the allocated token.


### PR DESCRIPTION
## Summary

Token-generator delegate's `UserResponse` arm just stored the user's response and emitted `ContextUpdated`. It never re-ran `allocate_token`, so the original `RequestNewToken` payload (criteria, records, assignment_hash) was lost and the application never saw `AllocatedToken`. Permission dialog grant was a dead end.

## Why it failed

- The `UserInputResponse.context` field that the delegate receives is **always empty** — host code in `freenet-core` (`crates/core/src/contract.rs:557`) explicitly attaches `DelegateContext::default()` because the executor maintains the actual context separately.
- The executor-managed context Vec<u8> doesn't persist either: each iteration of `handle_delegate_with_contract_requests`'s loop calls `execute_delegate_request` which starts a fresh `process_inbound` with `context = Vec::new()`. The first iteration processes `RequestNewToken`; the next iteration delivers `UserResponse` in a separate conversation with a brand-new empty context.
- So the in-context `pending_requests` HashMap I tried first was invisible to the UserResponse arm.

## Fix

Use the SecretStore (which IS persistent across delegate invocations).

- On the first `RequestNewToken` call: bincode-serialize the request and write it to a secret keyed by `pending_request_<request_id>`.
- On `UserResponse`: read the secret, remove it, deserialize the `RequestNewToken`, build a fresh Context with `user_response` populated, and re-call `allocate_token` — which now hits the `(_, Some(response))` arm and emits `AllocatedToken` (or `Failure`) as an `ApplicationMessage`.

Also:

- Map `RESPONSES = ["true", "false"]` raw bytes manually to the `Response` enum. `serde_json::from_slice(b"true")` doesn't decode as `Response::Allowed`; the host round-trips the raw button-label bytes verbatim.
- Add `Clone` to `AllocationCriteria` and `RequestNewToken` for the stash path.

## Test plan

Manually verified end-to-end against an isolated local node (gateway 7510 / peer 7511, isolated HOME so no public Freenet bootstrap):

- [x] Build + sign + publish test webapp
- [x] Open webapp → identity persisted across reload
- [x] Send message → permission dialog appears (no panic, fixed in #38)
- [x] Click "true" → AFT-gen delegate runs `allocate_token`, emits `AllocatedToken`
- [x] UI receives `AllocatedToken`, fires UPDATE on token-record contract
- [x] Gateway logs show contract state updated successfully

Known follow-up (not blocking): UI panics deserializing the UPDATE response payload as `TokenAllocationSummary` (api.rs:972). The panic is downstream of the now-working AFT flow — message is committed by then. Separate fix.

## Related

- builds on freenet/mail#38 (spawn_forever for send-message + delegate-echo handling + panic hook)
- freenet/freenet-core#3982 (closed; was wrongly suspected to be a host-side bug, traced here)