### PR TITLE
fix(ui): defensive UpdateResponse summary deser (no more panic)

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -998,12 +998,11 @@ pub(crate) async fn node_comms(
                             }
                         },
                     };
-                    if let Some(summary) = summary {
-                        if let Err(e) =
+                    if let Some(summary) = summary
+                        && let Err(e) =
                             AftRecords::confirm_allocation(&mut client, *key.id(), summary).await
-                        {
-                            crate::log::error(format!("confirm_allocation failed: {e}"), None);
-                        }
+                    {
+                        crate::log::error(format!("confirm_allocation failed: {e}"), None);
                     }
                     token_rec_to_id.insert(key, identity.clone());
                 }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -969,10 +969,42 @@ pub(crate) async fn node_comms(
             }
             HostResponse::ContractResponse(ContractResponse::UpdateResponse { key, summary }) => {
                 if let Some(identity) = token_rec_to_id.remove(&key) {
-                    let summary = TokenAllocationSummary::try_from(summary).unwrap();
-                    AftRecords::confirm_allocation(&mut client, *key.id(), summary)
-                        .await
-                        .unwrap();
+                    // The host's UpdateResponse `summary` field has, in
+                    // practice, sometimes carried the full
+                    // TokenAllocationRecord JSON (`{"tokens_by_tier":...}`)
+                    // instead of the contract's TokenAllocationSummary
+                    // (`{"Day1":[...]}`). Accept either: try Summary first,
+                    // then fall back to deserializing as Record and
+                    // summarizing locally. Bail with an error log instead
+                    // of panicking — the AFT allocation has already
+                    // committed at this point, the panic was just losing
+                    // the post-commit hook.
+                    let bytes = summary.as_ref();
+                    let summary = match TokenAllocationSummary::try_from(summary.clone()) {
+                        Ok(s) => Some(s),
+                        Err(_) => match serde_json::from_slice::<freenet_aft_interface::TokenAllocationRecord>(bytes) {
+                            Ok(record) => Some(record.summarize()),
+                            Err(e) => {
+                                crate::log::error(
+                                    format!(
+                                        "UpdateResponse summary deser failed as both Summary and Record: {e}"
+                                    ),
+                                    None,
+                                );
+                                None
+                            }
+                        },
+                    };
+                    if let Some(summary) = summary {
+                        if let Err(e) =
+                            AftRecords::confirm_allocation(&mut client, *key.id(), summary).await
+                        {
+                            crate::log::error(
+                                format!("confirm_allocation failed: {e}"),
+                                None,
+                            );
+                        }
+                    }
                     token_rec_to_id.insert(key, identity.clone());
                 }
             }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -982,7 +982,10 @@ pub(crate) async fn node_comms(
                     let bytes = summary.as_ref();
                     let summary = match TokenAllocationSummary::try_from(summary.clone()) {
                         Ok(s) => Some(s),
-                        Err(_) => match serde_json::from_slice::<freenet_aft_interface::TokenAllocationRecord>(bytes) {
+                        Err(_) => match serde_json::from_slice::<
+                            freenet_aft_interface::TokenAllocationRecord,
+                        >(bytes)
+                        {
                             Ok(record) => Some(record.summarize()),
                             Err(e) => {
                                 crate::log::error(
@@ -999,10 +1002,7 @@ pub(crate) async fn node_comms(
                         if let Err(e) =
                             AftRecords::confirm_allocation(&mut client, *key.id(), summary).await
                         {
-                            crate::log::error(
-                                format!("confirm_allocation failed: {e}"),
-                                None,
-                            );
+                            crate::log::error(format!("confirm_allocation failed: {e}"), None);
                         }
                     }
                     token_rec_to_id.insert(key, identity.clone());


### PR DESCRIPTION
## Summary

After #39, the AFT-record UPDATE actually completes on the node and the host returns an UpdateResponse to the UI. The UI was calling \`TokenAllocationSummary::try_from(summary).unwrap()\` which panicked because the summary payload carried full TokenAllocationRecord JSON (\`{tokens_by_tier:...}\`) instead of TokenAllocationSummary (\`{Day1:[...]}\`).

Make it defensive: try Summary, fall back to Record→summarize locally, log + skip on total parse failure instead of panicking. The AFT allocation has already committed by the time this response arrives, so a parse failure here only loses the post-commit confirm hook, not the message itself.

## Verified end-to-end

With this PR + #38 + #39 stacked, on an isolated local node:

- [x] Send → permission dialog → grant → AFT-gen runs allocate_token → AllocatedToken back to UI → UI fires UPDATE on token-record contract → contract state updated successfully on gateway → UpdateResponse parses cleanly (no panic) → next-hop inbox UPDATE attempted.

The next observable behaviour is an AFT-side rejection: "slot for day1 has already been allocated" when alice sends to herself twice in the same day. That is the rate-limiter working as designed (one Day1 token per identity per slot), not a bug.