### PR TITLE
feat(ui): Archive folder + Delete vs Archive split (#47c)

### DIFF
--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -85,6 +85,19 @@ pub enum DeliveryState {
     Failed,
 }
 
+/// A snapshot of an inbox message that the user has explicitly archived.
+/// 47c removes the row from the inbox contract on archive; the local copy
+/// here keeps the message visible in the Archive folder. True unarchive
+/// (re-PUT into the contract via an owner-signed delta) is tracked in #60.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Default)]
+pub struct ArchivedMessage {
+    pub from: String,
+    pub title: String,
+    pub content: String,
+    /// Unix millis at the time the user clicked Archive.
+    pub archived_at: i64,
+}
+
 /// A snapshot of an outgoing message stashed locally on Send. Mirrors what the
 /// user typed plus enough metadata to render the Sent folder and to seed
 /// Reply / Forward / Resend without round-tripping the contract.
@@ -142,6 +155,16 @@ pub struct AliasState {
     pub kept: HashMap<String, KeptMessage>,
     #[serde(default)]
     pub sent: HashMap<SentId, SentMessage>,
+    /// Inbox messages explicitly archived by the user. Keyed by stringified
+    /// `MessageId` (matching the kept map's convention).
+    #[serde(default)]
+    pub archived: HashMap<String, ArchivedMessage>,
+    /// Inbox message ids the user has explicitly deleted. Used to hide rows
+    /// in the Inbox view even when the contract eviction has not yet taken
+    /// effect (or, in offline / mock mode, never will). The list is bounded
+    /// by the number of messages the user has touched.
+    #[serde(default)]
+    pub deleted: Vec<MessageId>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Default)]
@@ -180,6 +203,27 @@ impl LocalState {
             .get(alias)
             .into_iter()
             .flat_map(|s| s.sent.iter())
+    }
+
+    pub fn archived_of(&self, alias: &str) -> impl Iterator<Item = (&String, &ArchivedMessage)> {
+        self.aliases
+            .get(alias)
+            .into_iter()
+            .flat_map(|s| s.archived.iter())
+    }
+
+    /// Whether `id` was archived by `alias`. Used by the Inbox merge to hide
+    /// rows the user has moved to the Archive folder.
+    pub fn is_archived(&self, alias: &str, id: MessageId) -> bool {
+        self.aliases
+            .get(alias)
+            .is_some_and(|s| s.archived.contains_key(&id.to_string()))
+    }
+
+    pub fn is_deleted(&self, alias: &str, id: MessageId) -> bool {
+        self.aliases
+            .get(alias)
+            .is_some_and(|s| s.deleted.contains(&id))
     }
 }
 
@@ -221,6 +265,28 @@ pub enum LocalStateMsg {
     DeleteSent {
         alias: Alias,
         id: SentId,
+    },
+    /// Stash an inbox message in the local archive. Issued from OpenMessage's
+    /// Archive button; the UI also fires a `remove_messages` against the
+    /// inbox contract. True unarchive (re-PUT into the contract) is tracked
+    /// in #60.
+    ArchiveMessage {
+        alias: Alias,
+        msg_id: MessageId,
+        archived: ArchivedMessage,
+    },
+    /// Drop the local archive entry for `msg_id`. Does NOT re-insert into
+    /// the contract — that path is gated on #60.
+    UnarchiveMessage {
+        alias: Alias,
+        msg_id: MessageId,
+    },
+    /// Hard delete an inbox message: clear any local copies (kept + archived)
+    /// for that id. The caller is also expected to have issued
+    /// `remove_messages` against the inbox contract.
+    DeleteMessage {
+        alias: Alias,
+        msg_id: MessageId,
     },
     /// Returns the entire `LocalState` JSON via an `ApplicationMessage`
     /// response. UI filters per active alias.
@@ -301,6 +367,45 @@ impl DelegateInterface for LocalState {
                             s.read.push(msg_id);
                         }
                         s.kept.insert(msg_id.to_string(), kept);
+                        store(ctx, &secret_key, &state)?;
+                        Ok(vec![])
+                    }
+                    LocalStateMsg::ArchiveMessage {
+                        alias,
+                        msg_id,
+                        archived,
+                    } => {
+                        let mut state = load_or_default(ctx, &secret_key)?;
+                        let s = state.aliases.entry(alias).or_default();
+                        // Archiving is also "read" by definition — the user
+                        // explicitly acted on it. Drop any kept copy so the
+                        // message isn't surfaced twice (Inbox via kept fallback
+                        // AND Archive folder).
+                        s.kept.remove(&msg_id.to_string());
+                        if !s.read.contains(&msg_id) {
+                            s.read.push(msg_id);
+                        }
+                        s.archived.insert(msg_id.to_string(), archived);
+                        store(ctx, &secret_key, &state)?;
+                        Ok(vec![])
+                    }
+                    LocalStateMsg::UnarchiveMessage { alias, msg_id } => {
+                        let mut state = load_or_default(ctx, &secret_key)?;
+                        if let Some(s) = state.aliases.get_mut(&alias) {
+                            s.archived.remove(&msg_id.to_string());
+                        }
+                        store(ctx, &secret_key, &state)?;
+                        Ok(vec![])
+                    }
+                    LocalStateMsg::DeleteMessage { alias, msg_id } => {
+                        let mut state = load_or_default(ctx, &secret_key)?;
+                        let s = state.aliases.entry(alias).or_default();
+                        s.kept.remove(&msg_id.to_string());
+                        s.archived.remove(&msg_id.to_string());
+                        s.read.retain(|id| *id != msg_id);
+                        if !s.deleted.contains(&msg_id) {
+                            s.deleted.push(msg_id);
+                        }
                         store(ctx, &secret_key, &state)?;
                         Ok(vec![])
                     }
@@ -459,6 +564,36 @@ mod boundary_tests {
         let json = br#"{"to":"bob","recipient_fingerprint":"abcd","subject":"hi","body":"yo","sent_at":1}"#;
         let s: SentMessage = serde_json::from_slice(json).expect("should deserialise");
         assert_eq!(s.delivery_state, DeliveryState::Pending);
+    }
+
+    /// `AliasState` written before the Archive feature deserialises with an
+    /// empty `archived` map. Pre-#47c state must keep loading.
+    #[test]
+    fn alias_state_missing_archived_defaults_empty() {
+        let json = br#"{"drafts":{},"read":[],"kept":{},"sent":{}}"#;
+        let s: AliasState = serde_json::from_slice(json).expect("should deserialise");
+        assert!(s.archived.is_empty());
+    }
+
+    #[test]
+    fn round_trip_archived_state() {
+        let mut state = LocalState::default();
+        let alias = state.aliases.entry("alice".into()).or_default();
+        alias.archived.insert(
+            "9".into(),
+            ArchivedMessage {
+                from: "bob".into(),
+                title: "old".into(),
+                content: "stash".into(),
+                archived_at: 99,
+            },
+        );
+        let bytes = serde_json::to_vec(&state).unwrap();
+        let back = LocalState::try_from(bytes.as_slice()).unwrap();
+        assert!(back.is_archived("alice", 9));
+        let archived: Vec<_> = back.archived_of("alice").collect();
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0].1.content.as_str(), "stash");
     }
 
     #[test]

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -633,6 +633,7 @@ mod menu {
         folder: Folder,
         email: Option<u64>,
         sent_id: Option<String>,
+        archived_id: Option<u64>,
         new_msg: bool,
         search: String,
         compose_prefill: Option<ComposePrefill>,
@@ -647,6 +648,7 @@ mod menu {
                 self.new_msg = true;
                 self.email = None;
                 self.sent_id = None;
+                self.archived_id = None;
             }
         }
 
@@ -677,6 +679,14 @@ mod menu {
             self.sent_id.as_deref()
         }
 
+        pub fn open_archived(&mut self, id: u64) {
+            self.archived_id = Some(id);
+        }
+
+        pub fn archived_id(&self) -> Option<u64> {
+            self.archived_id
+        }
+
         pub fn take_compose_prefill(&mut self) -> Option<ComposePrefill> {
             self.compose_prefill.take()
         }
@@ -688,6 +698,7 @@ mod menu {
         pub fn at_inbox_list(&mut self) {
             self.email = None;
             self.sent_id = None;
+            self.archived_id = None;
             self.new_msg = false;
             self.compose_prefill = None;
         }
@@ -709,6 +720,7 @@ mod menu {
                 self.folder = f;
                 self.email = None;
                 self.sent_id = None;
+                self.archived_id = None;
             }
         }
 
@@ -731,8 +743,7 @@ fn folder_count(emails: &[Message], folder: menu::Folder, alias: &str) -> usize 
         menu::Folder::Inbox => emails.iter().filter(|m| !m.read).count(),
         menu::Folder::Drafts => crate::local_state::drafts_for(alias).len(),
         menu::Folder::Sent => crate::local_state::sent_for(alias).len(),
-        // Archive isn't backed yet (#47c). Show 0.
-        menu::Folder::Archive => 0,
+        menu::Folder::Archive => crate::local_state::archived_for(alias).len(),
     }
 }
 
@@ -912,6 +923,12 @@ fn MessageList() -> Element {
             let alias = id.alias.to_string();
             for msg in &current_model.borrow().messages {
                 let mut m = Message::from(msg.clone());
+                // Hide archived rows from the Inbox list (#47c). Until the
+                // contract eviction round-trips, the live contract may still
+                // serve a row the user has archived; we drop it client-side.
+                if crate::local_state::is_archived(&alias, m.id) {
+                    continue;
+                }
                 // Read-state survives reload because it lives in the
                 // mail-local-state delegate, not just `mark_as_read`'s
                 // local mutation. See issue #47/47a.
@@ -922,9 +939,13 @@ fn MessageList() -> Element {
             }
             // Merge kept-locally messages (b): rows the inbox contract has
             // already evicted but the user has read. They are always read,
-            // and dedup by id against the live contract messages.
+            // and dedup by id against the live contract messages. Archived
+            // rows are excluded — they belong to the Archive folder, not Inbox.
             for (mid, kept) in crate::local_state::kept_for(&alias) {
                 if emails.iter().any(|m| m.id == mid) {
+                    continue;
+                }
+                if crate::local_state::is_archived(&alias, mid) {
                     continue;
                 }
                 emails.push(Message {
@@ -959,20 +980,27 @@ fn MessageList() -> Element {
 
     let inbox_view = inbox.read();
     let emails = inbox_view.messages.borrow();
+    let active_alias = user
+        .read()
+        .logged_id()
+        .map(|id| id.alias.to_string())
+        .unwrap_or_default();
     let visible: Vec<Message> = if matches!(folder, menu::Folder::Inbox) {
         emails
             .iter()
+            // Hide archived/deleted rows. In offline mode the populate loop
+            // above is a no-op (no inbox_data), so emails are seeded once at
+            // login and never re-filtered without this guard. Same call also
+            // hides them in use-node mode if the contract eviction is still
+            // in flight.
+            .filter(|m| !crate::local_state::is_archived(&active_alias, m.id))
+            .filter(|m| !crate::local_state::is_deleted(&active_alias, m.id))
             .filter(|m| matches_search(m, &search))
             .cloned()
             .collect()
     } else {
         Vec::new()
     };
-    let active_alias = user
-        .read()
-        .logged_id()
-        .map(|id| id.alias.to_string())
-        .unwrap_or_default();
     let drafts: Vec<(String, mail_local_state::Draft)> = if matches!(folder, menu::Folder::Drafts) {
         let mut d = crate::local_state::drafts_for(&active_alias);
         // Newest first.
@@ -989,12 +1017,22 @@ fn MessageList() -> Element {
         } else {
             Vec::new()
         };
+    let archived_msgs: Vec<(u64, mail_local_state::ArchivedMessage)> =
+        if matches!(folder, menu::Folder::Archive) {
+            let mut a = crate::local_state::archived_for(&active_alias);
+            a.sort_by_key(|b| std::cmp::Reverse(b.1.archived_at));
+            a
+        } else {
+            Vec::new()
+        };
     let count = match folder {
         menu::Folder::Drafts => drafts.len(),
         menu::Folder::Sent => sent_msgs.len(),
+        menu::Folder::Archive => archived_msgs.len(),
         _ => visible.len(),
     };
     let selected_sent_id = menu_selection.read().sent_id().map(str::to_string);
+    let selected_archived_id = menu_selection.read().archived_id();
 
     rsx! {
         section { class: "list-col",
@@ -1003,7 +1041,39 @@ fn MessageList() -> Element {
                 span { class: "list-count", "{count}" }
             }
             div { class: "list-scroll", "data-testid": "fm-list",
-                if matches!(folder, menu::Folder::Sent) {
+                if matches!(folder, menu::Folder::Archive) {
+                    if archived_msgs.is_empty() {
+                        div { style: "padding:24px 18px; font-family:'Geist Mono',monospace; font-size:10px; letter-spacing:0.1em; text-transform:uppercase; color:var(--ink4);",
+                            "Archive is empty"
+                        }
+                    } else {
+                        {
+                            archived_msgs.into_iter().map(|(mid, a)| {
+                                let from_disp = if a.from.is_empty() { "(no sender)".to_string() } else { a.from.clone() };
+                                let subj_disp = if a.title.is_empty() { "(no subject)".to_string() } else { a.title.clone() };
+                                let preview = a.content.clone();
+                                let mut classes = String::from("msg-card");
+                                if Some(mid) == selected_archived_id { classes.push_str(" selected"); }
+                                rsx! {
+                                    article {
+                                        class: "{classes}",
+                                        "data-testid": "fm-archive-card",
+                                        "data-msg-id": "{mid}",
+                                        onclick: move |_| {
+                                            menu_selection.write().open_archived(mid);
+                                        },
+                                        div { class: "msg-row1",
+                                            span { class: "msg-sender", "{from_disp}" }
+                                            span { class: "msg-time", "" }
+                                        }
+                                        div { class: "msg-subj", "{subj_disp}" }
+                                        div { class: "msg-prev", "{preview}" }
+                                    }
+                                }
+                            })
+                        }
+                    }
+                } else if matches!(folder, menu::Folder::Sent) {
                     if sent_msgs.is_empty() {
                         div { style: "padding:24px 18px; font-family:'Geist Mono',monospace; font-size:10px; letter-spacing:0.1em; text-transform:uppercase; color:var(--ink4);",
                             "Sent is empty"
@@ -1119,6 +1189,7 @@ fn DetailPanel() -> Element {
     let folder = menu_selection.read().folder();
     let selected_id = menu_selection.read().email();
     let selected_sent_id = menu_selection.read().sent_id().map(str::to_string);
+    let selected_archived_id = menu_selection.read().archived_id();
     let view = inbox.read();
     let emails = view.messages.borrow();
     let selected = selected_id.and_then(|id| emails.iter().find(|m| m.id == id).cloned());
@@ -1133,6 +1204,29 @@ fn DetailPanel() -> Element {
                     div { class: "empty",
                         div { class: "empty-glyph", "✉" }
                         div { class: "empty-hint", "Select a message" }
+                    }
+                }
+            }
+        }
+    } else if matches!(folder, menu::Folder::Archive) {
+        let alias = user
+            .read()
+            .logged_id()
+            .map(|id| id.alias.to_string())
+            .unwrap_or_default();
+        let archived = selected_archived_id.and_then(|aid| {
+            crate::local_state::archived_for(&alias)
+                .into_iter()
+                .find(|(mid, _)| *mid == aid)
+        });
+        if let Some((mid, msg)) = archived {
+            rsx! { OpenArchivedMessage { msg_id: mid, msg } }
+        } else {
+            rsx! {
+                section { class: "detail-col",
+                    div { class: "empty",
+                        div { class: "empty-glyph", "✉" }
+                        div { class: "empty-hint", "Select an archived message" }
                     }
                 }
             }
@@ -1180,6 +1274,104 @@ fn quote_body(body: &str) -> String {
         .map(|l| format!("> {l}"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[component]
+fn OpenArchivedMessage(msg_id: u64, msg: mail_local_state::ArchivedMessage) -> Element {
+    let mut menu_selection = use_context::<Signal<menu::MenuSelection>>();
+    let mut toast = use_context::<Signal<Option<String>>>();
+    let user = use_context::<Signal<User>>();
+    let client = crate::api::WEB_API_SENDER.get().unwrap();
+
+    let from = msg.from.clone();
+    let from_initial = from.chars().next().unwrap_or('·').to_string();
+    let title = msg.title.clone();
+    let content = msg.content.clone();
+    let reply_to = from.clone();
+    let reply_subj = format!("Re: {title}");
+
+    let alias = user
+        .read()
+        .logged_id()
+        .map(|id| id.alias.to_string())
+        .unwrap_or_default();
+    let delete_alias = alias.clone();
+
+    rsx! {
+        section { class: "detail-col",
+            div { class: "detail-head",
+                h1 { class: "detail-subj", "{title}" }
+                div { class: "detail-from",
+                    div { class: "sender-orb", "{from_initial}" }
+                    div { class: "from-text",
+                        span { class: "from-name", "from {from}" }
+                        span { class: "from-addr", "archived" }
+                    }
+                    span { class: "from-time", "" }
+                }
+            }
+            div { class: "toolbar",
+                button {
+                    class: "btn btn-primary",
+                    "data-testid": "fm-archive-reply",
+                    onclick: move |_| {
+                        menu_selection.write().open_compose_with(reply_to.to_string(), reply_subj.clone());
+                    },
+                    "Reply"
+                }
+                // Unarchive lives behind issue #60 (inbox contract OwnerInsert
+                // variant). Disabled here so the affordance is visible without
+                // mis-promising round-trippable archives.
+                button {
+                    class: "btn btn-secondary",
+                    "data-testid": "fm-archive-unarchive",
+                    disabled: true,
+                    title: "Unarchive requires inbox contract OwnerInsert (#60)",
+                    "Unarchive"
+                }
+                button {
+                    class: "btn btn-secondary",
+                    "data-testid": "fm-archive-delete",
+                    onclick: move |_| {
+                        if !delete_alias.is_empty() {
+                            crate::local_state::local_delete_message(&delete_alias, msg_id);
+                            #[cfg(feature = "use-node")]
+                            {
+                                let mut c = client.clone();
+                                let a = delete_alias.clone();
+                                spawn(async move {
+                                    if let Err(e) = crate::local_state::delete_message(
+                                        &mut c, a, msg_id,
+                                    )
+                                    .await
+                                    {
+                                        crate::log::error(
+                                            format!("delete_message failed: {e}"),
+                                            None,
+                                        );
+                                    }
+                                });
+                            }
+                        }
+                        menu_selection.write().at_inbox_list();
+                        toast.set(Some("Deleted".to_string()));
+                        spawn_toast_clear();
+                    },
+                    "Delete"
+                }
+                div { class: "spacer" }
+            }
+            div { class: "detail-scroll",
+                div { class: "detail-body", "data-testid": "fm-archive-body",
+                    {
+                        content.split("\n\n").map(|para| rsx! {
+                            p { "{para}" }
+                        })
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[component]
@@ -1348,6 +1540,16 @@ fn OpenMessage(msg: Message) -> Element {
     let archive_inbox_data = inbox_data.clone();
     let delete_client = client.clone();
     let delete_inbox_data = inbox_data.clone();
+    let active_alias = user
+        .read()
+        .logged_id()
+        .map(|id| id.alias.to_string())
+        .unwrap_or_default();
+    let archive_alias = active_alias.clone();
+    let archive_from = msg.from.to_string();
+    let archive_title = msg.title.to_string();
+    let archive_content = msg.content.to_string();
+    let delete_alias = active_alias.clone();
 
     rsx! {
         section { class: "detail-col",
@@ -1375,6 +1577,40 @@ fn OpenMessage(msg: Message) -> Element {
                     class: "btn btn-secondary",
                     "data-testid": "fm-archive",
                     onclick: move |_| {
+                        // Archive: stash a local copy in mail-local-state then
+                        // remove from the inbox contract. Phase 1 of #47c —
+                        // re-PUT-on-unarchive lands in #60.
+                        let archived = mail_local_state::ArchivedMessage {
+                            from: archive_from.clone(),
+                            title: archive_title.clone(),
+                            content: archive_content.clone(),
+                            archived_at: chrono::Utc::now().timestamp_millis(),
+                        };
+                        if !archive_alias.is_empty() {
+                            crate::local_state::local_archive_message(
+                                &archive_alias,
+                                id,
+                                archived.clone(),
+                            );
+                            #[cfg(feature = "use-node")]
+                            {
+                                let mut c = archive_client.clone();
+                                let a = archive_alias.clone();
+                                let ar = archived.clone();
+                                spawn(async move {
+                                    if let Err(e) = crate::local_state::archive_message(
+                                        &mut c, a, id, ar,
+                                    )
+                                    .await
+                                    {
+                                        crate::log::error(
+                                            format!("archive_message failed: {e}"),
+                                            None,
+                                        );
+                                    }
+                                });
+                            }
+                        }
                         let result = inbox
                             .write()
                             .remove_messages(archive_client.clone(), &[id], archive_inbox_data.clone())
@@ -1390,6 +1626,29 @@ fn OpenMessage(msg: Message) -> Element {
                     class: "btn btn-secondary",
                     "data-testid": "fm-delete",
                     onclick: move |_| {
+                        // Delete: drop any local kept/archived copies AND
+                        // remove from the inbox contract. Distinct from
+                        // Archive because it leaves no trace.
+                        if !delete_alias.is_empty() {
+                            crate::local_state::local_delete_message(&delete_alias, id);
+                            #[cfg(feature = "use-node")]
+                            {
+                                let mut c = delete_client.clone();
+                                let a = delete_alias.clone();
+                                spawn(async move {
+                                    if let Err(e) = crate::local_state::delete_message(
+                                        &mut c, a, id,
+                                    )
+                                    .await
+                                    {
+                                        crate::log::error(
+                                            format!("delete_message failed: {e}"),
+                                            None,
+                                        );
+                                    }
+                                });
+                            }
+                        }
                         let result = inbox
                             .write()
                             .remove_messages(delete_client.clone(), &[id], delete_inbox_data.clone())

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -11,7 +11,9 @@
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use mail_local_state::{Draft, KeptMessage, LocalState, LocalStateMsg, MessageId, SentMessage};
+use mail_local_state::{
+    ArchivedMessage, Draft, KeptMessage, LocalState, LocalStateMsg, MessageId, SentMessage,
+};
 
 thread_local! {
     /// Most recent snapshot returned by the delegate. Replaced wholesale on
@@ -44,6 +46,25 @@ pub(crate) fn drafts_for(alias: &str) -> Vec<(String, Draft)> {
 
 pub(crate) fn is_read(alias: &str, id: MessageId) -> bool {
     SNAPSHOT.with(|s| s.borrow().is_read(alias, id))
+}
+
+pub(crate) fn archived_for(alias: &str) -> Vec<(MessageId, ArchivedMessage)> {
+    SNAPSHOT.with(|s| match s.borrow().for_alias(alias) {
+        Some(state) => state
+            .archived
+            .iter()
+            .filter_map(|(k, v)| k.parse::<MessageId>().ok().map(|id| (id, v.clone())))
+            .collect(),
+        None => Vec::new(),
+    })
+}
+
+pub(crate) fn is_archived(alias: &str, id: MessageId) -> bool {
+    SNAPSHOT.with(|s| s.borrow().is_archived(alias, id))
+}
+
+pub(crate) fn is_deleted(alias: &str, id: MessageId) -> bool {
+    SNAPSHOT.with(|s| s.borrow().is_deleted(alias, id))
 }
 
 pub(crate) fn sent_for(alias: &str) -> Vec<(String, SentMessage)> {
@@ -182,6 +203,40 @@ mod wire {
         .await
     }
 
+    pub(crate) async fn archive_message(
+        client: &mut WebApiRequestClient,
+        alias: String,
+        msg_id: MessageId,
+        archived: ArchivedMessage,
+    ) -> Result<(), DynError> {
+        send_msg(
+            client,
+            &LocalStateMsg::ArchiveMessage {
+                alias,
+                msg_id,
+                archived,
+            },
+        )
+        .await
+    }
+
+    #[allow(dead_code)] // Wired for #60 (true unarchive); unused until then.
+    pub(crate) async fn unarchive_message(
+        client: &mut WebApiRequestClient,
+        alias: String,
+        msg_id: MessageId,
+    ) -> Result<(), DynError> {
+        send_msg(client, &LocalStateMsg::UnarchiveMessage { alias, msg_id }).await
+    }
+
+    pub(crate) async fn delete_message(
+        client: &mut WebApiRequestClient,
+        alias: String,
+        msg_id: MessageId,
+    ) -> Result<(), DynError> {
+        send_msg(client, &LocalStateMsg::DeleteMessage { alias, msg_id }).await
+    }
+
     pub(crate) async fn save_sent(
         client: &mut WebApiRequestClient,
         alias: String,
@@ -203,14 +258,14 @@ mod wire {
 
 #[cfg(feature = "use-node")]
 pub(crate) use wire::{
-    LOCAL_STATE_KEY, delete_draft, fetch_all, mark_read, register_and_init, save_draft, save_sent,
+    LOCAL_STATE_KEY, archive_message, delete_draft, delete_message, fetch_all, mark_read,
+    register_and_init, save_draft, save_sent,
 };
-// `delete_sent` and `local_delete_sent` are wired but not yet called from any
-// component; the Archive action in 47c will use them. Re-export here so the
-// future PR doesn't need to touch the export list.
+// `delete_sent`, `local_delete_sent`, and `unarchive_message` are wired but
+// unused until later phases.
 #[cfg(feature = "use-node")]
 #[allow(unused_imports)]
-pub(crate) use wire::delete_sent;
+pub(crate) use wire::{delete_sent, unarchive_message};
 
 // Optimistic local mutations: patch `SNAPSHOT` immediately so the UI
 // re-renders without waiting for the delegate roundtrip.
@@ -258,6 +313,46 @@ pub(crate) fn local_delete_sent(alias: &str, id: &str) {
         let mut state = s.borrow_mut();
         if let Some(entry) = state.aliases_mut().get_mut(alias) {
             entry.sent.remove(id);
+        }
+    });
+    bump();
+}
+
+pub(crate) fn local_archive_message(alias: &str, msg_id: MessageId, archived: ArchivedMessage) {
+    SNAPSHOT.with(|s| {
+        let mut state = s.borrow_mut();
+        let entry = state.aliases_mut().entry(alias.to_string()).or_default();
+        // Mirrors the delegate semantics: archiving implies read, drops any
+        // kept fallback for the same id, and stashes the snapshot.
+        entry.kept.remove(&msg_id.to_string());
+        if !entry.read.contains(&msg_id) {
+            entry.read.push(msg_id);
+        }
+        entry.archived.insert(msg_id.to_string(), archived);
+    });
+    bump();
+}
+
+#[allow(dead_code)] // Wired for #60 (true unarchive).
+pub(crate) fn local_unarchive_message(alias: &str, msg_id: MessageId) {
+    SNAPSHOT.with(|s| {
+        let mut state = s.borrow_mut();
+        if let Some(entry) = state.aliases_mut().get_mut(alias) {
+            entry.archived.remove(&msg_id.to_string());
+        }
+    });
+    bump();
+}
+
+pub(crate) fn local_delete_message(alias: &str, msg_id: MessageId) {
+    SNAPSHOT.with(|s| {
+        let mut state = s.borrow_mut();
+        let entry = state.aliases_mut().entry(alias.to_string()).or_default();
+        entry.kept.remove(&msg_id.to_string());
+        entry.archived.remove(&msg_id.to_string());
+        entry.read.retain(|id| *id != msg_id);
+        if !entry.deleted.contains(&msg_id) {
+            entry.deleted.push(msg_id);
         }
     });
     bump();

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -142,8 +142,9 @@ test.describe("Inbox view", () => {
     );
 
     await page.locator('[data-testid="fm-folder-archive"]').click();
+    // 47c: Archive backs a real list; empty detail prompt mirrors Sent.
     await expect(page.locator(".empty-hint")).toContainText(
-      "Archive is empty",
+      "Select an archived message",
     );
   });
 });
@@ -980,5 +981,95 @@ test.describe("Rename identity (#32)", () => {
     await expect(
       page.locator('[data-testid="fm-id-row"][data-alias="address1"]'),
     ).toBeVisible();
+  });
+});
+
+// Archive (issue #47/47c). Archive splits from Delete: Archive stashes the
+// message locally and removes it from the inbox contract; Delete only
+// removes (no local trace). Re-PUT-on-unarchive lands in #60.
+test.describe("Archive folder (#47c)", () => {
+  test("Archive moves message from Inbox to Archive folder", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    // Open the first inbox message (id=0 = Welcome to the offline preview).
+    await page.locator("#email-inbox-accessor-0").click();
+    await expect(page.locator(".detail-subj")).toContainText(
+      "Welcome to the offline preview",
+    );
+
+    // Archive it. Mobile viewports stack columns and the list-col can
+    // intercept the toolbar's pointer events; dispatchEvent fires the
+    // synthetic click directly on the button.
+    await page.locator('[data-testid="fm-archive"]').dispatchEvent("click");
+
+    // Inbox no longer shows the row.
+    await expect(page.locator("#email-inbox-accessor-0")).toHaveCount(0);
+
+    // Archive folder shows the row.
+    await page.locator('[data-testid="fm-folder-archive"]').click();
+    const card = page.locator('[data-testid="fm-archive-card"]').first();
+    await expect(card).toBeVisible();
+    await expect(card.locator(".msg-subj")).toContainText(
+      "Welcome to the offline preview",
+    );
+
+    await card.click();
+    await expect(page.locator(".detail-subj")).toContainText(
+      "Welcome to the offline preview",
+    );
+    // Unarchive is wired but disabled until #60 lands.
+    const unarchive = page.locator('[data-testid="fm-archive-unarchive"]');
+    await expect(unarchive).toBeDisabled();
+  });
+
+  test("Delete from Inbox does not produce an Archive entry", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    await page.locator("#email-inbox-accessor-1").click();
+    await page.locator('[data-testid="fm-delete"]').dispatchEvent("click");
+
+    await expect(page.locator("#email-inbox-accessor-1")).toHaveCount(0);
+
+    await page.locator('[data-testid="fm-folder-archive"]').click();
+    await expect(page.locator('[data-testid="fm-archive-card"]')).toHaveCount(0);
+  });
+
+  test("Archive count badge reflects archived rows", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    const archiveBtn = page.locator('[data-testid="fm-folder-archive"]');
+    await expect(archiveBtn.locator(".count")).toHaveText("");
+
+    await page.locator("#email-inbox-accessor-2").click();
+    await page.locator('[data-testid="fm-archive"]').dispatchEvent("click");
+
+    await expect(archiveBtn.locator(".count")).toHaveText("1");
+  });
+
+  test("Delete on archived row removes it from Archive too", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    await page.locator("#email-inbox-accessor-0").click();
+    await page.locator('[data-testid="fm-archive"]').dispatchEvent("click");
+
+    await page.locator('[data-testid="fm-folder-archive"]').click();
+    await page.locator('[data-testid="fm-archive-card"]').first().click();
+    await page.locator('[data-testid="fm-archive-delete"]').dispatchEvent("click");
+
+    await expect(page.locator('[data-testid="fm-archive-card"]')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 of #47c (Archive folder). Splits Delete from Archive: Archive stashes a local copy in \`mail-local-state\` and removes the message from the inbox contract; Delete removes only. Move-back-to-Inbox is wired into the UI but disabled — true unarchive needs a contract-side OwnerInsert variant, tracked in **#60**.

## Schema

\`AliasState\` gains:

- \`archived: HashMap<String, ArchivedMessage>\` — Inbox messages explicitly archived; keyed by stringified MessageId.
- \`deleted: Vec<MessageId>\` — Inbox message ids explicitly deleted; lets the UI hide rows even when contract eviction has not yet taken effect.

Both fields are \`#[serde(default)]\` so pre-#47c state files load cleanly.

New delegate messages: \`ArchiveMessage\`, \`UnarchiveMessage\`, \`DeleteMessage\`. Archive implies read + drops the kept-locally fallback for the same id; Delete clears kept + archived + read and records the id.

## UI behavior

- **Archive button** (Inbox detail toolbar): stash to local archive + send \`ArchiveMessage\` to the delegate + remove from the inbox contract.
- **Delete button** (Inbox detail toolbar): remove from contract + send \`DeleteMessage\` to the delegate (clears kept + archived + adds to deleted set).
- **Inbox merge** filters archived + deleted ids out client-side so the Inbox folder reflects user intent immediately.
- **Archive folder** renders a list-col + detail-col view. Detail panel toolbar:
  - Reply (recipient = original sender, \`Re:\` subject).
  - Unarchive (disabled — gated on #60).
  - Delete (drops local archive entry too).

## Tests

- **Delegate boundary**: 2 new tests (archived round-trip, missing-archived default). 13/13 pass.
- **Playwright**: 4 new specs × 2 browsers = 8 runs. Covers Archive moves message out of Inbox, Delete leaves no Archive trace, count badge, and archive-detail Delete path. 56/62 pass (6 skipped: live-node + production-liveness, unrelated).

## Out of scope (tracked separately)

- **#60** — inbox contract OwnerInsert variant for true unarchive (re-PUT into contract bypassing AFT, owner ML-DSA signed). Phase 2 of 47c.
- **#58** — per-message delivery ack from inbox contract.
- **47a coverage gaps** (#47 comment) — read-state / kept fallback / draft-across-reload / multi-alias isolation real-node specs.

## Test plan

- [x] \`cargo test -p mail-local-state\` — 13/13 pass.
- [x] \`cargo check -p freenet-email-ui\` (default + offline) — clean.
- [x] \`cargo clippy -p mail-local-state -p freenet-email-ui\` — clean both modes.
- [x] \`cargo make test-ui-playwright\` — 56 passed, 6 skipped.
- [ ] Manual QA against a local node for the round-trip through the real WebSocket bridge.