### PR TITLE
feat(ui): widen fingerprint to 3 words, hover for full 6 (closes #75)

### DIFF
--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -116,6 +116,11 @@ pub struct SentMessage {
     /// Short fingerprint of the recipient's verifying key at send time.
     /// Stored so the Sent UI can show trust info without a contact-book lookup.
     pub recipient_fingerprint: String,
+    /// Full six-word fingerprint of the recipient. Empty for legacy rows
+    /// written before this field existed; UI must fall back to the short
+    /// form for hover/tooltip in that case.
+    #[serde(default)]
+    pub recipient_fingerprint_full: String,
     pub subject: String,
     pub body: String,
     /// Unix millis at send-button click time.
@@ -638,6 +643,7 @@ mod boundary_tests {
             SentMessage {
                 to: "bob".into(),
                 recipient_fingerprint: "AB12".into(),
+                recipient_fingerprint_full: "AB12-CD34-EF56".into(),
                 subject: "hi".into(),
                 body: "yo".into(),
                 sent_at: 42,

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -972,15 +972,19 @@ fn Sidebar() -> Element {
     let inbox = use_context::<Signal<InboxView>>();
     let emails_snapshot: Vec<Message> = inbox.read().messages.borrow().clone();
     let active = menu_selection.read().folder();
-    let (active_alias, active_fp_short) = {
+    let (active_alias, active_fp_short, active_fp_full) = {
         let user_ref = user.read();
         match user_ref.logged_id() {
             Some(id) => {
                 let words =
                     address_book::fingerprint_words(&id.ml_dsa_vk_bytes(), &id.ml_kem_ek_bytes());
-                (id.alias.to_string(), format!("{}-{}", words[0], words[1]))
+                (
+                    id.alias.to_string(),
+                    format!("{}-{}-{}", words[0], words[1], words[2]),
+                    words.join("-"),
+                )
             }
-            None => (String::new(), String::new()),
+            None => (String::new(), String::new(), String::new()),
         }
     };
     // Track local-state generation so Drafts count re-renders when the
@@ -1038,6 +1042,7 @@ fn Sidebar() -> Element {
                             span {
                                 class: "val",
                                 "data-testid": testid::FM_SIDEBAR_FINGERPRINT,
+                                title: "{active_fp_full}",
                                 "{active_fp_short}"
                             }
                         }
@@ -1589,6 +1594,11 @@ fn OpenSentMessage(msg: mail_local_state::SentMessage) -> Element {
     let subject = msg.subject.clone();
     let body = msg.body.clone();
     let fingerprint = msg.recipient_fingerprint.clone();
+    let fingerprint_full = if msg.recipient_fingerprint_full.is_empty() {
+        msg.recipient_fingerprint.clone()
+    } else {
+        msg.recipient_fingerprint_full.clone()
+    };
     let time_full = chrono::DateTime::from_timestamp_millis(msg.sent_at)
         .map(format_time_full)
         .unwrap_or_default();
@@ -1631,6 +1641,7 @@ fn OpenSentMessage(msg: mail_local_state::SentMessage) -> Element {
                         span {
                             class: "from-addr",
                             "data-testid": testid::FM_SENT_FINGERPRINT,
+                            title: "{fingerprint_full}",
                             "fingerprint: {fingerprint}"
                         }
                     }
@@ -1763,14 +1774,17 @@ fn OpenMessage(msg: Message) -> Element {
         }
         crate::inbox::VerificationState::Unverified => ("verif-badge verif-none", "unverified"),
     };
-    let sender_fp_short = if msg.sender_vk.is_empty() {
-        String::new()
+    let (sender_fp_short, sender_fp_full) = if msg.sender_vk.is_empty() {
+        (String::new(), String::new())
     } else {
         // Address-book fingerprint mixes both VK and EK; for messages
         // we only have the sender's VK, so use it twice (the message's
         // unique key here is the VK alone).
         let words = address_book::fingerprint_words(&msg.sender_vk, &msg.sender_vk);
-        format!("{}-{}", words[0], words[1])
+        (
+            format!("{}-{}-{}", words[0], words[1], words[2]),
+            words.join("-"),
+        )
     };
     let show_add_to_ab = matches!(
         verification,
@@ -1804,6 +1818,7 @@ fn OpenMessage(msg: Message) -> Element {
                             span {
                                 class: "from-addr",
                                 "data-testid": testid::FM_DETAIL_FINGERPRINT,
+                                title: "{sender_fp_full}",
                                 "{sender_fp_short}"
                             }
                         } else {
@@ -1984,15 +1999,18 @@ fn ComposeSheet() -> Element {
     let user_alias = user.read().logged_id().unwrap().alias.to_string();
     // "Sending as <fingerprint>" surface (#51) — shows the user which
     // ML-DSA key the outgoing message will be signed under.
-    let sender_fp_short = {
+    let (sender_fp_short, sender_fp_full) = {
         let user_ref = user.read();
         match user_ref.logged_id() {
             Some(id) => {
                 let words =
                     address_book::fingerprint_words(&id.ml_dsa_vk_bytes(), &id.ml_kem_ek_bytes());
-                format!("{}-{}", words[0], words[1])
+                (
+                    format!("{}-{}-{}", words[0], words[1], words[2]),
+                    words.join("-"),
+                )
             }
-            None => String::new(),
+            None => (String::new(), String::new()),
         }
     };
 
@@ -2191,6 +2209,7 @@ fn ComposeSheet() -> Element {
             let sent = mail_local_state::SentMessage {
                 to: to_val.clone(),
                 recipient_fingerprint: recipient.fingerprint_short(),
+                recipient_fingerprint_full: recipient.fingerprint_full(),
                 subject: title_val.clone(),
                 body: content_val.clone(),
                 sent_at: chrono::Utc::now().timestamp_millis(),
@@ -2264,6 +2283,7 @@ fn ComposeSheet() -> Element {
                             class: "from-addr",
                             style: "margin-left:8px;",
                             "data-testid": testid::FM_COMPOSE_SENDING_AS,
+                            title: "{sender_fp_full}",
                             "Sending as: {sender_fp_short}"
                         }
                     }
@@ -2289,6 +2309,7 @@ fn ComposeSheet() -> Element {
                                 ("badge badge-warn", "unverified")
                             };
                         let fp_short = r.fingerprint_short();
+                        let fp_full = r.fingerprint_full();
                         rsx! {
                             div { class: "sheet-recipient-badge", "data-testid": "compose-recipient-badge",
                                 span {
@@ -2299,6 +2320,7 @@ fn ComposeSheet() -> Element {
                                 span {
                                     class: "badge-fp",
                                     "data-testid": "compose-recipient-fingerprint",
+                                    title: "{fp_full}",
                                     "fingerprint: {fp_short}"
                                 }
                             }

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -121,7 +121,12 @@ impl ContactCard {
     #[allow(dead_code)]
     pub fn fingerprint_short(&self) -> String {
         let fp = self.fingerprint();
-        format!("{}-{}", fp[0], fp[1])
+        format!("{}-{}-{}", fp[0], fp[1], fp[2])
+    }
+
+    #[allow(dead_code)]
+    pub fn fingerprint_full(&self) -> String {
+        self.fingerprint().join("-")
     }
 }
 
@@ -145,7 +150,11 @@ impl Contact {
 
     pub fn fingerprint_short(&self) -> String {
         let fp = self.fingerprint();
-        format!("{}-{}", fp[0], fp[1])
+        format!("{}-{}-{}", fp[0], fp[1], fp[2])
+    }
+
+    pub fn fingerprint_full(&self) -> String {
+        self.fingerprint().join("-")
     }
 }
 
@@ -172,10 +181,17 @@ pub struct Recipient {
 }
 
 impl Recipient {
-    /// First two fingerprint words joined with `-`. Cheap disambiguator
-    /// shown in the compose picker.
+    /// First three fingerprint words joined with `-`. Compact disambiguator
+    /// shown in the compose picker; hover for full six-word value.
     pub fn fingerprint_short(&self) -> String {
-        format!("{}-{}", self.fingerprint[0], self.fingerprint[1])
+        format!(
+            "{}-{}-{}",
+            self.fingerprint[0], self.fingerprint[1], self.fingerprint[2]
+        )
+    }
+
+    pub fn fingerprint_full(&self) -> String {
+        self.fingerprint.join("-")
     }
 }
 
@@ -538,7 +554,7 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_short_returns_first_two_words_joined() {
+    fn fingerprint_short_returns_first_three_words_joined() {
         let card = ContactCard {
             version: 1,
             ml_dsa_vk_bytes: vec![17; 1952],
@@ -547,7 +563,11 @@ mod tests {
             suggested_description: None,
         };
         let fp = card.fingerprint();
-        assert_eq!(card.fingerprint_short(), format!("{}-{}", fp[0], fp[1]));
+        assert_eq!(
+            card.fingerprint_short(),
+            format!("{}-{}-{}", fp[0], fp[1], fp[2])
+        );
+        assert_eq!(card.fingerprint_full(), fp.join("-"));
     }
 
     #[test]

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -1569,6 +1569,7 @@ fn ContactsSection() -> Element {
                     {
                         let alias_str = contact.local_alias.to_string();
                         let fp_short = contact.fingerprint_short();
+                        let fp_full = contact.fingerprint_full();
                         let del_alias = alias_str.clone();
                         let verified = contact.verified;
                         let description = contact.description.clone();
@@ -1583,6 +1584,7 @@ fn ContactsSection() -> Element {
                                     }
                                     span { class: "contact-fp",
                                         "data-testid": "contact-fingerprint",
+                                        title: "{fp_full}",
                                         "{fp_short}"
                                     }
                                 }

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -448,7 +448,8 @@ test.describe("Address book: import contact and display", () => {
       .locator(".verify-word .w")
       .allTextContents();
     expect(fingerprintWords).toHaveLength(6);
-    const fingerprintShort = `${fingerprintWords[0]}-${fingerprintWords[1]}`;
+    const fingerprintShort = `${fingerprintWords[0]}-${fingerprintWords[1]}-${fingerprintWords[2]}`;
+    const fingerprintFull = fingerprintWords.join("-");
 
     // ── Step 4: complete import and verify contact appears ────────────────
     await page.locator('[data-testid="fm-import-submit"]').click();
@@ -465,6 +466,9 @@ test.describe("Address book: import contact and display", () => {
     await expect(
       contactRow.locator('[data-testid="contact-fingerprint"]'),
     ).toContainText(fingerprintShort);
+    await expect(
+      contactRow.locator('[data-testid="contact-fingerprint"]'),
+    ).toHaveAttribute("title", fingerprintFull);
 
     await expect(
       contactRow.locator('[data-testid="contact-verify-badge"]'),
@@ -1133,21 +1137,31 @@ test.describe("Sender trust badge (#51)", () => {
 
     const label = page.locator('[data-testid="fm-compose-sending-as"]');
     await expect(label).toHaveCount(1);
-    // "Sending as: <two-word fingerprint>".
-    await expect(label).toHaveText(/^Sending as: [a-z]+-[a-z]+$/);
+    // "Sending as: <three-word fingerprint>".
+    await expect(label).toHaveText(/^Sending as: [a-z]+-[a-z]+-[a-z]+$/);
+    // Tooltip exposes the full six-word fingerprint.
+    await expect(label).toHaveAttribute(
+      "title",
+      /^[a-z]+-[a-z]+-[a-z]+-[a-z]+-[a-z]+-[a-z]+$/,
+    );
   });
 });
 
 test.describe("Sidebar fingerprint (#48)", () => {
-  test("sidebar shows two-word fingerprint for active identity", async ({ page }) => {
+  test("sidebar shows three-word fingerprint for active identity", async ({ page }) => {
     await page.goto("/");
     await waitForApp(page);
     await selectIdentity(page, "address1");
 
     const fp = page.locator('[data-testid="fm-sidebar-fingerprint"]');
     await expect(fp).toHaveCount(1);
-    // Two BIP-39 words joined by `-`, lowercase a-z only.
-    await expect(fp).toHaveText(/^[a-z]+-[a-z]+$/);
+    // Three BIP-39 words joined by `-`, lowercase a-z only.
+    await expect(fp).toHaveText(/^[a-z]+-[a-z]+-[a-z]+$/);
+    // Hover tooltip carries the full six-word fingerprint.
+    await expect(fp).toHaveAttribute(
+      "title",
+      /^[a-z]+-[a-z]+-[a-z]+-[a-z]+-[a-z]+-[a-z]+$/,
+    );
   });
 
   test("fingerprint changes when switching identities", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Default fingerprint disambiguator widens from 2 → 3 BIP-39 words across every short-form render site (sent card, compose recipient picker, compose "Sending as", sidebar own-identity, inbox detail sender, contacts list).
- Each short-form render gains a `title` attribute carrying the full six-word fingerprint, so desktop users can hover to verify without opening the identity-detail screens.
- `SentMessage` gains additive `recipient_fingerprint_full: String` (`#[serde(default)]`). Legacy rows keep deserialising and the hover falls back to the stored short form when the new field is empty.

Closes #75.

## Test plan

- [x] `cargo test -p mail-local-state` — 13 tests pass (round-trip covers new field).
- [x] `cargo test -p freenet-email-ui --lib` — 25 tests pass; `fingerprint_short_returns_first_three_words_joined` covers both `fingerprint_short` and new `fingerprint_full`.
- [x] `cargo make clippy` — clean.
- [x] `cargo check -p freenet-email-ui --target wasm32-unknown-unknown` — clean.
- [ ] Playwright sidebar + sending-as + contact-import tests — assertions updated for 3-word render + 6-word `title` tooltip; CI to validate across the 5 browser profiles.