### PR TITLE
docs: state LGPL-3.0-or-later in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,6 @@ See [`RELEASING.md`](RELEASING.md) for the release runbook.
 
 ## License
 
-TBD (see Cargo.toml).
+Licensed under the GNU Lesser General Public License v3.0 or later
+(LGPL-3.0-or-later). See [`COPYING.LESSER`](COPYING.LESSER) and
+[`COPYING`](COPYING) for the full license text.


### PR DESCRIPTION
## Summary
- Replace "TBD (see Cargo.toml)" with link to COPYING.LESSER + COPYING
- Follow-up to #45 (license commit landed without README update)

## Test plan
- [ ] CI green