### PR TITLE
cleanup(ui): drop RelatedStateAndDelta inline-bundle workaround (closes #80)

### DIFF
--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -119,14 +119,6 @@ impl AftRecords {
         })
     }
 
-    /// Returns the locally-cached AFT record state for the given identity, if any.
-    /// Used by `MessageModel::finish_sending` to bundle the sender's AFT
-    /// record state alongside the inbox UPDATE delta as `RelatedStateAndDelta`,
-    /// bypassing the runtime's broken RequestRelated orchestration (#80).
-    pub fn record_state_for(identity: &Identity) -> Option<TokenAllocationRecord> {
-        RECORDS.with(|recs| recs.borrow().get(identity).cloned())
-    }
-
     pub async fn confirm_allocation(
         client: &mut WebApiRequestClient,
         aft_record: AftRecordId,
@@ -151,11 +143,13 @@ impl AftRecords {
             return Ok(());
         };
         // Optimistically append the freshly-minted assignment to the local
-        // RECORDS cache so `MessageModel::finish_sending` can bundle the
-        // post-burn state inline with the inbox UPDATE as
-        // `RelatedStateAndDelta` (see freenet/mail#80). Without this the
-        // local cache still reflects the pre-burn state and the receiving
-        // inbox contract sees an empty AFT record, rejecting the message.
+        // RECORDS cache so subsequent local reads (e.g. UI counters of
+        // remaining tokens, dev-mode introspection) reflect the post-burn
+        // state without having to wait for the AFT contract update to
+        // round-trip back through SubscribeResponse. Cross-node delivery
+        // does not depend on this cache anymore — runtime PR #4007 lets
+        // the inbox contract's `update_state` requires(AFT) signal resolve
+        // via `fetch_related_via_network` on the receiver side.
         if let Some(sender) = sender {
             RECORDS.with(|recs| {
                 let mut recs = recs.borrow_mut();

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -301,42 +301,21 @@ impl MessageModel {
         });
 
         if let Some(update) = pending_update {
-            let token_record_id = assignment.token_record;
             let stored = update.msg.to_stored(assignment, &update.sender)?;
             let delta = UpdateInbox::AddMessages {
                 messages: vec![stored],
             };
             let delta_bytes = serde_json::to_vec(&delta)?;
-            // Bundle the sender's AFT record state alongside the inbox delta
-            // as `RelatedStateAndDelta` so the inbox contract can verify the
-            // burn locally without depending on the runtime's RequestRelated
-            // → GET orchestration (broken end-to-end, see #80).
-            let data = match AftRecords::record_state_for(&update.sender) {
-                Some(record) => {
-                    let related_state = record
-                        .serialized()
-                        .map_err(|e| format!("failed to serialize AFT record state: {e}"))?;
-                    UpdateData::RelatedStateAndDelta {
-                        related_to: token_record_id,
-                        state: related_state.into(),
-                        delta: delta_bytes.into(),
-                    }
-                }
-                None => {
-                    crate::log::error(
-                        format!(
-                            "no local AFT record state for sender `{}`, sending bare delta — \
-                             inbox contract will request it via RequestRelated",
-                            update.sender.alias()
-                        ),
-                        None,
-                    );
-                    UpdateData::Delta(delta_bytes.into())
-                }
-            };
+            // Send a bare `UpdateData::Delta` and let the runtime resolve
+            // the inbox contract's `update_state` requires(AFT record)
+            // signal via `fetch_related_via_network`. This relies on
+            // freenet-core PR #4006 (validate-side) + PR #4007
+            // (update-side) — without those the receiver's
+            // `update_state` errors with MissingRelated and the broadcast
+            // bounces through ResyncRequest recovery, see #80.
             let request = ContractRequest::Update {
                 key: inbox_contract,
-                data,
+                data: UpdateData::Delta(delta_bytes.into()),
             };
             client.send(request.into()).await?;
             // todo: event after sending, we may fail to update, must keep this in mind in case we receive no confirmation


### PR DESCRIPTION
## Summary

Closes #80.

freenet-core PR #4006 (validate-side network-fetch fallback) and #4007 (update_state requires(missing) network-fetch fallback) shipped on main. The receiver's inbox `update_state` can now return `UpdateModification::requires(AFT-record)` and the runtime resolves it on its own via local-then-network fetch. The UI's `RelatedStateAndDelta` inline-bundle on every send was a workaround for those two upstream gaps and is now redundant.

## Changes

- `ui/src/inbox.rs::MessageModel::finish_sending` — send `UpdateData::Delta` instead of `RelatedStateAndDelta`
- `ui/src/aft.rs::AftRecords::record_state_for` — removed (no callers)
- `confirm_allocation` — kept the optimistic RECORDS-cache append (still useful for local UI counters), updated the comment to reflect that it's no longer load-bearing for delivery

## Test plan
- [x] `cargo check -p freenet-email-ui --target wasm32-unknown-unknown` clean
- [x] E2E validated locally on `freenet 0.2.51` (with #4007 merged) via the iso-nodes harness: bob receives alice's mail with bare-delta UPDATE
- [ ] CI
- [ ] Playwright (offline, `example-data,no-sync`) still passes