### PR TITLE
feat(ui): show active identity fingerprint in sidebar (closes #48)

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -826,11 +826,17 @@ fn Sidebar() -> Element {
     let inbox = use_context::<Signal<InboxView>>();
     let emails_snapshot: Vec<Message> = inbox.read().messages.borrow().clone();
     let active = menu_selection.read().folder();
-    let active_alias = user
-        .read()
-        .logged_id()
-        .map(|id| id.alias.to_string())
-        .unwrap_or_default();
+    let (active_alias, active_fp_short) = {
+        let user_ref = user.read();
+        match user_ref.logged_id() {
+            Some(id) => {
+                let words =
+                    address_book::fingerprint_words(&id.ml_dsa_vk_bytes(), &id.ml_kem_ek_bytes());
+                (id.alias.to_string(), format!("{}-{}", words[0], words[1]))
+            }
+            None => (String::new(), String::new()),
+        }
+    };
     // Track local-state generation so Drafts count re-renders when the
     // user types into the compose sheet (autosave bumps `GENERATION`).
     let _local_gen = crate::local_state::GENERATION.load(std::sync::atomic::Ordering::Relaxed);
@@ -879,6 +885,16 @@ fn Sidebar() -> Element {
                             "connection"
                         }
                         span { class: "val", "live" }
+                    }
+                    if !active_fp_short.is_empty() {
+                        div { class: "conn-row",
+                            span { class: "lbl", "key" }
+                            span {
+                                class: "val",
+                                "data-testid": "fm-sidebar-fingerprint",
+                                "{active_fp_short}"
+                            }
+                        }
                     }
                 }
                 button {

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -1073,3 +1073,31 @@ test.describe("Archive folder (#47c)", () => {
     await expect(page.locator('[data-testid="fm-archive-card"]')).toHaveCount(0);
   });
 });
+
+test.describe("Sidebar fingerprint (#48)", () => {
+  test("sidebar shows two-word fingerprint for active identity", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    const fp = page.locator('[data-testid="fm-sidebar-fingerprint"]');
+    await expect(fp).toHaveCount(1);
+    // Two BIP-39 words joined by `-`, lowercase a-z only.
+    await expect(fp).toHaveText(/^[a-z]+-[a-z]+$/);
+  });
+
+  test("fingerprint changes when switching identities", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    const fp = page.locator('[data-testid="fm-sidebar-fingerprint"]');
+    const fpA = await fp.textContent();
+
+    await page.locator('[data-testid="fm-logout"]').click();
+    await selectIdentity(page, "address2");
+
+    const fpB = await fp.textContent();
+    expect(fpA).not.toEqual(fpB);
+  });
+});


### PR DESCRIPTION
## Summary

- Active identity's two-word ML-DSA+ML-KEM fingerprint shows under sidebar Connection card
- Reuses `address_book::fingerprint_words` so all surfaces show identical words
- Pulse dot already wired in CSS; only adds a second `conn-row` with the key

Closes #48.

## Test plan
- [x] `cargo make clippy` clean
- [x] Playwright (chromium + mobile-chrome): both specs green
  - sidebar shows fingerprint matching `[a-z]+-[a-z]+`
  - fingerprint differs between address1 and address2