### PR TITLE
fix(ui): refresh identity list after CreateIdentity without reload

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -433,6 +433,7 @@ mod identity_management {
         inbox_to_id: &mut HashMap<ContractKey, Identity>,
         token_rec_to_id: &mut HashMap<ContractKey, Identity>,
         user: Signal<crate::app::User>,
+        mut login_controller: Signal<crate::app::LoginController>,
     ) {
         let id = identity_management::PENDING_CONFIRMATION
             .with(|pend| pend.borrow_mut().remove(identity_key));
@@ -465,6 +466,10 @@ mod identity_management {
             );
             inbox_to_id.insert(inbox_key, identity.clone());
             token_rec_to_id.insert(aft_rec.unwrap(), identity);
+            // ALIASES is a thread-local RefCell, not a Signal — mutating it
+            // does not wake the Identities component. Bump the controller
+            // so the just-created identity shows without a page reload.
+            login_controller.write().updated = true;
         }
 
         // Send contract subscriptions after identity creation.
@@ -805,6 +810,7 @@ pub(crate) async fn node_comms(
                         inbox_to_id,
                         token_rec_to_id,
                         user,
+                        login_controller,
                     )
                     .await;
                 }
@@ -1293,6 +1299,7 @@ pub(crate) async fn node_comms(
                             inbox_to_id,
                             token_rec_to_id,
                             user,
+                            login_controller,
                         )
                         .await;
                     }
@@ -1327,6 +1334,7 @@ pub(crate) async fn node_comms(
                             inbox_to_id,
                             token_rec_to_id,
                             user,
+                            login_controller,
                         )
                         .await;
                     }
@@ -1377,6 +1385,7 @@ pub(crate) async fn node_comms(
                                 inbox_to_id,
                                 token_rec_to_id,
                                 user,
+                                login_controller,
                             )
                             .await;
                         }


### PR DESCRIPTION
## Summary
Newly created identities did not appear in the Identities list until the user reloaded the page. Root cause: `Identity::set_alias` mutates the thread-local `ALIASES` `RefCell`, but the `Identities` component re-renders on `LoginController.updated`, which was bumped on Contact create/delete/rename but not on identity creation.

Threads `login_controller` into `alias_creation` and bumps `updated = true` after `Identity::set_alias` registers the new identity. Four call sites updated.

## Test plan
- [ ] Create a fresh identity in the iso-node UI → entry appears immediately, no reload required
- [ ] Existing flows (create contact / delete contact / rename) continue to refresh