### PR TITLE
fix(aft): close audit findings #1, #3, #5

### DIFF
--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -239,9 +239,22 @@ impl Inbox {
         allocation_records: &HashMap<ContractInstanceId, TokenAllocationRecord>,
         messages: Vec<Message>,
     ) -> Result<(), VerificationError> {
-        // FIXME: make sure we are not re-adding old messages by verifying the time is more recent
-        // than last updated
+        // Replay guard: skip messages whose `assignment_hash` is already
+        // in the inbox. Without this, an Update(Delta=AddMessages) with
+        // an old token still passes both signature and
+        // `assignment_exists` checks (the token *was* legitimately
+        // burned), so the same message would be appended again on every
+        // replay — including resurrection of locally-deleted messages.
+        // Mirrors the per-`assignment_hash` dedup in `merge`.
+        let known: HashSet<_> = self
+            .messages
+            .iter()
+            .map(|m| m.token_assignment.assignment_hash)
+            .collect();
         for message in messages {
+            if known.contains(&message.token_assignment.assignment_hash) {
+                continue;
+            }
             let records = allocation_records
                 .get(&message.token_assignment.token_record)
                 .ok_or_else(|| {

--- a/contracts/inbox/tests/integration.rs
+++ b/contracts/inbox/tests/integration.rs
@@ -193,6 +193,67 @@ fn update_rejects_token_with_invalid_slot() {
     );
 }
 
+#[test]
+fn update_dedups_replay_of_previously_added_message() {
+    // Replay attack: a valid Update(Delta=AddMessages) with a token
+    // that already burned and landed in the inbox must be a no-op, not
+    // a duplicate append. Without this guard the same `assignment_hash`
+    // can land twice in `inbox.messages` — and a deleted message would
+    // resurrect on the next replay.
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let (gen_sk, gen_vk_bytes) = make_token_generator_keypair();
+    let params = make_params(&owner_vk);
+
+    let token_record_id = token_record_id_for(b"replay-record");
+    let assignment = make_token_assignment(
+        &gen_sk,
+        gen_vk_bytes,
+        Tier::Day1,
+        fixed_valid_slot(),
+        assignment_hash_for(b"replayed-msg"),
+        token_record_id,
+    );
+    let message = make_message(b"opaque-payload".to_vec(), assignment.clone());
+    let record = make_token_record(assignment);
+
+    let initial_state = make_inbox_state(&owner_sk, vec![], Utc::now(), InboxSettings::default());
+
+    // First add: persists.
+    let after_first = unwrap_valid(
+        Inbox::update_state(
+            params.clone(),
+            initial_state,
+            vec![
+                add_messages_delta(vec![message.clone()]),
+                related_state_update(token_record_id, record.clone()),
+            ],
+        )
+        .expect("first add"),
+    );
+
+    // Replay: same delta, same record. Must be a no-op (still 1 msg).
+    let after_replay = unwrap_valid(
+        Inbox::update_state(
+            params,
+            after_first,
+            vec![
+                add_messages_delta(vec![message]),
+                related_state_update(token_record_id, record),
+            ],
+        )
+        .expect("replay add"),
+    );
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(after_replay.as_ref()).expect("inbox json");
+    assert_eq!(
+        parsed["messages"].as_array().map(|m| m.len()).unwrap_or(0),
+        1,
+        "replayed AddMessages must not duplicate the message"
+    );
+}
+
 // ─── summarize_state / get_state_delta round trip ────────────────────────
 
 #[test]

--- a/modules/antiflood-tokens/interfaces/src/lib.rs
+++ b/modules/antiflood-tokens/interfaces/src/lib.rs
@@ -538,12 +538,14 @@ impl TokenAllocationRecord {
     pub fn summarize(&self) -> TokenAllocationSummary {
         let mut by_tier = HashMap::with_capacity(self.tokens_by_tier.len());
         for (tier, assignments) in &self.tokens_by_tier {
-            let mut assignments_ts = Vec::with_capacity(assignments.len());
+            let mut slots = Vec::with_capacity(assignments.len());
             for a in assignments {
-                let ts = a.time_slot.timestamp();
-                assignments_ts.push(ts);
+                slots.push(SummarySlot {
+                    time_slot: a.time_slot.timestamp(),
+                    assignment_hash: a.assignment_hash,
+                });
             }
-            by_tier.insert(*tier, assignments_ts);
+            by_tier.insert(*tier, slots);
         }
         TokenAllocationSummary(by_tier)
     }
@@ -561,9 +563,8 @@ impl TokenAllocationRecord {
             let summary_slots = summary.0.get(tier);
             let mut missing = Vec::with_capacity(assigned.len());
             for a in assigned {
-                let ts = a.time_slot.timestamp();
                 let already_known = summary_slots
-                    .map(|slots| slots.binary_search(&ts).is_ok())
+                    .map(|slots| slots.iter().any(|s| s.assignment_hash == a.assignment_hash))
                     .unwrap_or(false);
                 if !already_known {
                     missing.push(a.clone());
@@ -655,23 +656,40 @@ impl TryFrom<TokenAllocationRecord> for StateDelta<'static> {
     }
 }
 
+/// One entry of the per-tier allocation summary. Carries the slot
+/// timestamp (for legacy slot-based equality) and the full
+/// `assignment_hash` so callers can match a specific assignment without
+/// false positives on slot collision (#3 in the AFT audit).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct SummarySlot {
+    pub time_slot: i64,
+    pub assignment_hash: [u8; 32],
+}
+
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TokenAllocationSummary(HashMap<Tier, Vec<i64>>);
+pub struct TokenAllocationSummary(HashMap<Tier, Vec<SummarySlot>>);
 
 impl TokenAllocationSummary {
+    /// True if any slot in `tier` matches `slot` by timestamp. Retained
+    /// for callers that don't have an `assignment_hash` to match against.
     pub fn contains_alloc(&self, tier: Tier, slot: DateTime<Utc>) -> bool {
         self.0
             .get(&tier)
-            .and_then(|assignments| {
-                let slot = slot.timestamp();
-                for ts in assignments {
-                    if *ts == slot {
-                        return Some(());
-                    }
-                }
-                None
+            .map(|slots| {
+                let target = slot.timestamp();
+                slots.iter().any(|s| s.time_slot == target)
             })
-            .is_some()
+            .unwrap_or(false)
+    }
+
+    /// True if any slot in `tier` matches `assignment_hash` exactly.
+    /// Prefer this over `contains_alloc` when binding the summary
+    /// confirmation to a specific in-flight assignment.
+    pub fn contains_alloc_hash(&self, tier: Tier, assignment_hash: &[u8; 32]) -> bool {
+        self.0
+            .get(&tier)
+            .map(|slots| slots.iter().any(|s| &s.assignment_hash == assignment_hash))
+            .unwrap_or(false)
     }
 }
 
@@ -1117,5 +1135,56 @@ mod boundary_tests {
             as_record.is_err(),
             "bare TokenAssignment JSON must NOT decode as TokenAllocationRecord; got {as_record:?}"
         );
+    }
+
+    /// `contains_alloc_hash` must distinguish between two assignments
+    /// that share the same `(tier, time_slot)` but have different
+    /// `assignment_hash` — the legacy `contains_alloc` couldn't, which
+    /// made `confirm_allocation` race-prone when two in-flight
+    /// allocations landed in the same slot before either confirmed.
+    #[test]
+    fn summary_contains_alloc_hash_disambiguates_concurrent_allocs() {
+        use std::collections::HashMap;
+
+        let a = make_assignment(0xA1);
+        // Force a second assignment into the same slot but with a different
+        // `assignment_hash`. (In production this can only happen across
+        // nodes mid-propagation; here we construct it directly.)
+        let mut b = a.clone();
+        b.assignment_hash = [0xB2; 32];
+        assert_eq!(a.tier, b.tier);
+        assert_eq!(a.time_slot, b.time_slot);
+        assert_ne!(a.assignment_hash, b.assignment_hash);
+
+        let mut tokens = HashMap::new();
+        tokens.insert(a.tier, vec![a.clone()]);
+        let record = TokenAllocationRecord::new(tokens);
+        let summary = record.summarize();
+
+        // hash-precise lookup: a is present, b is not.
+        assert!(summary.contains_alloc_hash(a.tier, &a.assignment_hash));
+        assert!(!summary.contains_alloc_hash(b.tier, &b.assignment_hash));
+
+        // legacy slot-only lookup matches both, demonstrating the
+        // false-positive that hash-precise lookup avoids.
+        assert!(summary.contains_alloc(a.tier, a.time_slot));
+        assert!(summary.contains_alloc(b.tier, b.time_slot));
+    }
+
+    /// Pin the wire shape of `TokenAllocationSummary` so the cross-crate
+    /// confirmation path keeps decoding. The shape is
+    /// `{ <Tier>: [{ "time_slot": <i64>, "assignment_hash": [u8; 32] }] }`.
+    #[test]
+    fn summary_wire_shape_round_trips() {
+        let assignment = make_assignment(0xE5);
+        let mut tokens = std::collections::HashMap::new();
+        tokens.insert(assignment.tier, vec![assignment.clone()]);
+        let record = TokenAllocationRecord::new(tokens);
+        let summary = record.summarize();
+
+        let state_summary: StateSummary<'static> = summary.try_into().expect("encode summary");
+        let decoded = TokenAllocationSummary::try_from(state_summary).expect("decode summary");
+        assert!(decoded.contains_alloc_hash(assignment.tier, &assignment.assignment_hash));
+        assert!(decoded.contains_alloc(assignment.tier, assignment.time_slot));
     }
 }

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -56,15 +56,25 @@ thread_local! {
     static PENDING_INBOXES_UPDATES: RefCell<Vec<(InboxContract, AssignmentHash)>> = const { RefCell::new(Vec::new()) };
 }
 
-// FIXME: we should check time to time in the API coroutine if any of the pending assignments
-// have not been verified; if that's the case we may need to request again and cannot guarantee
-// that a message has been delivered
+/// Default timeout for pending AFT confirmations. If the host's
+/// `UpdateResponse` summary doesn't acknowledge the assignment within
+/// this window, `expire_stale` reaps the entry and surfaces an error to
+/// the UI so the user knows the send didn't land. Tuned for the typical
+/// cross-node propagation window (low single-digit seconds) plus
+/// margin for network jitter.
+pub(crate) const PENDING_ASSIGNMENT_TIMEOUT_SECS: i64 = 30;
+
+/// How often the API coroutine checks for stale pending assignments.
+/// Short enough that a stuck send surfaces quickly, long enough that
+/// the WASM scheduler isn't busy on it. The actual user-visible
+/// latency to error is bounded by `PENDING_ASSIGNMENT_TIMEOUT_SECS +
+/// PENDING_ASSIGNMENT_SWEEP_INTERVAL_MS`.
+pub(crate) const PENDING_ASSIGNMENT_SWEEP_INTERVAL_MS: u32 = 5_000;
+
 struct PendingAssignmentRegister {
-    /// time at which the request started
-    #[allow(dead_code)] // TODO: used by the timeout/retry path (see FIXME above)
+    /// Time at which the assignment was queued for confirmation. Reaped by
+    /// `expire_stale` once the timeout elapses.
     start: DateTime<Utc>,
-    // time_slot: DateTime<Utc>,
-    // tier: freenet_aft_interface::Tier,
     record: TokenAssignment,
     inbox: InboxContract,
 }
@@ -112,6 +122,45 @@ impl AftRecords {
         Ok(contract_key)
     }
 
+    /// Drain pending confirmations older than `timeout_secs` and return
+    /// the expired records so the caller can surface the failure to the
+    /// UI. Also clears the matching entry in `PENDING_INBOXES_UPDATES`
+    /// so a retry can re-queue without colliding with a stale entry.
+    ///
+    /// Without this sweep, a `confirm_allocation` that never arrives
+    /// (host crash, network drop, malformed summary) leaves the user's
+    /// send hanging forever with no UI feedback — see #1 in the AFT
+    /// audit.
+    pub fn expire_stale(timeout_secs: i64) -> Vec<TokenAssignment> {
+        let now = Utc::now();
+        let mut expired: Vec<TokenAssignment> = Vec::new();
+        PENDING_CONFIRMED_ASSIGNMENTS.with(|pending| {
+            let mut pending = pending.borrow_mut();
+            for registers in pending.values_mut() {
+                registers.retain(|r| {
+                    let elapsed = now.signed_duration_since(r.start).num_seconds();
+                    if elapsed >= timeout_secs {
+                        expired.push(r.record.clone());
+                        false
+                    } else {
+                        true
+                    }
+                });
+            }
+            pending.retain(|_, v| !v.is_empty());
+        });
+        if !expired.is_empty() {
+            let expired_hashes: HashMap<AssignmentHash, ()> =
+                expired.iter().map(|r| (r.assignment_hash, ())).collect();
+            PENDING_INBOXES_UPDATES.with(|queue| {
+                queue
+                    .borrow_mut()
+                    .retain(|(_, hash)| !expired_hashes.contains_key(hash));
+            });
+        }
+        expired
+    }
+
     pub fn pending_assignment(delegate: AftDelegate, contract: InboxContract) {
         PENDING_TOKEN_ASSIGNMENT.with(|map| {
             let map = &mut *map.borrow_mut();
@@ -139,11 +188,7 @@ impl AftRecords {
                 registers
                     .iter()
                     .position(|r| {
-                        // fixme: the summary should also have the assignment hash
-                        if summary.contains_alloc(r.record.tier, r.record.time_slot) {
-                            return true;
-                        }
-                        false
+                        summary.contains_alloc_hash(r.record.tier, &r.record.assignment_hash)
                     })
                     .map(|idx| registers.remove(idx))
             })

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1552,6 +1552,10 @@ pub(crate) async fn node_comms(
         }
     }
 
+    let mut pending_sweep =
+        gloo_timers::future::IntervalStream::new(crate::aft::PENDING_ASSIGNMENT_SWEEP_INTERVAL_MS)
+            .fuse();
+
     loop {
         futures::select! {
             r = api.host_responses.next() => {
@@ -1581,6 +1585,27 @@ pub(crate) async fn node_comms(
                     Some(Err((msg, action))) => crate::log::error(format!("{msg}"), Some(action)),
                     Some(Ok(_)) => {}
                     None => panic!("error ch closed"),
+                }
+            }
+            _ = pending_sweep.next() => {
+                // Reap AFT assignments whose `confirm_allocation` never
+                // arrived. Without this the user's send hangs silently;
+                // with it, surfaces as a SendMessage error so the UI can
+                // mark the Sent row failed.
+                let expired = AftRecords::expire_stale(
+                    crate::aft::PENDING_ASSIGNMENT_TIMEOUT_SECS,
+                );
+                for assignment in expired {
+                    crate::log::error(
+                        format!(
+                            "AFT assignment confirmation timed out (>{}s) for tier={} slot={} hash={}",
+                            crate::aft::PENDING_ASSIGNMENT_TIMEOUT_SECS,
+                            assignment.tier,
+                            assignment.time_slot,
+                            bs58::encode(assignment.assignment_hash).into_string(),
+                        ),
+                        Some(TryNodeAction::SendMessage),
+                    );
                 }
             }
         }


### PR DESCRIPTION
Three independent fixes surfaced by the AFT mechanism audit (5/2/2026). Each is self-contained.

## #1 — pending-assignment timeout sweep

`AftRecords::expire_stale(timeout_secs)` reaps entries from `PENDING_CONFIRMED_ASSIGNMENTS` whose `confirm_allocation` never arrived (host crash, network drop, malformed summary). Wired into the API coroutine via a 5 s `IntervalStream`; expired records surface as `TryNodeAction::SendMessage` errors so the UI can mark the Sent row failed instead of hanging forever.

- Default timeout 30 s — covers cross-node propagation plus jitter.
- Sweep also clears matching entries in `PENDING_INBOXES_UPDATES` so a retry can re-queue.
- Closes the FIXME at `ui/src/aft.rs:59` and removes the `#[allow(dead_code)]` on `PendingAssignmentRegister.start`.

## #3 — `TokenAllocationSummary` carries `assignment_hash`

Confirmation in `confirm_allocation` previously matched the in-flight assignment by `(tier, time_slot)` only. Two concurrent allocations landing in the same slot (possible across nodes mid-propagation) collided false-positively.

- Summary now stores `Vec<SummarySlot { time_slot, assignment_hash }>`.
- New `contains_alloc_hash` for precise hash-based lookup. Legacy `contains_alloc` retained for callers without a hash.
- New tests: `summary_contains_alloc_hash_disambiguates_concurrent_allocs`, `summary_wire_shape_round_trips`.

**Wire-format change to the summary** — old summaries on the network won't decode. Acceptable: the contract ID is already non-reproducible across signers (timestamp-based per AGENTS.md), so this rolls into the next release as normal contract churn.

## #5 — inbox replay guard

`Inbox::add_messages` previously appended any message whose `(token_assignment, signature, assignment_exists)` checks passed. Replaying an \`Update(Delta=AddMessages)\` with an already-burned token therefore landed the same message twice — and would resurrect a locally-deleted message on the next replay.

- Per-\`assignment_hash\` dedup against the existing \`inbox.messages\`, mirroring the dedup added to \`merge\` in #82.
- New integration test: \`update_dedups_replay_of_previously_added_message\`.

## Out of scope here

- **Finding #2** (msg-before-token race) is closed by #82's catch-up Get + \`merge\` dedup combined with the existing optimistic local-cache append in \`confirm_allocation\`. No code change.
- **Finding #4** (hardcoded \`Tier::Day1\` + 365 d max_age) is filed as #85; the fix requires making \`InboxParams\` carry the recipient's required tier, which is a wire-format change that warrants its own PR.

## Test plan

- [x] \`cargo test --workspace\` — 81 passed (was 78 pre-rebase + 3 new)
- [x] \`cargo make clippy\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo build -p freenet-email-ui\` (use-node) and \`-p freenet-email-ui --no-default-features --features example-data,no-sync\` (offline)
- [ ] CI build-and-test
- [ ] CI e2e-real-node