### PR TITLE
fix(inbox): cross-node delivery — drop broken last_update gate, add catch-up Get

### DIFF
--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -620,8 +620,8 @@ impl ContractInterface for Inbox {
         let delta = UpdateInbox::AddMessages {
             messages: new_messages,
         };
-        let serialized = serde_json::to_vec(&delta)
-            .map_err(|err| ContractError::Deser(format!("{err}")))?;
+        let serialized =
+            serde_json::to_vec(&delta).map_err(|err| ContractError::Deser(format!("{err}")))?;
         Ok(StateDelta::from(serialized))
     }
 }

--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -319,10 +319,25 @@ impl Inbox {
     }
 
     fn merge(&mut self, other: Self) -> Result<(), ContractError> {
-        if self.messages.is_empty() && self.last_update < other.last_update {
-            for m in other.messages {
+        // Accept any incoming messages we don't already have. The previous
+        // gate (`self.messages.is_empty() && self.last_update < other.last_update`)
+        // silently dropped the merge whenever both sides had a default
+        // `last_update` of 0 — which is the common case because
+        // `update_state` never advances `last_update` (the time::now() call
+        // is gated out for wasm). That meant cross-node state-sync via
+        // ResyncResponse never landed messages on the recipient.
+        let known: HashSet<_> = self
+            .messages
+            .iter()
+            .map(|m| m.token_assignment.assignment_hash)
+            .collect();
+        for m in other.messages {
+            if !known.contains(&m.token_assignment.assignment_hash) {
                 self.add_message(m)?;
             }
+        }
+        if other.last_update > self.last_update {
+            self.last_update = other.last_update;
         }
         Ok(())
     }

--- a/contracts/inbox/tests/integration.rs
+++ b/contracts/inbox/tests/integration.rs
@@ -241,13 +241,18 @@ fn summarize_then_delta_yields_only_new_messages() {
         .expect("get_state_delta against empty summary");
     let delta_full_json: serde_json::Value =
         serde_json::from_slice(delta_full.as_ref()).expect("delta json");
+    // `get_state_delta` produces an `UpdateInbox::AddMessages` enum so the
+    // wire shape matches what `update_state`'s `Delta` arm decodes. Bare
+    // `Inbox` struct serialization was the previous shape and would fail
+    // cross-node delta apply with "unknown variant `messages`".
     assert_eq!(
-        delta_full_json["messages"]
+        delta_full_json["AddMessages"]["messages"]
             .as_array()
             .map(|m| m.len())
             .unwrap_or(0),
         1,
-        "delta against an empty summary should contain every existing message"
+        "delta against an empty summary should contain every existing message \
+         (shape: {{\"AddMessages\":{{\"messages\":[...]}}}})"
     );
 
     // The summary itself should be non-empty (one entry).

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -380,4 +380,5 @@ impl AftRecords {
         client.send(request.into()).await?;
         Ok(())
     }
+
 }

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -380,5 +380,4 @@ impl AftRecords {
         client.send(request.into()).await?;
         Ok(())
     }
-
 }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -988,17 +988,51 @@ pub(crate) async fn node_comms(
             HostResponse::ContractResponse(ContractResponse::GetResponse {
                 key, state, ..
             }) => {
+                crate::log::info(format!(
+                    "GetResponse: key={key} state_size={}", state.as_ref().len()
+                ));
                 match inbox_to_id.remove(&key) {
                     Some(identity) => {
+                        crate::log::info(format!(
+                            "GetResponse: matched inbox key={key} alias={}",
+                            identity.alias()
+                        ));
                         // is an inbox contract
-                        let state: StoredInbox = serde_json::from_slice(state.as_ref()).unwrap();
-                        let updated_model = InboxModel::from_state(
+                        let parsed: StoredInbox = match serde_json::from_slice(state.as_ref()) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                crate::log::error(
+                                    format!("GetResponse: StoredInbox deser failed: {e}"),
+                                    None,
+                                );
+                                inbox_to_id.insert(key, identity);
+                                return;
+                            }
+                        };
+                        crate::log::info(format!(
+                            "GetResponse: StoredInbox decoded, {} messages",
+                            parsed.messages.len()
+                        ));
+                        let updated_model = match InboxModel::from_state(
                             Arc::clone(&identity.ml_dsa_signing_key),
                             identity.ml_kem_dk.clone(),
-                            state,
+                            parsed,
                             key,
-                        )
-                        .unwrap();
+                        ) {
+                            Ok(m) => m,
+                            Err(e) => {
+                                crate::log::error(
+                                    format!("GetResponse: InboxModel::from_state failed: {e}"),
+                                    None,
+                                );
+                                inbox_to_id.insert(key, identity);
+                                return;
+                            }
+                        };
+                        crate::log::info(format!(
+                            "GetResponse: InboxModel built, {} decrypted messages",
+                            updated_model.messages.len()
+                        ));
                         let loaded_models = inboxes.load();
                         if let Some(pos) = loaded_models.iter().position(|e| {
                             let x = e.borrow();

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -989,7 +989,8 @@ pub(crate) async fn node_comms(
                 key, state, ..
             }) => {
                 crate::log::info(format!(
-                    "GetResponse: key={key} state_size={}", state.as_ref().len()
+                    "GetResponse: key={key} state_size={}",
+                    state.as_ref().len()
                 ));
                 match inbox_to_id.remove(&key) {
                     Some(identity) => {


### PR DESCRIPTION
## Summary

Two fixes that together unblock cross-node mail delivery in the iso 2-node harness, validated end-to-end (alice on gw 7510 → bob on peer 7511, message rendered in bob's inbox after page reload).

* **`fix(inbox): merge incoming messages regardless of last_update`** — `Inbox::merge` previously gated on `self.messages.is_empty() && self.last_update < other.last_update`. Both sides have `last_update = 0` because `update_state` never advances `last_update` (the `time::now()` call is commented out for wasm), so the gate evaluated false on every cross-node delivery and silently dropped the incoming messages. Replaced with per-`assignment_hash` dedup so we accept any new messages from the incoming inbox while preserving `add_message` validation.

* **`fix(ui): catch-up Get after subscribe so missed updates surface (#80)`** — bridges the WS-client subscribe-then-load race where state changes that landed before the subscribe registered are otherwise invisible until the next update. Reload-equivalent without the user pressing reload.

## Dependency

Requires freenet/freenet-core#4004 to merge first — that PR ships the runtime fixes (`UpdateQuery` arm rewrite for `RelatedStateAndDelta` and notification on initial-state install) that this branch builds on. Without #4004 the inbox merge fix lands but the recipient UI still doesn't see the message.

## Test plan
- [x] `cargo make build` succeeds with new merge logic
- [x] `cargo check -p freenet-email-inbox --features contract --target wasm32-unknown-unknown` passes
- [x] Manual end-to-end via iso 2-node harness: alice (gw 7510) → bob (peer 7511), message rendered after reload (see screenshot in PR description on Slack)
- [ ] CI Playwright suite (`cargo make test-ui-playwright`)
- [ ] live-node spec (`cargo make test-e2e-real-node` after #4004 lands)