### PR TITLE
feat(ui+contract): sender signing + verified badge (closes #51)

### DIFF
--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -124,6 +124,15 @@ type EncryptedContent = Vec<u8>;
 pub struct Message {
     pub content: EncryptedContent,
     pub token_assignment: TokenAssignment,
+    /// Sender's ML-DSA-65 verifying key (FIPS 204 encoded, 1952 bytes).
+    /// Empty for legacy unsigned messages — the recipient renders those
+    /// as "unverified" rather than rejecting (#51).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sender_vk: Vec<u8>,
+    /// Detached ML-DSA-65 signature over `content` (the ciphertext blob).
+    /// Verifies before decryption. Empty for legacy unsigned messages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub signature: Vec<u8>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/contracts/inbox/tests/common/mod.rs
+++ b/contracts/inbox/tests/common/mod.rs
@@ -109,6 +109,8 @@ pub fn make_message(content: Vec<u8>, token: TokenAssignment) -> Message {
     Message {
         content,
         token_assignment: token,
+        sender_vk: Vec::new(),
+        signature: Vec::new(),
     }
 }
 

--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -14,6 +14,10 @@
   "fmArchiveCard": "fm-archive-card",
 
   "fmDetailTime": "fm-detail-time",
+  "fmDetailFingerprint": "fm-detail-fingerprint",
+  "fmDetailVerif": "fm-detail-verif",
+  "fmAddToAb": "fm-add-to-ab",
+  "fmComposeSendingAs": "fm-compose-sending-as",
   "fmSidebarFingerprint": "fm-sidebar-fingerprint",
 
   "fmReply": "fm-reply",

--- a/ui/public/vendor/css/components/detail.css
+++ b/ui/public/vendor/css/components/detail.css
@@ -37,6 +37,19 @@
     .from-addr { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--ink3); }
     .from-time { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--ink3); flex: 0 0 auto; }
 
+    /* Per-message signature-verification badge (#51). Three states map
+       to three colour roles: known/verified (trust green), signed-but-
+       unknown (caution amber), unsigned/forged (warning red). */
+    .verif-badge {
+      font-family: "Geist Mono", monospace; font-size: 9px;
+      letter-spacing: 0.04em; text-transform: uppercase;
+      padding: 2px 7px; border-radius: 999px;
+      border: 1px solid currentColor; flex: 0 0 auto;
+    }
+    .verif-known   { color: var(--trust, #226e44); }
+    .verif-unknown { color: var(--caution, #a6731f); }
+    .verif-none    { color: var(--warn, #a32f2f); }
+
     /* TOOLBAR */
     .toolbar {
       display: flex; align-items: center; gap: 8px;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -366,6 +366,8 @@ impl InboxView {
                     content: content.content.clone().into(),
                     read: false,
                     time: content.time,
+                    sender_vk: Vec::new(),
+                    signature_valid: false,
                 };
                 MOCK_SENT_MESSAGES.with(|map| {
                     map.borrow_mut()
@@ -457,6 +459,8 @@ impl InboxView {
                     content: body.clone(),
                     read: false,
                     time: t(15),
+                    sender_vk: Vec::new(),
+                    signature_valid: false,
                 },
                 Message {
                     id: 1,
@@ -465,6 +469,8 @@ impl InboxView {
                     content: body.clone(),
                     read: false,
                     time: t(60 * 26),
+                    sender_vk: Vec::new(),
+                    signature_valid: false,
                 },
                 Message {
                     id: 2,
@@ -473,6 +479,8 @@ impl InboxView {
                     content: body,
                     read: true,
                     time: t(60 * 24 * 4),
+                    sender_vk: Vec::new(),
+                    signature_valid: false,
                 },
             ]
         } else {
@@ -484,6 +492,8 @@ impl InboxView {
                     content: body.clone(),
                     read: false,
                     time: t(35),
+                    sender_vk: Vec::new(),
+                    signature_valid: false,
                 },
                 Message {
                     id: 1,
@@ -492,6 +502,8 @@ impl InboxView {
                     content: body,
                     read: false,
                     time: t(60 * 50),
+                    sender_vk: Vec::new(),
+                    signature_valid: false,
                 },
             ]
         };
@@ -612,6 +624,32 @@ struct Message {
     /// short timestamp + detail-header full timestamp + descending
     /// sort. See issue #49.
     time: chrono::DateTime<chrono::Utc>,
+    /// Sender's ML-DSA-65 verifying key bytes (FIPS 204 encoded). Empty
+    /// for legacy unsigned messages. Used for the per-message verified
+    /// badge + sender-fingerprint surface (#51).
+    sender_vk: Vec<u8>,
+    /// Pure-crypto signature check result. Combined with the address-
+    /// book lookup at render time to produce a `VerificationState`.
+    signature_valid: bool,
+}
+
+impl Message {
+    /// Three-valued verification: combines crypto check + address-book
+    /// trust (#51). Verified-known requires both a signature that
+    /// validates AND an address-book contact whose `verified` flag is
+    /// set; verified-unknown is a valid signature without a verified
+    /// contact; everything else (missing/forged signature) is
+    /// unverified.
+    fn verification_state(&self) -> crate::inbox::VerificationState {
+        use crate::inbox::VerificationState;
+        if !self.signature_valid {
+            return VerificationState::Unverified;
+        }
+        match address_book::contact_by_vk(&self.sender_vk) {
+            Some(c) if c.verified => VerificationState::VerifiedKnown,
+            _ => VerificationState::VerifiedUnknown,
+        }
+    }
 }
 
 impl From<MessageModel> for Message {
@@ -623,6 +661,8 @@ impl From<MessageModel> for Message {
             content: value.content.content.into(),
             read: false,
             time: value.content.time,
+            sender_vk: value.sender_vk,
+            signature_valid: value.signature_valid,
         }
     }
 }
@@ -1079,6 +1119,8 @@ fn MessageList() -> Element {
                     content: kept.content.into(),
                     read: true,
                     time,
+                    sender_vk: Vec::new(),
+                    signature_valid: false,
                 });
             }
             crate::log::debug!("active id: {:?}; emails number: {}", id.alias, emails.len());
@@ -1709,6 +1751,31 @@ fn OpenMessage(msg: Message) -> Element {
     let reply_to = from.clone();
     let reply_subj = format!("Re: {}", title);
     let time_full = format_time_full(msg.time);
+    // Sender trust state (#51) — three-valued: verified-known (sig OK +
+    // contact verified), verified-unknown (sig OK, sender VK not in AB),
+    // unverified (no sig / forged sig). Fingerprint short-form is shown
+    // when the VK is present (i.e. the message was signed).
+    let verification = msg.verification_state();
+    let (verif_class, verif_label) = match verification {
+        crate::inbox::VerificationState::VerifiedKnown => ("verif-badge verif-known", "verified"),
+        crate::inbox::VerificationState::VerifiedUnknown => {
+            ("verif-badge verif-unknown", "signed · unknown sender")
+        }
+        crate::inbox::VerificationState::Unverified => ("verif-badge verif-none", "unverified"),
+    };
+    let sender_fp_short = if msg.sender_vk.is_empty() {
+        String::new()
+    } else {
+        // Address-book fingerprint mixes both VK and EK; for messages
+        // we only have the sender's VK, so use it twice (the message's
+        // unique key here is the VK alone).
+        let words = address_book::fingerprint_words(&msg.sender_vk, &msg.sender_vk);
+        format!("{}-{}", words[0], words[1])
+    };
+    let show_add_to_ab = matches!(
+        verification,
+        crate::inbox::VerificationState::VerifiedUnknown
+    );
 
     let archive_client = client.clone();
     let archive_inbox_data = inbox_data.clone();
@@ -1733,7 +1800,20 @@ fn OpenMessage(msg: Message) -> Element {
                     div { class: "sender-orb", "{from_initial}" }
                     div { class: "from-text",
                         span { class: "from-name", "{from}" }
-                        span { class: "from-addr", "" }
+                        if !sender_fp_short.is_empty() {
+                            span {
+                                class: "from-addr",
+                                "data-testid": testid::FM_DETAIL_FINGERPRINT,
+                                "{sender_fp_short}"
+                            }
+                        } else {
+                            span { class: "from-addr", "" }
+                        }
+                    }
+                    span {
+                        class: "{verif_class}",
+                        "data-testid": testid::FM_DETAIL_VERIF,
+                        "{verif_label}"
                     }
                     span {
                         class: "from-time",
@@ -1743,6 +1823,23 @@ fn OpenMessage(msg: Message) -> Element {
                 }
             }
             div { class: "toolbar",
+                if show_add_to_ab {
+                    button {
+                        class: "btn btn-secondary",
+                        "data-testid": testid::FM_ADD_TO_AB,
+                        onclick: move |_| {
+                            // Stub: opens the existing address-book import
+                            // modal. Pre-filling it with this sender's VK
+                            // is a follow-up — the affordance is wired now
+                            // so the verified-unknown flow has a path
+                            // (#51).
+                            toast.set(Some(
+                                "Open the address book to add this sender".into(),
+                            ));
+                        },
+                        "Add to address book"
+                    }
+                }
                 button {
                     class: "btn btn-primary",
                     "data-testid": testid::FM_REPLY,
@@ -1885,6 +1982,19 @@ fn ComposeSheet() -> Element {
     let mut inbox = use_context::<Signal<InboxView>>();
     let user = use_context::<Signal<User>>();
     let user_alias = user.read().logged_id().unwrap().alias.to_string();
+    // "Sending as <fingerprint>" surface (#51) — shows the user which
+    // ML-DSA key the outgoing message will be signed under.
+    let sender_fp_short = {
+        let user_ref = user.read();
+        match user_ref.logged_id() {
+            Some(id) => {
+                let words =
+                    address_book::fingerprint_words(&id.ml_dsa_vk_bytes(), &id.ml_kem_ek_bytes());
+                format!("{}-{}", words[0], words[1])
+            }
+            None => String::new(),
+        }
+    };
 
     let prefill = menu_selection.write().take_compose_prefill();
     let initial_to = prefill.as_ref().map(|p| p.to.clone()).unwrap_or_default();
@@ -2149,6 +2259,14 @@ fn ComposeSheet() -> Element {
                 div { class: "sheet-field",
                     span { class: "field-lbl", "From" }
                     span { class: "field-input", style: "color:var(--ink2);", "{user_alias}" }
+                    if !sender_fp_short.is_empty() {
+                        span {
+                            class: "from-addr",
+                            style: "margin-left:8px;",
+                            "data-testid": testid::FM_COMPOSE_SENDING_AS,
+                            "Sending as: {sender_fp_short}"
+                        }
+                    }
                 }
                 div { class: "sheet-field",
                     span { class: "field-lbl", "To" }

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -307,6 +307,18 @@ pub fn all_contacts() -> Vec<Contact> {
     })
 }
 
+/// Look up a contact by ML-DSA verifying key (#51 — sender trust). Returns
+/// `None` for unknown VKs and for the user's own identities (which are
+/// stored as `Own` entries, not contacts).
+pub fn contact_by_vk(vk_bytes: &[u8]) -> Option<Contact> {
+    ADDRESS_BOOK.with(|ab| {
+        ab.borrow().values().find_map(|e| match e {
+            Entry::Contact(c) if c.ml_dsa_vk_bytes == vk_bytes => Some(c.clone()),
+            _ => None,
+        })
+    })
+}
+
 /// Check whether a fingerprint matches one of the user's own identities
 /// (used to reject self-import during contact import).
 pub fn is_own_fingerprint(vk_bytes: &[u8], ek_bytes: &[u8]) -> bool {

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use futures::FutureExt;
 use futures::future::LocalBoxFuture;
 use ml_dsa::{
-    MlDsa65, SigningKey as MlDsaSigningKey, VerifyingKey as MlDsaVerifyingKey,
-    signature::{Keypair as MlDsaKeypair, Signer as MlDsaSigner},
+    EncodedVerifyingKey, MlDsa65, SigningKey as MlDsaSigningKey, VerifyingKey as MlDsaVerifyingKey,
+    signature::{Keypair as MlDsaKeypair, Signer as MlDsaSigner, Verifier as MlDsaVerifier},
 };
 use ml_kem::{
     DecapsulationKey, EncapsulationKey, MlKem768,
@@ -79,8 +79,30 @@ pub(crate) fn inbox_key_for(
     ContractKey::from_params(INBOX_CODE_HASH, params).map_err(|e| format!("{e}").into())
 }
 
+/// Verify a detached ML-DSA-65 signature over `ciphertext` using the
+/// sender's encoded verifying key. Returns `false` for empty / wrong-
+/// length / cryptographically-invalid inputs (the recipient renders
+/// these as "unverified" rather than rejecting; #51).
+pub(crate) fn verify_message_signature(
+    ciphertext: &[u8],
+    sender_vk: &[u8],
+    signature: &[u8],
+) -> bool {
+    if sender_vk.is_empty() || signature.is_empty() {
+        return false;
+    }
+    let Ok(encoded_vk): Result<EncodedVerifyingKey<MlDsa65>, _> = sender_vk.try_into() else {
+        return false;
+    };
+    let vk = MlDsaVerifyingKey::<MlDsa65>::decode(&encoded_vk);
+    let Ok(sig) = ml_dsa::Signature::<MlDsa65>::try_from(signature) else {
+        return false;
+    };
+    MlDsaVerifier::verify(&vk, ciphertext, &sig).is_ok()
+}
+
 thread_local! {
-    static PENDING_INBOXES_UPDATE: RefCell<HashMap<InboxContract, Vec<DecryptedMessage>>> = RefCell::new(HashMap::new());
+    static PENDING_INBOXES_UPDATE: RefCell<HashMap<InboxContract, Vec<PendingOutgoing>>> = RefCell::new(HashMap::new());
     static INBOX_TO_ID: RefCell<HashMap<InboxContract, Identity>> =
         RefCell::new(HashMap::new());
     /// Outgoing messages awaiting an `UpdateResponse` from the recipient's
@@ -146,6 +168,14 @@ pub(crate) fn remove_pending_sent_ack(
     });
 }
 
+/// Outgoing message awaiting an AFT token assignment. Holds the sender
+/// identity so we can sign the ciphertext with the sender's ML-DSA-65
+/// signing key when the assignment lands (#51).
+struct PendingOutgoing {
+    msg: DecryptedMessage,
+    sender: Identity,
+}
+
 #[derive(Debug, Clone)]
 struct InternalSettings {
     /// This id is used for internal handling of the inbox and is not persistent
@@ -198,11 +228,37 @@ impl InternalSettings {
     }
 }
 
+/// Per-message signature-verification state (#51). Combines a pure
+/// crypto check (sig validates against `sender_vk`) with an address-book
+/// lookup (does the user trust this VK).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum VerificationState {
+    /// Signature verified AND `sender_vk` matches a contact the user has
+    /// flagged as verified.
+    VerifiedKnown,
+    /// Signature verified, but the sender VK is unknown to the address
+    /// book (or known-unverified).
+    VerifiedUnknown,
+    /// Signature missing, malformed, or fails to verify.
+    #[default]
+    Unverified,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct MessageModel {
     pub id: u64,
     pub content: DecryptedMessage,
     pub token_assignment: TokenAssignment,
+    /// Sender's ML-DSA-65 verifying key bytes. Empty for legacy messages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sender_vk: Vec<u8>,
+    /// Pure-crypto verification: sig validates against `sender_vk` over
+    /// the ciphertext blob. Address-book trust is layered on top at
+    /// render time. The address-book lookup is fast (HashMap) so we
+    /// don't cache a `VerificationState` here — see `verification_state`
+    /// in the UI render path.
+    #[serde(default)]
+    pub signature_valid: bool,
 }
 
 impl MessageModel {
@@ -214,6 +270,11 @@ impl MessageModel {
         Ok::<_, DynError>(StoredMessage {
             content,
             token_assignment: self.token_assignment.clone(),
+            // Re-encryption path doesn't have access to the original
+            // sender's signing key. Empty sig = recipient renders as
+            // "unverified" (#51). The to_state path isn't wired up yet.
+            sender_vk: Vec::new(),
+            signature: Vec::new(),
         })
     }
 
@@ -240,8 +301,9 @@ impl MessageModel {
         });
 
         if let Some(update) = pending_update {
+            let stored = update.msg.to_stored(assignment, &update.sender)?;
             let delta = UpdateInbox::AddMessages {
-                messages: vec![update.to_stored(assignment)?],
+                messages: vec![stored],
             };
             let request = ContractRequest::Update {
                 key: inbox_contract,
@@ -317,17 +379,37 @@ impl DecryptedMessage {
 
         PENDING_INBOXES_UPDATE.with(|map| {
             let map = &mut *map.borrow_mut();
-            map.entry(inbox_key).or_insert_with(Vec::new).push(self);
+            map.entry(inbox_key)
+                .or_insert_with(Vec::new)
+                .push(PendingOutgoing {
+                    msg: self,
+                    sender: from.clone(),
+                });
         });
         let _ = recipient_ek; // ek is used inside to_stored via pending queue
         Ok(())
     }
 
-    fn to_stored(&self, token_assignment: TokenAssignment) -> Result<StoredMessage, DynError> {
+    fn to_stored(
+        &self,
+        token_assignment: TokenAssignment,
+        sender: &Identity,
+    ) -> Result<StoredMessage, DynError> {
+        use ml_dsa::signature::Keypair;
         let (_, content) = self.assignment_hash_and_signed_content()?;
+        // Detached ML-DSA-65 signature over the ciphertext (#51). The
+        // recipient verifies before decrypting; sender VK is sent
+        // alongside so the recipient can both verify and recognise the
+        // sender even if the address book has never seen this key.
+        let signing_key = sender.ml_dsa_signing_key.as_ref();
+        let sig: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(signing_key, &content);
+        let signature = sig.encode().to_vec();
+        let sender_vk = signing_key.verifying_key().encode().to_vec();
         Ok::<_, DynError>(StoredMessage {
             content,
             token_assignment,
+            sender_vk,
+            signature,
         })
     }
 
@@ -616,7 +698,12 @@ impl InboxModel {
                 .iter()
                 .any(|c| c.content.time == m.content.time)
             {
-                self.add_received_message(m.content, m.token_assignment);
+                self.add_received_message(
+                    m.content,
+                    m.token_assignment,
+                    m.sender_vk,
+                    m.signature_valid,
+                );
             }
         }
     }
@@ -658,10 +745,14 @@ impl InboxModel {
             .enumerate()
             .map(|(id, msg)| {
                 let content = DecryptedMessage::from_stored(&ml_kem_dk, msg.content.clone());
+                let signature_valid =
+                    verify_message_signature(&msg.content, &msg.sender_vk, &msg.signature);
                 Ok(MessageModel {
                     id: id as u64,
                     content,
                     token_assignment: msg.token_assignment.clone(),
+                    sender_vk: msg.sender_vk.clone(),
+                    signature_valid,
                 })
             })
             .collect::<Result<Vec<_>, DynError>>()?;
@@ -681,11 +772,15 @@ impl InboxModel {
         &mut self,
         content: DecryptedMessage,
         token_assignment: TokenAssignment,
+        sender_vk: Vec<u8>,
+        signature_valid: bool,
     ) {
         self.messages.push(MessageModel {
             id: self.settings.next_msg_id,
             content,
             token_assignment,
+            sender_vk,
+            signature_valid,
         });
         self.settings.next_msg_id += 1;
     }
@@ -799,6 +894,8 @@ mod tests {
                 id,
                 content: DecryptedMessage::default(),
                 token_assignment: crate::test_util::test_assignment(),
+                sender_vk: Vec::new(),
+                signature_valid: false,
             });
         }
         let t0 = std::time::Instant::now();
@@ -806,5 +903,58 @@ mod tests {
             inbox.remove_received_message(&[id]);
         }
         eprintln!("{}ms", t0.elapsed().as_millis());
+    }
+
+    fn fresh_signing_key() -> MlDsaSigningKey<MlDsa65> {
+        MlDsa65::from_seed(&rand::random::<[u8; 32]>().into())
+    }
+
+    #[test]
+    fn verify_signature_round_trip() {
+        let sk = fresh_signing_key();
+        let ciphertext = b"opaque encrypted payload".to_vec();
+        let sig: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(&sk, &ciphertext);
+        let sig_bytes = sig.encode().to_vec();
+        let vk_bytes = MlDsaKeypair::verifying_key(&sk).encode().to_vec();
+        assert!(verify_message_signature(&ciphertext, &vk_bytes, &sig_bytes));
+    }
+
+    #[test]
+    fn verify_rejects_tampered_ciphertext() {
+        let sk = fresh_signing_key();
+        let ciphertext = b"original payload".to_vec();
+        let sig: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(&sk, &ciphertext);
+        let sig_bytes = sig.encode().to_vec();
+        let vk_bytes = MlDsaKeypair::verifying_key(&sk).encode().to_vec();
+        let tampered = b"different payload".to_vec();
+        assert!(!verify_message_signature(&tampered, &vk_bytes, &sig_bytes));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_vk() {
+        let sk1 = fresh_signing_key();
+        let sk2 = fresh_signing_key();
+        let ciphertext = b"payload".to_vec();
+        let sig: ml_dsa::Signature<MlDsa65> = MlDsaSigner::sign(&sk1, &ciphertext);
+        let sig_bytes = sig.encode().to_vec();
+        let vk2_bytes = MlDsaKeypair::verifying_key(&sk2).encode().to_vec();
+        assert!(!verify_message_signature(
+            &ciphertext,
+            &vk2_bytes,
+            &sig_bytes
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_empty_inputs() {
+        assert!(!verify_message_signature(b"x", &[], &[1, 2, 3]));
+        assert!(!verify_message_signature(b"x", &[1, 2, 3], &[]));
+        assert!(!verify_message_signature(b"x", &[], &[]));
+    }
+
+    #[test]
+    fn verify_rejects_garbage_lengths() {
+        // Wrong-length VK and signature bytes both bail out cleanly.
+        assert!(!verify_message_signature(b"x", &[0u8; 5], &[0u8; 5]));
     }
 }

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -33,6 +33,10 @@ pub(crate) const FM_ARCHIVE_CARD: &str = "fm-archive-card";
 
 // Detail header
 pub(crate) const FM_DETAIL_TIME: &str = "fm-detail-time";
+pub(crate) const FM_DETAIL_FINGERPRINT: &str = "fm-detail-fingerprint";
+pub(crate) const FM_DETAIL_VERIF: &str = "fm-detail-verif";
+pub(crate) const FM_ADD_TO_AB: &str = "fm-add-to-ab";
+pub(crate) const FM_COMPOSE_SENDING_AS: &str = "fm-compose-sending-as";
 
 // Sidebar
 pub(crate) const FM_SIDEBAR_FINGERPRINT: &str = "fm-sidebar-fingerprint";
@@ -116,6 +120,10 @@ mod tests {
             ("fmSentCard", super::FM_SENT_CARD),
             ("fmArchiveCard", super::FM_ARCHIVE_CARD),
             ("fmDetailTime", super::FM_DETAIL_TIME),
+            ("fmDetailFingerprint", super::FM_DETAIL_FINGERPRINT),
+            ("fmDetailVerif", super::FM_DETAIL_VERIF),
+            ("fmAddToAb", super::FM_ADD_TO_AB),
+            ("fmComposeSendingAs", super::FM_COMPOSE_SENDING_AS),
             ("fmSidebarFingerprint", super::FM_SIDEBAR_FINGERPRINT),
             ("fmReply", super::FM_REPLY),
             ("fmDelete", super::FM_DELETE),

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -1109,6 +1109,35 @@ test.describe("Message timestamps (#49)", () => {
   });
 });
 
+test.describe("Sender trust badge (#51)", () => {
+  test("detail header shows verified badge for incoming message", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+    await page.locator("#email-inbox-accessor-0").click();
+
+    // example-data messages are unsigned (no real send path), so they
+    // render as "unverified". The badge surface is what matters here.
+    const badge = page.locator('[data-testid="fm-detail-verif"]');
+    await expect(badge).toHaveCount(1);
+    await expect(badge).toContainText("unverified");
+  });
+
+  test("compose sheet shows 'Sending as: <fingerprint>' label", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+    await page.locator('[data-testid="fm-compose-btn"]').click();
+
+    const label = page.locator('[data-testid="fm-compose-sending-as"]');
+    await expect(label).toHaveCount(1);
+    // "Sending as: <two-word fingerprint>".
+    await expect(label).toHaveText(/^Sending as: [a-z]+-[a-z]+$/);
+  });
+});
+
 test.describe("Sidebar fingerprint (#48)", () => {
   test("sidebar shows two-word fingerprint for active identity", async ({ page }) => {
     await page.goto("/");


### PR DESCRIPTION
## Summary

Adds detached ML-DSA-65 signatures to the inbox wire format so recipients can verify sender authenticity before decryption.

- Inbox `Message` gains optional `sender_vk` + `signature` (`#[serde(default)]`); legacy unsigned messages render as "unverified" instead of being rejected
- Sender's `Identity` is stashed in the pending-AFT queue so `to_stored` can sign the ciphertext when the token assignment lands
- Three-valued `VerificationState` (verified-known / verified-unknown / unverified) computed at render time — combines a pure-crypto check with `address_book::contact_by_vk` lookup
- Detail header gains a verified badge (green/amber/red) + sender fingerprint short-form; verified-unknown sender gets an inline "Add to address book" button (stub)
- Compose sheet shows "Sending as: <fingerprint>"

Closes #51.

## Test plan
- [x] `cargo make clippy` clean
- [x] 5 unit tests for `verify_message_signature` (round trip, tampered ciphertext, wrong VK, empty inputs, garbage lengths)
- [x] `cargo make test-inbox` — 8 contract integration tests pass after wiring the two new optional fields into `make_message`
- [x] Playwright (chromium + mobile-chrome) full suite: 72 passed
  - detail header renders verified badge
  - compose shows `Sending as: [a-z]+-[a-z]+`

## Out of scope (follow-ups)
- Spoof-check on list cards (display-name vs VK mismatch)
- AB import pre-fill from inbox detail
- Search across all fingerprint forms / AB labels