### PR TITLE
feat(ui): settings shell — desktop port of design handoff

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -65,5 +65,10 @@
   "fmContactImport": "fm-contact-import",
   "fmImportContactModal": "fm-import-contact-modal",
   "fmImportFp": "fm-import-fp",
-  "fmImportSubmit": "fm-import-submit"
+  "fmImportSubmit": "fm-import-submit",
+
+  "fmSettingsBtn": "fm-settings-btn",
+  "fmSettingsShell": "fm-settings-shell",
+  "fmSettingsBack": "fm-settings-back",
+  "fmSettingsNavItem": "fm-settings-nav-item"
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -26,6 +26,7 @@
     <link rel="stylesheet" href="vendor/css/components/compose.css" />
     <link rel="stylesheet" href="vendor/css/components/toast.css" />
     <link rel="stylesheet" href="vendor/css/components/login.css" />
+    <link rel="stylesheet" href="vendor/css/components/settings.css" />
   </head>
   <body>
     <div id="main"></div>

--- a/ui/public/vendor/css/components/settings.css
+++ b/ui/public/vendor/css/components/settings.css
@@ -1,0 +1,607 @@
+/* Settings shell — full-screen takeover inside .fm-app, layered on top
+   of tokens.css and the existing component layers. Ported from the
+   Claude Design handoff bundle (mail-config-ui-design/project/settings.css)
+   and scoped under @layer components + @scope (.fm-app) to match the
+   existing component CSS pattern (see tokens.css comment). Mobile (.fm-m*)
+   classes intentionally omitted — first pass is desktop-only. */
+
+@layer components {
+  @scope (.fm-app) {
+
+    /* ============ Settings shell ============ */
+    .fm-settings {
+      position: absolute;
+      inset: 50px 0 0 0;
+      display: grid;
+      grid-template-columns: 240px 1fr;
+      background: var(--c0);
+      background-image:
+        radial-gradient(ellipse 65% 45% at 12% -8%, rgba(0, 102, 204, 0.055) 0%, transparent 55%),
+        radial-gradient(ellipse 55% 65% at 92% 108%, rgba(51, 153, 102, 0.055) 0%, transparent 50%);
+      background-attachment: fixed;
+      overflow: hidden;
+      z-index: 30;
+      animation: fm-settings-in 0.22s cubic-bezier(0.34, 1.28, 0.64, 1) both;
+    }
+    @keyframes fm-settings-in {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    /* Sidebar */
+    .fm-set-side {
+      border-right: 1px solid var(--line);
+      background: rgba(241, 245, 249, 0.4);
+      display: flex; flex-direction: column;
+      padding: 18px 12px 14px;
+      gap: 14px;
+      min-height: 0;
+    }
+    .fm-set-back {
+      height: 32px; padding: 0 10px;
+      display: inline-flex; align-items: center; gap: 8px;
+      font-size: 12.5px; color: var(--ink3);
+      border-radius: 7px;
+      align-self: flex-start;
+      background: transparent; border: 0;
+      transition: background 0.15s ease, color 0.15s ease;
+    }
+    .fm-set-back:hover { background: rgba(255, 255, 255, 0.6); color: var(--ink1); }
+    .fm-set-back .arrow { font-family: "Geist Mono", monospace; font-size: 12px; }
+
+    .fm-set-title {
+      font-family: "Fraunces", serif; font-style: italic; font-weight: 300;
+      font-size: 22px; letter-spacing: -0.04em;
+      color: var(--ink0); padding: 0 10px;
+    }
+
+    .fm-set-ident {
+      margin: 0 4px; padding: 12px 12px 11px;
+      background: #fff; border: 1px solid var(--line2);
+      border-radius: 11px; box-shadow: var(--sh-sm);
+      display: flex; align-items: center; gap: 11px;
+      cursor: default;
+      transition: box-shadow 0.15s ease, border-color 0.15s ease;
+    }
+    .fm-set-ident:hover { border-color: var(--c3); box-shadow: 0 4px 16px rgba(0, 40, 100, 0.08); }
+    .fm-set-ident-av {
+      width: 30px; height: 30px; border-radius: 50%;
+      background: var(--accent-bg); border: 1px solid var(--accent-mid);
+      display: inline-flex; align-items: center; justify-content: center;
+      font-family: "Fraunces", serif; font-style: italic; color: var(--accent); font-size: 15px;
+    }
+    .fm-set-ident-text { display: flex; flex-direction: column; gap: 1px; line-height: 1.15; flex: 1; min-width: 0; }
+    .fm-set-ident-name {
+      font-family: "Fraunces", serif; font-style: italic; font-size: 14px;
+      letter-spacing: -0.025em; color: var(--ink0);
+    }
+    .fm-set-ident-meta { font-family: "Geist Mono", monospace; font-size: 9px; color: var(--ink3); }
+    .fm-set-ident-caret { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ink4); }
+
+    .fm-set-nav { display: flex; flex-direction: column; gap: 1px; padding: 0 4px; flex: 1; min-height: 0; overflow: auto; }
+    .fm-set-nav-group {
+      font-family: "Geist Mono", monospace; font-size: 7.5px;
+      text-transform: uppercase; letter-spacing: 0.14em; color: var(--ink4);
+      padding: 14px 10px 6px;
+    }
+    .fm-set-nav-group:first-child { padding-top: 4px; }
+    .fm-set-nav-item {
+      height: 32px; padding: 0 10px 0 12px; border-radius: 7px;
+      display: flex; align-items: center; gap: 9px;
+      font-size: 13px; color: var(--ink2); letter-spacing: -0.005em;
+      background: transparent; border: 0;
+      transition: background 0.08s ease, color 0.08s ease, box-shadow 0.08s ease;
+      text-align: left; width: 100%;
+    }
+    .fm-set-nav-item .glyph {
+      font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ink3); width: 14px; text-align: center;
+    }
+    .fm-set-nav-item .label { flex: 1; }
+    .fm-set-nav-item .meta {
+      font-family: "Geist Mono", monospace; font-size: 9px; color: var(--ink4); letter-spacing: 0.04em;
+    }
+    .fm-set-nav-item .meta.warn { color: var(--unread); }
+    .fm-set-nav-item .meta.trust { color: var(--trust); }
+    .fm-set-nav-item:hover { background: rgba(255, 255, 255, 0.55); color: var(--ink0); }
+    .fm-set-nav-item.is-active {
+      background: #fff; color: var(--ink0); font-weight: 500;
+      box-shadow: var(--sh-sm), inset 2px 0 0 var(--accent);
+    }
+    .fm-set-nav-item.is-active .glyph { color: var(--accent); }
+
+    /* Main panel */
+    .fm-set-main { display: flex; flex-direction: column; min-height: 0; overflow: auto; }
+    .fm-set-bar {
+      height: 50px; flex: 0 0 50px;
+      display: flex; align-items: center; gap: 12px;
+      padding: 0 28px;
+      border-bottom: 1px solid var(--line2);
+      background: rgba(248, 250, 252, 0.7);
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+      position: sticky; top: 0; z-index: 5;
+    }
+    .fm-set-bar-title {
+      font-family: "Fraunces", serif; font-size: 17px; letter-spacing: -0.035em;
+      color: var(--ink0); font-weight: 500;
+    }
+    .fm-set-bar-scope {
+      font-family: "Geist Mono", monospace; font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase;
+      color: var(--ink3); padding: 3px 8px; border-radius: 4px;
+      background: rgba(100, 116, 139, 0.06); border: 1px solid var(--line2);
+    }
+    .fm-set-bar-scope.identity { color: var(--accent); background: var(--accent-bg); border-color: var(--accent-mid); }
+    .fm-set-bar-grow { flex: 1; }
+    .fm-set-bar-meta { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--ink3); }
+
+    .fm-set-body { flex: 1; min-height: 0; padding: 28px 32px 80px; }
+    .fm-set-inner { max-width: 720px; margin: 0 auto; }
+
+    .fm-set-lede {
+      font-family: "DM Sans", system-ui, sans-serif; font-size: 13.5px; line-height: 1.6; color: var(--ink2);
+      letter-spacing: -0.005em; max-width: 56ch; margin-bottom: 22px;
+    }
+
+    /* Card */
+    .fm-card {
+      background: #fff; border: 1px solid var(--line2);
+      border-radius: 12px; box-shadow: var(--sh-sm);
+      overflow: hidden;
+      margin-bottom: 18px;
+    }
+    .fm-card-head {
+      padding: 16px 20px 12px;
+      border-bottom: 1px solid var(--line2);
+    }
+    .fm-card-title {
+      font-family: "Fraunces", serif; font-size: 15px; letter-spacing: -0.025em;
+      color: var(--ink0); font-weight: 500;
+    }
+    .fm-card-sub {
+      font-family: "DM Sans", system-ui, sans-serif; font-size: 12px; color: var(--ink3);
+      margin-top: 3px; line-height: 1.5;
+    }
+
+    /* Setting row */
+    .fm-row-set {
+      padding: 14px 20px;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 16px;
+      align-items: center;
+    }
+    .fm-row-set + .fm-row-set { border-top: 1px solid var(--line2); }
+    .fm-row-set.stacked { grid-template-columns: 1fr; gap: 10px; }
+    .fm-row-set-label { font-size: 13.5px; color: var(--ink1); letter-spacing: -0.005em; }
+    .fm-row-set-help {
+      font-size: 11.5px; color: var(--ink3); margin-top: 2px; line-height: 1.5;
+      letter-spacing: -0.005em;
+    }
+    .fm-row-set-help code, .fm-row-set-help .mono {
+      font-family: "Geist Mono", monospace; font-size: 10.5px; color: var(--ink2);
+    }
+
+    /* Toggle */
+    .fm-toggle {
+      width: 32px; height: 18px; border-radius: 999px;
+      background: var(--c2); position: relative; cursor: default;
+      transition: background 0.15s ease;
+      flex: 0 0 32px;
+      border: 0; padding: 0;
+    }
+    .fm-toggle::after {
+      content: ''; position: absolute; left: 2px; top: 2px;
+      width: 14px; height: 14px; border-radius: 50%;
+      background: #fff; box-shadow: 0 1px 2px rgba(0, 40, 100, 0.18);
+      transition: transform 0.15s ease;
+    }
+    .fm-toggle.on { background: var(--accent); }
+    .fm-toggle.on::after { transform: translateX(14px); }
+
+    /* Select */
+    .fm-select {
+      height: 30px; padding: 0 28px 0 11px;
+      background: #fff; border: 1px solid var(--c3);
+      border-radius: 7px;
+      font-family: "DM Sans", system-ui, sans-serif; font-size: 12.5px; color: var(--ink1);
+      appearance: none;
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'><path d='M2 4l3 3 3-3' stroke='%236b7280' stroke-width='1.2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+      background-repeat: no-repeat;
+      background-position: right 9px center;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+    .fm-select:focus { border-color: var(--accent-mid); box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.08); }
+
+    /* Inputs */
+    .fm-input {
+      height: 30px; padding: 0 11px;
+      background: #fff; border: 1px solid var(--c3);
+      border-radius: 7px;
+      font-family: "DM Sans", system-ui, sans-serif; font-size: 12.5px; color: var(--ink1);
+      letter-spacing: -0.005em;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    }
+    .fm-input:focus { border-color: var(--accent-mid); box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.08); }
+    .fm-input.mono { font-family: "Geist Mono", monospace; font-size: 11.5px; }
+    .fm-input.full { width: 100%; }
+    .fm-textarea {
+      width: 100%; min-height: 80px; padding: 9px 11px;
+      background: #fff; border: 1px solid var(--c3);
+      border-radius: 7px; resize: vertical;
+      font-family: "DM Sans", system-ui, sans-serif; font-size: 13px; color: var(--ink1);
+      line-height: 1.55; letter-spacing: -0.005em;
+    }
+    .fm-textarea:focus { border-color: var(--accent-mid); box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.08); outline: none; }
+
+    /* Buttons */
+    .fm-btn-primary {
+      height: 30px; padding: 0 14px; border-radius: 7px;
+      background: var(--ink0); color: #fff;
+      font-size: 12px; font-weight: 500; letter-spacing: -0.005em;
+      border: 0;
+      transition: background 0.15s ease;
+    }
+    .fm-btn-primary:hover { background: var(--ink1); }
+    .fm-btn-secondary {
+      height: 30px; padding: 0 12px; border-radius: 7px;
+      background: #fff; color: var(--ink1);
+      border: 1px solid var(--c3);
+      font-size: 12px; font-weight: 500; letter-spacing: -0.005em;
+      transition: background 0.15s ease, border-color 0.15s ease;
+    }
+    .fm-btn-secondary:hover { background: rgba(255, 255, 255, 0.6); border-color: var(--ink4); }
+    .fm-btn-danger {
+      height: 30px; padding: 0 12px; border-radius: 7px;
+      background: #fff; color: #b91c1c;
+      border: 1px solid rgba(185, 28, 28, 0.25);
+      font-size: 12px; font-weight: 500; letter-spacing: -0.005em;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .fm-btn-danger:hover { background: #fee2e2; border-color: rgba(185, 28, 28, 0.4); color: #a32f2f; }
+
+    /* Key card */
+    .fm-keys-grid {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+      padding: 14px 20px;
+    }
+    @media (max-width: 760px) { .fm-keys-grid { grid-template-columns: 1fr; } }
+    .fm-key-card {
+      border: 1px solid var(--line);
+      border-radius: 11px;
+      padding: 16px 18px;
+      background: linear-gradient(180deg, #fff 0%, rgba(248, 250, 252, 0.6) 100%);
+    }
+    .fm-key-card-head {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-bottom: 12px;
+    }
+    .fm-key-card-name {
+      font-family: "Geist Mono", monospace; font-size: 10px;
+      letter-spacing: 0.12em; text-transform: uppercase;
+      color: var(--ink2); font-weight: 500;
+    }
+    .fm-key-card-tag {
+      font-family: "Geist Mono", monospace; font-size: 8.5px;
+      letter-spacing: 0.1em; text-transform: uppercase;
+      padding: 2px 6px; border-radius: 3px;
+      color: var(--trust); background: var(--trust-bg);
+      border: 1px solid rgba(51, 153, 102, 0.25);
+    }
+    .fm-key-card-fp {
+      font-family: "Geist Mono", monospace; font-size: 13px; color: var(--ink0);
+      letter-spacing: 0.04em;
+    }
+    .fm-key-card-foot {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-top: 12px;
+      padding-top: 10px; border-top: 1px dashed var(--line2);
+    }
+    .fm-key-meta-list {
+      display: flex; gap: 18px;
+      font-family: "Geist Mono", monospace; font-size: 9.5px; color: var(--ink3);
+    }
+    .fm-key-meta-list .v { color: var(--ink2); }
+    .fm-key-actions { display: flex; gap: 6px; }
+
+    /* Fingerprint visualization grid */
+    .fm-fp-grid {
+      display: grid;
+      grid-template-columns: repeat(8, 1fr);
+      gap: 2px;
+      width: 80px; height: 80px;
+      flex: 0 0 80px;
+      border-radius: 6px;
+      overflow: hidden;
+      border: 1px solid var(--line2);
+      padding: 4px;
+      background: var(--c1);
+    }
+    .fm-fp-grid .cell { aspect-ratio: 1; border-radius: 1px; }
+
+    /* AFT tier picker */
+    .fm-tier-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 8px;
+      padding: 14px 20px 18px;
+    }
+    .fm-tier {
+      cursor: default;
+      border: 1px solid var(--line);
+      border-radius: 11px;
+      padding: 12px 12px 10px;
+      background: #fff;
+      display: flex; flex-direction: column; gap: 4px;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+    }
+    .fm-tier:hover { border-color: var(--c3); box-shadow: var(--sh-sm); }
+    .fm-tier.is-active {
+      border-color: var(--accent);
+      box-shadow: var(--sh-sm), inset 0 -2px 0 var(--accent);
+      background: linear-gradient(180deg, #fff 0%, rgba(239, 246, 255, 0.5) 100%);
+    }
+    .fm-tier-name {
+      font-family: "Geist Mono", monospace; font-size: 10.5px;
+      letter-spacing: 0.06em; text-transform: uppercase;
+      color: var(--ink0); font-weight: 500;
+    }
+    .fm-tier.is-active .fm-tier-name { color: var(--accent); }
+    .fm-tier-rate {
+      font-family: "Fraunces", serif; font-size: 18px;
+      color: var(--ink0); letter-spacing: -0.03em;
+      line-height: 1;
+    }
+    .fm-tier-rate .unit { font-family: "Geist Mono", monospace; font-size: 9px; color: var(--ink3); letter-spacing: 0.04em; }
+    .fm-tier-help { font-size: 11px; color: var(--ink3); line-height: 1.4; }
+
+    /* Quota */
+    .fm-quota {
+      padding: 18px 20px;
+      border-bottom: 1px solid var(--line2);
+    }
+    .fm-quota-head {
+      display: flex; align-items: baseline; justify-content: space-between;
+      margin-bottom: 12px;
+    }
+    .fm-quota-num {
+      font-family: "Fraunces", serif; font-size: 32px;
+      color: var(--ink0); letter-spacing: -0.04em; line-height: 1;
+    }
+    .fm-quota-num .of { color: var(--ink4); font-style: italic; font-weight: 300; }
+    .fm-quota-num .denom { color: var(--ink3); }
+    .fm-quota-label {
+      font-family: "Geist Mono", monospace; font-size: 9px;
+      letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink3);
+    }
+    .fm-quota-bar {
+      height: 8px; border-radius: 4px;
+      background: var(--c1); overflow: hidden; position: relative;
+      border: 1px solid var(--line2);
+    }
+    .fm-quota-fill {
+      height: 100%;
+      background: linear-gradient(90deg, var(--trust) 0%, var(--accent) 100%);
+      border-radius: 4px;
+      transition: width 0.4s ease;
+    }
+    .fm-quota-fill.warn {
+      background: linear-gradient(90deg, var(--accent) 0%, var(--unread) 100%);
+    }
+    .fm-quota-foot {
+      display: flex; justify-content: space-between; margin-top: 8px;
+      font-family: "Geist Mono", monospace; font-size: 9.5px; color: var(--ink3); letter-spacing: 0.04em;
+    }
+
+    /* Spark */
+    .fm-spark { padding: 16px 20px; }
+    .fm-spark-row {
+      display: grid; grid-template-columns: 60px 1fr 50px;
+      gap: 10px; align-items: center;
+      padding: 4px 0;
+      font-family: "Geist Mono", monospace; font-size: 10px; color: var(--ink3);
+    }
+    .fm-spark-row .day { letter-spacing: 0.04em; }
+    .fm-spark-row .val { text-align: right; color: var(--ink2); }
+    .fm-spark-track {
+      height: 6px; background: var(--c1); border-radius: 3px; overflow: hidden;
+    }
+    .fm-spark-fill {
+      height: 100%; background: var(--accent); opacity: 0.85;
+      border-radius: 3px;
+    }
+
+    /* Banner */
+    .fm-banner {
+      display: flex; align-items: flex-start; gap: 12px;
+      padding: 13px 16px;
+      border-radius: 9px;
+      margin-bottom: 16px;
+      border: 1px solid;
+      font-size: 12.5px; line-height: 1.55;
+    }
+    .fm-banner.amber {
+      background: rgba(254, 243, 199, 0.5);
+      border-color: rgba(217, 119, 6, 0.25);
+      color: #a6731f;
+    }
+    .fm-banner-glyph {
+      font-family: "Fraunces", serif; font-style: italic;
+      font-size: 18px; line-height: 1;
+    }
+    .fm-banner-text { flex: 1; }
+    .fm-banner-text strong { color: var(--ink0); font-weight: 500; }
+    .fm-banner-actions { display: flex; gap: 6px; flex-shrink: 0; }
+
+    /* Contact list */
+    .fm-contact-list { padding: 4px 8px 8px; }
+    .fm-contact-row {
+      display: grid;
+      grid-template-columns: 28px 1fr auto auto auto;
+      gap: 12px; align-items: center;
+      padding: 10px 12px; border-radius: 7px;
+      cursor: default;
+      transition: background 0.15s ease;
+    }
+    .fm-contact-row:hover { background: rgba(241, 245, 249, 0.6); }
+    .fm-contact-av {
+      width: 28px; height: 28px; border-radius: 50%;
+      background: var(--accent-bg); border: 1px solid var(--accent-mid);
+      display: inline-flex; align-items: center; justify-content: center;
+      font-family: "Fraunces", serif; font-style: italic; color: var(--accent); font-size: 13px;
+    }
+    .fm-contact-name { font-size: 13px; color: var(--ink1); letter-spacing: -0.005em; }
+    .fm-contact-name .alias { font-family: "Fraunces", serif; font-style: italic; font-size: 14px; color: var(--ink0); }
+    .fm-contact-name .fp {
+      font-family: "Geist Mono", monospace; font-size: 9.5px; color: var(--ink3);
+      margin-left: 8px;
+    }
+    .fm-contact-trust {
+      font-family: "Geist Mono", monospace; font-size: 8px; letter-spacing: 0.06em; text-transform: uppercase;
+      padding: 2px 6px; border-radius: 3px; border: 1px solid;
+    }
+    .fm-contact-trust.known { color: var(--trust); border-color: rgba(51, 153, 102, 0.3); background: var(--trust-bg); }
+    .fm-contact-trust.unknown { color: #a6731f; border-color: rgba(217, 119, 6, 0.3); background: rgba(217, 119, 6, 0.06); }
+    .fm-contact-trust.unsigned { color: #a32f2f; border-color: rgba(163, 47, 47, 0.3); background: #fee2e2; }
+    .fm-contact-tier {
+      font-family: "Geist Mono", monospace; font-size: 9px; letter-spacing: 0.04em;
+      color: var(--ink3); padding: 2px 6px; border-radius: 3px;
+      background: rgba(100, 116, 139, 0.06);
+    }
+
+    /* Modal */
+    .fm-modal-veil {
+      position: absolute; inset: 0; background: rgba(15, 23, 42, 0.32);
+      -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px);
+      z-index: 100;
+      display: flex; align-items: center; justify-content: center;
+      animation: fm-veil-in 0.15s ease both;
+    }
+    @keyframes fm-veil-in {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+    .fm-modal {
+      width: 460px; max-width: calc(100% - 40px);
+      background: #fff; border-radius: 14px;
+      box-shadow: var(--sh-lg);
+      overflow: hidden;
+      animation: fm-modal-in 0.22s cubic-bezier(0.34, 1.28, 0.64, 1) both;
+    }
+    @keyframes fm-modal-in {
+      from { opacity: 0; transform: translateY(20px) scale(0.97); }
+      to   { opacity: 1; transform: translateY(0) scale(1); }
+    }
+    .fm-modal-head {
+      padding: 20px 22px 14px;
+      border-bottom: 1px solid var(--line2);
+    }
+    .fm-modal.amber .fm-modal-head {
+      background: linear-gradient(180deg, rgba(254, 243, 199, 0.4) 0%, transparent 100%);
+    }
+    .fm-modal-title {
+      font-family: "Fraunces", serif; font-size: 18px;
+      letter-spacing: -0.03em; color: var(--ink0); font-weight: 500;
+    }
+    .fm-modal-body { padding: 16px 22px; font-size: 13px; color: var(--ink2); line-height: 1.6; }
+    .fm-modal-body p + p { margin-top: 10px; }
+    .fm-modal-confirm {
+      margin-top: 14px;
+      display: flex; align-items: center; gap: 10px;
+      padding: 11px 12px;
+      background: rgba(254, 226, 226, 0.4); border: 1px solid rgba(163, 47, 47, 0.18);
+      border-radius: 7px;
+    }
+    .fm-modal-confirm .k {
+      font-family: "Geist Mono", monospace; font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase;
+      color: #b91c1c;
+    }
+    .fm-modal-foot {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 14px 22px; background: rgba(241, 245, 249, 0.4);
+      border-top: 1px solid var(--line2);
+    }
+    .fm-modal-foot .help {
+      font-family: "Geist Mono", monospace; font-size: 9.5px; color: var(--ink3); letter-spacing: 0.04em;
+    }
+    .fm-modal-actions { display: flex; gap: 6px; }
+    .fm-btn-danger-solid {
+      height: 32px; padding: 0 14px; border-radius: 7px;
+      background: #b91c1c; color: #fff;
+      font-size: 12.5px; font-weight: 500; letter-spacing: -0.005em;
+      border: 0;
+      transition: background 0.15s ease, transform 0.06s ease;
+    }
+    .fm-btn-danger-solid:hover { background: #a32f2f; }
+    .fm-btn-danger-solid:active { transform: translateY(1px); }
+    .fm-btn-danger-solid:disabled { background: var(--c3); color: var(--ink4); cursor: not-allowed; }
+
+    /* Identity switcher popover */
+    .fm-id-popover {
+      position: absolute;
+      top: calc(100% + 4px); left: 12px; right: 12px;
+      background: #fff; border-radius: 11px;
+      box-shadow: 0 4px 16px rgba(0, 40, 100, 0.08);
+      border: 1px solid var(--line2);
+      padding: 6px;
+      z-index: 20;
+      animation: fm-modal-in 0.16s cubic-bezier(0.34, 1.28, 0.64, 1) both;
+    }
+    .fm-id-pop-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 9px 10px; border-radius: 7px; cursor: default;
+      transition: background 0.15s ease;
+    }
+    .fm-id-pop-row:hover { background: rgba(241, 245, 249, 0.7); }
+    .fm-id-pop-row.is-active { background: rgba(239, 246, 255, 0.7); }
+    .fm-id-pop-row.add { color: var(--accent); font-size: 12.5px; }
+
+    /* Diagnostics terminal */
+    .fm-term {
+      background: #0f172a;
+      color: #cbd5e1;
+      font-family: "Geist Mono", monospace;
+      font-size: 11px;
+      line-height: 1.55;
+      padding: 14px 16px;
+      border-radius: 7px;
+      margin: 14px 20px;
+      max-height: 200px; overflow: auto;
+    }
+    .fm-term .ts { color: #64748b; }
+    .fm-term .lvl-info { color: #93c5fd; }
+    .fm-term .lvl-warn { color: #fbbf24; }
+    .fm-term .lvl-ok { color: #86efac; }
+
+    /* Sub-row */
+    .fm-sub-row {
+      padding: 12px 20px;
+      display: flex; align-items: center; gap: 12px;
+      background: rgba(248, 250, 252, 0.5);
+      border-top: 1px solid var(--line2);
+    }
+    .fm-sub-row .label {
+      font-family: "Geist Mono", monospace; font-size: 9.5px;
+      letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink3);
+      flex: 0 0 auto;
+    }
+    .fm-sub-row .v { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--ink1); flex: 1; }
+
+    /* Topbar settings entry — gear icon button */
+    .fm-icon-btn {
+      width: 32px; height: 32px; border-radius: 7px;
+      color: var(--ink3); background: transparent; border: 0;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 16px;
+      transition: background 0.15s ease, color 0.15s ease;
+    }
+    .fm-icon-btn:hover { background: rgba(241, 245, 249, 0.7); color: var(--ink1); }
+    .fm-set-icon { position: relative; }
+    .fm-set-icon.has-dot::after {
+      content: ''; position: absolute; top: 5px; right: 5px;
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--unread);
+      box-shadow: 0 0 0 2px rgba(241, 245, 249, 0.85);
+    }
+
+  }
+}

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -27,6 +27,7 @@ use crate::{
 
 pub(crate) mod address_book;
 pub(crate) mod login;
+pub(crate) mod settings;
 
 // In-memory mailbox for offline (`example-data`, `!use-node`) mode.
 // Messages composed via `send_message` are stored here keyed by
@@ -774,6 +775,37 @@ mod menu {
         pub draft_id: Option<String>,
     }
 
+    /// Which Settings screen is open. `None` means the mailbox is showing.
+    #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+    pub(super) enum SettingsScreen {
+        #[default]
+        Account,
+        Privacy,
+        Aft,
+        Inbox,
+        Contacts,
+        Appearance,
+        Advanced,
+    }
+
+    impl SettingsScreen {
+        pub fn label(self) -> &'static str {
+            match self {
+                Self::Account => "Account & profile",
+                Self::Privacy => "Privacy & security",
+                Self::Aft => "Anti-Flood (AFT)",
+                Self::Inbox => "Inbox & folders",
+                Self::Contacts => "Contacts",
+                Self::Appearance => "Appearance",
+                Self::Advanced => "Advanced & Diagnostics",
+            }
+        }
+
+        pub fn is_global(self) -> bool {
+            matches!(self, Self::Appearance | Self::Advanced)
+        }
+    }
+
     #[derive(Default)]
     pub(super) struct MenuSelection {
         folder: Folder,
@@ -783,6 +815,7 @@ mod menu {
         new_msg: bool,
         search: String,
         compose_prefill: Option<ComposePrefill>,
+        settings: Option<SettingsScreen>,
     }
 
     impl MenuSelection {
@@ -877,6 +910,20 @@ mod menu {
         pub fn set_search(&mut self, q: String) {
             self.search = q;
         }
+
+        pub fn settings(&self) -> Option<SettingsScreen> {
+            self.settings
+        }
+
+        pub fn open_settings(&mut self, screen: SettingsScreen) {
+            self.settings = Some(screen);
+            self.new_msg = false;
+            self.compose_prefill = None;
+        }
+
+        pub fn close_settings(&mut self) {
+            self.settings = None;
+        }
     }
 }
 
@@ -909,6 +956,7 @@ fn UserInbox() -> Element {
     use_context_provider(|| Signal::new(Option::<String>::None));
 
     let menu_selection = use_context::<Signal<menu::MenuSelection>>();
+    let settings_open = menu_selection.read().settings().is_some();
 
     rsx! {
         div { class: "fm-app", "data-testid": testid::FM_APP,
@@ -917,6 +965,9 @@ fn UserInbox() -> Element {
                 Sidebar {}
                 MessageList {}
                 DetailPanel {}
+            }
+            if settings_open {
+                { settings::SettingsShell() }
             }
             if menu_selection.read().is_new_msg() {
                 ComposeSheet {}
@@ -959,6 +1010,21 @@ fn Topbar() -> Element {
                 }
             }
             div { class: "topbar-right",
+                button {
+                    class: "fm-icon-btn fm-set-icon",
+                    "aria-label": "Settings",
+                    title: "Settings",
+                    "data-testid": testid::FM_SETTINGS_BTN,
+                    onclick: move |_| {
+                        let mut sel = menu_selection.write();
+                        if sel.settings().is_some() {
+                            sel.close_settings();
+                        } else {
+                            sel.open_settings(menu::SettingsScreen::Account);
+                        }
+                    },
+                    "⚙"
+                }
                 div { class: "avatar", "data-testid": testid::FM_AVATAR, "{alias_initial}" }
             }
         }

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -1,0 +1,968 @@
+//! Settings shell — full-screen takeover inside `.fm-app`. Ported from
+//! the Claude Design handoff bundle (`mail-config-ui-design`).
+//!
+//! Scope of this module: visual + interaction parity with the prototype,
+//! wired to the real active identity for the keys/profile cards. Most
+//! per-screen toggles are still local `Signal<...>` state — persistence
+//! to IndexedDB / contract is a fast-follow.
+//!
+//! Mobile (`.fm-m*`) classes from the prototype are intentionally not
+//! ported in this pass; first cut is desktop-only.
+
+use dioxus::prelude::*;
+
+use crate::app::User;
+use crate::app::address_book;
+use crate::app::menu;
+use crate::testid;
+
+#[allow(non_snake_case)]
+pub(crate) fn SettingsShell() -> Element {
+    let mut menu_selection = use_context::<Signal<menu::MenuSelection>>();
+    let user = use_context::<Signal<User>>();
+
+    let screen = menu_selection
+        .read()
+        .settings()
+        .unwrap_or(menu::SettingsScreen::Account);
+
+    let alias = user
+        .read()
+        .logged_id()
+        .map(|id| id.alias.to_string())
+        .unwrap_or_default();
+    let initial = alias.chars().next().unwrap_or('·').to_string();
+    let fp_short_segs: [&'static str; 3] = user
+        .read()
+        .logged_id()
+        .map(|id| {
+            let words =
+                address_book::fingerprint_words(&id.ml_dsa_vk_bytes(), &id.ml_kem_ek_bytes());
+            [words[0], words[1], words[2]]
+        })
+        .unwrap_or([""; 3]);
+    let _fp_short = format!(
+        "{} · {} · {}",
+        fp_short_segs[0], fp_short_segs[1], fp_short_segs[2]
+    );
+
+    rsx! {
+        div { class: "fm-settings", "data-testid": testid::FM_SETTINGS_SHELL,
+            aside { class: "fm-set-side",
+                button {
+                    class: "fm-set-back",
+                    "data-testid": testid::FM_SETTINGS_BACK,
+                    onclick: move |_| menu_selection.write().close_settings(),
+                    span { class: "arrow", "←" }
+                    "Back to mailbox"
+                }
+                div { class: "fm-set-title", "Settings" }
+                div { class: "fm-set-ident",
+                    span { class: "fm-set-ident-av", "{initial}" }
+                    div { class: "fm-set-ident-text",
+                        span { class: "fm-set-ident-name", "{alias}" }
+                        span { class: "fm-set-ident-meta", "{fp_short_segs[0]} · {fp_short_segs[1]}…" }
+                    }
+                    span { class: "fm-set-ident-caret", "▾" }
+                }
+                NavBlock { current: screen }
+            }
+            main { class: "fm-set-main",
+                BarHeader { current: screen, alias: alias.clone() }
+                div { class: "fm-set-body",
+                    match screen {
+                        menu::SettingsScreen::Account => rsx! { ScrAccount {} },
+                        menu::SettingsScreen::Privacy => rsx! { ScrPrivacy {} },
+                        menu::SettingsScreen::Aft => rsx! { ScrAft {} },
+                        menu::SettingsScreen::Inbox => rsx! { ScrInbox {} },
+                        menu::SettingsScreen::Contacts => rsx! { ScrContacts {} },
+                        menu::SettingsScreen::Appearance => rsx! { ScrAppearance {} },
+                        menu::SettingsScreen::Advanced => rsx! { ScrAdvanced {} },
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn BarHeader(current: menu::SettingsScreen, alias: String) -> Element {
+    let scope_class = if current.is_global() {
+        "fm-set-bar-scope"
+    } else {
+        "fm-set-bar-scope identity"
+    };
+    let scope_text = if current.is_global() {
+        "GLOBAL".to_string()
+    } else {
+        format!("for {alias}")
+    };
+    rsx! {
+        div { class: "fm-set-bar",
+            div { class: "fm-set-bar-title", "{current.label()}" }
+            span { class: "{scope_class}", "{scope_text}" }
+            span { class: "fm-set-bar-grow" }
+            span { class: "fm-set-bar-meta", "⌘," }
+        }
+    }
+}
+
+#[component]
+fn NavBlock(current: menu::SettingsScreen) -> Element {
+    let mut menu_selection = use_context::<Signal<menu::MenuSelection>>();
+
+    let groups: &[(&str, &[(menu::SettingsScreen, &str)])] = &[
+        (
+            "GLOBAL",
+            &[
+                (menu::SettingsScreen::Appearance, "◐ Appearance"),
+                (menu::SettingsScreen::Advanced, "≡ Advanced & Diagnostics"),
+            ],
+        ),
+        (
+            "IDENTITY",
+            &[
+                (menu::SettingsScreen::Account, "◉ Account & profile"),
+                (menu::SettingsScreen::Privacy, "▣ Privacy & security"),
+                (menu::SettingsScreen::Aft, "▶ Anti-Flood (AFT)"),
+                (menu::SettingsScreen::Inbox, "◌ Inbox & folders"),
+                (menu::SettingsScreen::Contacts, "· Contacts"),
+            ],
+        ),
+    ];
+
+    rsx! {
+        div { class: "fm-set-nav",
+            for (heading, items) in groups.iter() {
+                div { class: "fm-set-nav-group", "{heading}" }
+                for (item, label) in items.iter() {
+                    {
+                        let item = *item;
+                        let glyph = label.split_whitespace().next().unwrap_or("·").to_string();
+                        let text = label
+                            .split_once(' ')
+                            .map(|x| x.1)
+                            .unwrap_or(label)
+                            .to_string();
+                        let is_active = current == item;
+                        let class = if is_active {
+                            "fm-set-nav-item is-active"
+                        } else {
+                            "fm-set-nav-item"
+                        };
+                        rsx! {
+                            button {
+                                key: "{label}",
+                                class: "{class}",
+                                "data-testid": testid::FM_SETTINGS_NAV_ITEM,
+                                onclick: move |_| menu_selection.write().open_settings(item),
+                                span { class: "glyph", "{glyph}" }
+                                span { class: "label", "{text}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ===== Atoms =====
+
+#[component]
+fn Card(title: Option<String>, sub: Option<String>, children: Element) -> Element {
+    rsx! {
+        div { class: "fm-card",
+            if title.is_some() || sub.is_some() {
+                div { class: "fm-card-head",
+                    if let Some(t) = title { div { class: "fm-card-title", "{t}" } }
+                    if let Some(s) = sub { div { class: "fm-card-sub", "{s}" } }
+                }
+            }
+            {children}
+        }
+    }
+}
+
+#[component]
+fn SettingRow(
+    label: String,
+    help: Option<String>,
+    stacked: Option<bool>,
+    control: Element,
+) -> Element {
+    let class = if stacked.unwrap_or(false) {
+        "fm-row-set stacked"
+    } else {
+        "fm-row-set"
+    };
+    rsx! {
+        div { class: "{class}",
+            div {
+                div { class: "fm-row-set-label", "{label}" }
+                if let Some(h) = help { div { class: "fm-row-set-help", "{h}" } }
+            }
+            div { {control} }
+        }
+    }
+}
+
+#[component]
+fn Toggle(on: Signal<bool>) -> Element {
+    let cls = if on() { "fm-toggle on" } else { "fm-toggle" };
+    rsx! {
+        button {
+            class: "{cls}",
+            r#type: "button",
+            role: "switch",
+            "aria-checked": "{on()}",
+            onclick: move |_| {
+                let v = on();
+                on.clone().set(!v);
+            },
+        }
+    }
+}
+
+#[component]
+fn FpGrid(seed: String) -> Element {
+    // Deterministic 8x8 fingerprint visualization derived from `seed`.
+    // Mirrors the prototype's `FpGrid` LCG so the visual is stable for a
+    // given identity. Not cryptographically meaningful — a glanceable
+    // identity check that complements the word-based fingerprint.
+    let cells = {
+        let mut h: u32 = 0;
+        for b in seed.as_bytes() {
+            h = h.wrapping_mul(31).wrapping_add(*b as u32);
+        }
+        let mut r = if h == 0 { 1u32 } else { h };
+        let palette = ["#0066cc", "#339966", "#bfdbfe", "#cbd5e1", "#1f2937"];
+        let mut out = Vec::with_capacity(64);
+        for _ in 0..64 {
+            r = r.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            let pick = (r % 7) as usize;
+            let color = match pick {
+                0..=4 => palette[pick],
+                _ => "transparent",
+            };
+            out.push(color.to_string());
+        }
+        out
+    };
+    rsx! {
+        div { class: "fm-fp-grid", "aria-label": "key fingerprint",
+            for (i, c) in cells.iter().enumerate() {
+                span { key: "{i}", class: "cell", style: "background: {c}" }
+            }
+        }
+    }
+}
+
+// ===== Screens =====
+
+#[allow(non_snake_case)]
+fn ScrAccount() -> Element {
+    let user = use_context::<Signal<User>>();
+    let alias = user
+        .read()
+        .logged_id()
+        .map(|id| id.alias.to_string())
+        .unwrap_or_default();
+    let (fp_short, fp_kem_short, vk_seed) = user
+        .read()
+        .logged_id()
+        .map(|id| {
+            let words =
+                address_book::fingerprint_words(&id.ml_dsa_vk_bytes(), &id.ml_kem_ek_bytes());
+            let fp_short = format!("{} · {} · {}", words[0], words[1], words[2]);
+            let fp_kem = format!("{} · {} · {}", words[3], words[4], words[5]);
+            let seed = id
+                .ml_dsa_vk_bytes()
+                .iter()
+                .take(16)
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>();
+            (fp_short, fp_kem, seed)
+        })
+        .unwrap_or_default();
+
+    let display_name = use_signal(String::new);
+    let signature = use_signal(|| String::from("Sent from a node I trust."));
+    let auto_sign = use_signal(|| true);
+    // Backups not yet wired — treat every identity as un-backed-up so the
+    // amber banner shows. Real value will read from a per-identity local
+    // record once #51 lands.
+    let backed_up = false;
+
+    rsx! {
+        div { class: "fm-set-inner",
+            p { class: "fm-set-lede",
+                "Identity-scoped settings. These follow this identity across devices once sync lands. Switch the active identity in the sidebar to edit a different one."
+            }
+            if !backed_up {
+                div { class: "fm-banner amber",
+                    span { class: "fm-banner-glyph", "!" }
+                    div { class: "fm-banner-text",
+                        strong { "This identity has not been backed up." }
+                        " If you lose this browser's storage, the keys go with it. There is no server-side recovery."
+                    }
+                    div { class: "fm-banner-actions",
+                        button { class: "fm-btn-primary", "Back up now" }
+                    }
+                }
+            }
+            Card {
+                title: "Profile",
+                sub: "Visible to anyone you send to.",
+                SettingRow {
+                    label: "Alias",
+                    help: "The handle others type to reach you. Bound to this identity's keys; cannot be changed without rotating.",
+                    control: rsx! { input { class: "fm-input mono", value: "{alias}", disabled: true, style: "width: 180px" } },
+                }
+                SettingRow {
+                    label: "Display name",
+                    help: "Shown next to your alias in recipients' inboxes. Plain text, no verification.",
+                    control: rsx! {
+                        input {
+                            class: "fm-input",
+                            value: "{display_name()}",
+                            style: "width: 180px",
+                            oninput: move |ev| display_name.clone().set(ev.value()),
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Signature",
+                    help: "Appended to outgoing messages from this identity. Plain text only.",
+                    stacked: true,
+                    control: rsx! {
+                        textarea {
+                            class: "fm-textarea",
+                            value: "{signature()}",
+                            oninput: move |ev| signature.clone().set(ev.value()),
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Append signature to new messages",
+                    help: "Disable per-message in the compose footer.",
+                    control: rsx! { Toggle { on: auto_sign } },
+                }
+            }
+            Card {
+                title: "Keys",
+                sub: "Post-quantum keypair. Burned into your alias.",
+                div { class: "fm-keys-grid",
+                    div { class: "fm-key-card",
+                        div { class: "fm-key-card-head",
+                            span { class: "fm-key-card-name", "ML-DSA-65 · signing" }
+                            span { class: "fm-key-card-tag", "verified" }
+                        }
+                        div { style: "display: flex; gap: 14px; align-items: center;",
+                            FpGrid { seed: vk_seed.clone() }
+                            div { class: "fm-key-card-fp", "{fp_short}" }
+                        }
+                        div { class: "fm-key-card-foot",
+                            div { class: "fm-key-meta-list",
+                                span { "rotates ", span { class: "v", "never" } }
+                            }
+                            div { class: "fm-key-actions",
+                                button { class: "fm-btn-secondary", "Show full key" }
+                                button { class: "fm-btn-secondary", "Copy" }
+                            }
+                        }
+                    }
+                    div { class: "fm-key-card",
+                        div { class: "fm-key-card-head",
+                            span { class: "fm-key-card-name", "ML-KEM-768 · encryption" }
+                            span { class: "fm-key-card-tag", "verified" }
+                        }
+                        div { style: "display: flex; gap: 14px; align-items: center;",
+                            FpGrid { seed: format!("{vk_seed}-kem") }
+                            div { class: "fm-key-card-fp", "{fp_kem_short}" }
+                        }
+                        div { class: "fm-key-card-foot",
+                            div { class: "fm-key-meta-list",
+                                span { "rotates ", span { class: "v", "on demand" } }
+                            }
+                            div { class: "fm-key-actions",
+                                button { class: "fm-btn-secondary", "Show full key" }
+                                button { class: "fm-btn-secondary", "Rotate" }
+                            }
+                        }
+                    }
+                }
+                div { class: "fm-sub-row",
+                    span { class: "label", "Fingerprint" }
+                    span { class: "v", "{fp_short}" }
+                    button { class: "fm-btn-secondary", "Show QR" }
+                }
+            }
+            Card {
+                title: "Backup & restore",
+                sub: "Backups are an encrypted bundle of both keys. There's no server-side recovery; lose this and the alias is gone.",
+                SettingRow {
+                    label: "Last backup",
+                    help: "No backup on record. Export one before relying on this identity.",
+                    control: rsx! { button { class: "fm-btn-primary", "Back up now" } },
+                }
+                SettingRow {
+                    label: "Restore from backup",
+                    help: "Replaces the active identity's keys. The current keys will be unrecoverable after this.",
+                    control: rsx! { button { class: "fm-btn-secondary", "Restore…" } },
+                }
+            }
+            Card {
+                title: "Danger zone",
+                SettingRow {
+                    label: "Delete this identity",
+                    help: "Wipes the keypair from this browser. There is no recovery. If you have a backup, you can restore it elsewhere.",
+                    control: rsx! { button { class: "fm-btn-danger", "Delete identity…" } },
+                }
+            }
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+fn ScrPrivacy() -> Element {
+    let verify_on_send = use_signal(|| true);
+    let hide_unsigned = use_signal(|| false);
+    let pad_length = use_signal(|| true);
+    let read_receipts = use_signal(|| false);
+    rsx! {
+        div { class: "fm-set-inner",
+            p { class: "fm-set-lede",
+                "How keys are verified, what counts as trusted, and what to do with messages that aren't."
+            }
+            Card { title: "Sender verification",
+                SettingRow {
+                    label: "Require known key to send",
+                    help: "Block compose to recipients whose ML-DSA-65 key isn't in your known-keys set. Forces you to verify out-of-band first.",
+                    control: rsx! { Toggle { on: verify_on_send } },
+                }
+                SettingRow {
+                    label: "Hide unsigned messages",
+                    help: "Move messages with no ML-DSA signature directly to a quarantine folder.",
+                    control: rsx! { Toggle { on: hide_unsigned } },
+                }
+                SettingRow {
+                    label: "Auto-accept new keys",
+                    help: "When does a sender's key get pinned as 'known' without an explicit verify?",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "never", "Never (manual only)" }
+                            option { value: "known", selected: true, "Only from known senders" }
+                            option { value: "any", "On first message" }
+                        }
+                    },
+                }
+            }
+            Card {
+                title: "Linkability",
+                sub: "Information that reveals patterns across your identities.",
+                SettingRow {
+                    label: "Share read receipts",
+                    help: "Senders see when you opened the message. Off by default; off is the unlinkable option.",
+                    control: rsx! { Toggle { on: read_receipts } },
+                }
+                SettingRow {
+                    label: "Pad message length",
+                    help: "Round ciphertext size to fixed buckets so observers can't infer content size. Adds ~5% bandwidth.",
+                    control: rsx! { Toggle { on: pad_length } },
+                }
+            }
+            Card {
+                title: "Identity delegate",
+                sub: "The contract that resolves your alias to keys.",
+                SettingRow {
+                    label: "Delegate",
+                    help: "identity-management/8c4a… · refreshed 4 min ago",
+                    control: rsx! { button { class: "fm-btn-secondary", "Refresh" } },
+                }
+            }
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+fn ScrAft() -> Element {
+    let used: u32 = 47;
+    let cap: u32 = 365;
+    let pct = used as f32 / cap as f32;
+    let fill_class = if pct > 0.8 {
+        "fm-quota-fill warn"
+    } else {
+        "fm-quota-fill"
+    };
+    let pct_pct = (pct * 100.0).round() as u32;
+
+    let history: [(&str, f32); 7] = [
+        ("MON", 0.18),
+        ("TUE", 0.45),
+        ("WED", 0.31),
+        ("THU", 0.62),
+        ("FRI", 0.92),
+        ("SAT", 0.08),
+        ("SUN", 0.13),
+    ];
+
+    let tiers: [(&str, &str, &str, &str); 4] = [
+        ("Min1", "3", "/ day", "Lowest tier. Casual identities."),
+        ("Min2", "30", "/ day", "Default. Most users sit here."),
+        ("Mid1", "365", "/ day", "Heavy use. Mailing lists, devs."),
+        ("Mid2", "10K", "/ day", "Power tier. Requires reputation."),
+    ];
+
+    let selected_tier = use_signal(|| "Mid1".to_string());
+    let allow_known = use_signal(|| true);
+    let allow_anon = use_signal(|| false);
+    let bounce = use_signal(|| {
+        String::from("Recipient requires Mid1 or higher to send. (https://freenet.org/aft)")
+    });
+
+    rsx! {
+        div { class: "fm-set-inner",
+            p { class: "fm-set-lede",
+                "Anti-Flood Tokens rate-limit the network without a server. Recipients require senders to hold a token of at least the recipient's chosen tier. You set both: what you require, and what you carry."
+            }
+            Card {
+                title: "Today's quota",
+                sub: "Tokens you've used to send. Resets at local midnight.",
+                div { class: "fm-quota",
+                    div { class: "fm-quota-head",
+                        div {
+                            div { class: "fm-quota-num",
+                                "{used} "
+                                span { class: "of", "/" }
+                                " "
+                                span { class: "denom", "{cap}" }
+                            }
+                            div { class: "fm-quota-label", style: "margin-top: 6px",
+                                "Mid1 · 365 / day"
+                            }
+                        }
+                        div { style: "text-align: right",
+                            div { class: "fm-quota-label", "resets in" }
+                            div { style: "font-family: 'Geist Mono', monospace; font-size: 13px; margin-top: 2px;",
+                                "09:28:11"
+                            }
+                        }
+                    }
+                    div { class: "fm-quota-bar",
+                        div { class: "{fill_class}", style: "width: {pct * 100.0}%" }
+                    }
+                    div { class: "fm-quota-foot",
+                        span { "0" }
+                        span { "{pct_pct}% used" }
+                        span { "{cap}" }
+                    }
+                }
+                div { class: "fm-spark",
+                    for (day, v) in history.iter() {
+                        div { key: "{day}", class: "fm-spark-row",
+                            span { class: "day", "{day}" }
+                            span { class: "fm-spark-track",
+                                span { class: "fm-spark-fill", style: "width: {v * 100.0}%" }
+                            }
+                            span { class: "val", "{(v * cap as f32) as u32}" }
+                        }
+                    }
+                }
+                div { class: "fm-sub-row",
+                    span { class: "label", "Notify at" }
+                    span { class: "v", "80% used (toast) · 95% used (modal)" }
+                    span { style: "flex: 1" }
+                    button { class: "fm-btn-secondary", "Edit thresholds" }
+                }
+            }
+            Card {
+                title: "Your tier",
+                sub: "The cap your local node mints against. Higher tiers cost reputation; lower tiers throttle.",
+                div { class: "fm-tier-grid",
+                    for (id, rate, per, help) in tiers.iter() {
+                        {
+                            let id_str = id.to_string();
+                            let active = selected_tier() == id_str;
+                            let cls = if active { "fm-tier is-active" } else { "fm-tier" };
+                            rsx! {
+                                button {
+                                    key: "{id}",
+                                    class: "{cls}",
+                                    r#type: "button",
+                                    style: "all: unset; display: flex; flex-direction: column; gap: 4px; cursor: default; border: 1px solid var(--line); border-radius: 11px; padding: 12px 12px 10px; background: #fff;",
+                                    onclick: move |_| selected_tier.clone().set(id_str.clone()),
+                                    div { class: "fm-tier-name", "{id}" }
+                                    div { class: "fm-tier-rate",
+                                        "{rate}"
+                                        span { class: "unit", " {per}" }
+                                    }
+                                    div { class: "fm-tier-help", "{help}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Card {
+                title: "Required tier for incoming mail",
+                sub: "Senders must hold a token of this tier or higher to land in your inbox. Lower-tier sends bounce.",
+                SettingRow {
+                    label: "Minimum tier",
+                    help: "Tighten this if you're seeing spam. Loosen it if you're being bounced from senders who don't carry your floor.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "Min1", "Min1" }
+                            option { value: "Min2", selected: true, "Min2" }
+                            option { value: "Mid1", "Mid1" }
+                            option { value: "Mid2", "Mid2" }
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Allow lower tiers from known contacts",
+                    help: "People in your address book bypass the tier floor.",
+                    control: rsx! { Toggle { on: allow_known } },
+                }
+                SettingRow {
+                    label: "Allow no-tier (anonymous)",
+                    help: "Off by default. Recommended only for public dropboxes.",
+                    control: rsx! { Toggle { on: allow_anon } },
+                }
+                SettingRow {
+                    label: "Bounce message",
+                    help: "Returned to senders below your floor. They see this; you don't.",
+                    stacked: true,
+                    control: rsx! {
+                        textarea {
+                            class: "fm-textarea",
+                            value: "{bounce()}",
+                            oninput: move |ev| bounce.clone().set(ev.value()),
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+fn ScrInbox() -> Element {
+    let drafts_in_inbox = use_signal(|| false);
+    let quarantine_unknown = use_signal(|| true);
+    rsx! {
+        div { class: "fm-set-inner",
+            p { class: "fm-set-lede", "How messages move through this inbox." }
+            Card { title: "Folders",
+                SettingRow {
+                    label: "Auto-archive after",
+                    help: "Read messages move from Inbox to Archive after this delay. Local rule; doesn't notify the sender.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "never", selected: true, "Never" }
+                            option { value: "7d", "7 days" }
+                            option { value: "30d", "30 days" }
+                            option { value: "90d", "90 days" }
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Sent retention",
+                    help: "How long to keep sent messages. Sent items also count against your contract storage.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "forever", selected: true, "Forever" }
+                            option { value: "1y", "1 year" }
+                            option { value: "30d", "30 days" }
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Show drafts in Inbox",
+                    help: "Off: drafts stay in Drafts only. On: surface them in Inbox above the unread band.",
+                    control: rsx! { Toggle { on: drafts_in_inbox } },
+                }
+            }
+            Card {
+                title: "Quarantine",
+                sub: "Where messages with verification problems land.",
+                SettingRow {
+                    label: "Hold messages with unknown keys",
+                    help: "Land them in Quarantine instead of Inbox. You'll see a count badge.",
+                    control: rsx! { Toggle { on: quarantine_unknown } },
+                }
+                SettingRow {
+                    label: "Auto-delete from Quarantine after",
+                    help: "Messages here never count against unread. They burn no token from you on receipt.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "7d", "7 days" }
+                            option { value: "14d", selected: true, "14 days" }
+                            option { value: "30d", "30 days" }
+                            option { value: "never", "Never" }
+                        }
+                    },
+                }
+            }
+            Card { title: "Compose defaults",
+                SettingRow {
+                    label: "Save drafts every",
+                    help: "Drafts are written to local IndexedDB only. Lose the browser, lose the draft.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "off", "off" }
+                            option { value: "10s", selected: true, "10s" }
+                            option { value: "30s", "30s" }
+                            option { value: "60s", "60s" }
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Default reply behavior",
+                    help: "Reply-all is unusual on Freenet — most threads are 1:1.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "reply", selected: true, "Reply (sender only)" }
+                            option { value: "all", "Reply all" }
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+fn ScrContacts() -> Element {
+    // Stub list — replaced when we wire to the real address book signal.
+    let contacts: &[(&str, &str, &str, &str, &str, &str)] = &[
+        ("alice.freenet", "a", "known", "Mid1", "ce11d8a93f02", ""),
+        (
+            "ian.freenet",
+            "i",
+            "known",
+            "Min2",
+            "7afd220e9c11",
+            "@ml-kem co-author",
+        ),
+        (
+            "freenet-aft",
+            "f",
+            "known",
+            "Mid2",
+            "system",
+            "AFT mint daemon",
+        ),
+        ("kex-bot", "k", "unknown", "Min2", "3f2a1c80de7b", ""),
+        ("ml-dsa-test", "m", "unsigned", "Min1", "9911aa00bb22", ""),
+    ];
+    rsx! {
+        div { class: "fm-set-inner",
+            p { class: "fm-set-lede",
+                "Your address book. Names you've assigned, trust levels you've accepted, and the tier each contact runs at."
+            }
+            Card {
+                div { style: "display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-bottom: 1px solid var(--line2);",
+                    input { class: "fm-input", placeholder: "Search contacts, fingerprints…", style: "flex: 1" }
+                    select { class: "fm-select",
+                        option { value: "all", "All trust levels" }
+                        option { value: "known", "Known only" }
+                        option { value: "unknown", "Unknown" }
+                        option { value: "unsigned", "Unsigned" }
+                    }
+                    button { class: "fm-btn-secondary", "Import…" }
+                    button { class: "fm-btn-primary", "Share my card" }
+                }
+                div { class: "fm-contact-list",
+                    for (alias, initial, trust, tier, fp, label) in contacts.iter() {
+                        div { key: "{alias}", class: "fm-contact-row",
+                            span { class: "fm-contact-av", "{initial}" }
+                            span { class: "fm-contact-name",
+                                span { class: "alias", "{alias}" }
+                                span { class: "fp", "…{fp}" }
+                                if !label.is_empty() {
+                                    span {
+                                        style: "font-style: italic; color: var(--ink3); font-size: 11.5px; margin-left: 8px;",
+                                        "· {label}"
+                                    }
+                                }
+                            }
+                            span { class: "fm-contact-trust {trust}", "{trust}" }
+                            span { class: "fm-contact-tier", "{tier}" }
+                            button { class: "fm-btn-secondary", style: "height: 26px; padding: 0 9px; font-size: 11px;", "Edit" }
+                        }
+                    }
+                }
+            }
+            Card { title: "Defaults for new contacts",
+                SettingRow {
+                    label: "Trust on first message",
+                    help: "Sets the starting trust level when someone new sends you a verifiable signed message.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "unknown", selected: true, "unknown" }
+                            option { value: "known", "known" }
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Format for share-my-card",
+                    help: "What gets copied when you click 'Share my card'.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "contact-uri", selected: true, "contact:// URI (default)" }
+                            option { value: "qr", "QR code" }
+                            option { value: "vcard", "vCard 4.0" }
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+fn ScrAppearance() -> Element {
+    let serif_subjects = use_signal(|| true);
+    rsx! {
+        div { class: "fm-set-inner",
+            p { class: "fm-set-lede", "Visual settings shared across every identity on this device." }
+            Card { title: "Theme",
+                SettingRow {
+                    label: "Color theme",
+                    help: "Dark theme matches the system; nothing is themed per identity.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "auto", selected: true, "auto" }
+                            option { value: "light", "light" }
+                            option { value: "dark", "dark" }
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Density",
+                    help: "Affects row height and padding throughout the mailbox.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "compact", "compact" }
+                            option { value: "cozy", selected: true, "cozy" }
+                            option { value: "comfortable", "comfortable" }
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Subjects in serif",
+                    help: "Off: subjects render in DM Sans like the rest of the UI.",
+                    control: rsx! { Toggle { on: serif_subjects } },
+                }
+            }
+            Card { title: "Typography",
+                SettingRow {
+                    label: "UI font size",
+                    help: "13.5px is the design default. 15 is recommended for small displays.",
+                    control: rsx! {
+                        select { class: "fm-select",
+                            option { value: "12", "12" }
+                            option { value: "13.5", selected: true, "13.5" }
+                            option { value: "15", "15" }
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+fn ScrAdvanced() -> Element {
+    let custom_relay = use_signal(|| false);
+    let log: &[(&str, &str, &str)] = &[
+        (
+            "14:32:01",
+            "info",
+            "ws connected · 127.0.0.1:7509 · 12ms rtt",
+        ),
+        ("14:32:01", "ok", "inbox contract resolved · 8f3c…d8a93f02"),
+        ("14:31:48", "info", "aft mint cap reached daily quota check"),
+        (
+            "14:31:46",
+            "ok",
+            "burned 1 token · msg sent to alice.freenet",
+        ),
+        ("14:30:12", "warn", "delegate stale (4m); refreshing"),
+        ("14:30:13", "ok", "delegate ok · ml-dsa-65 verified"),
+        (
+            "14:28:55",
+            "info",
+            "web-container hash matches contract-id.txt",
+        ),
+        (
+            "14:28:54",
+            "info",
+            "boot · ui v0.1.4-pre-alpha · wasm 1.4MB",
+        ),
+    ];
+    rsx! {
+        div { class: "fm-set-inner",
+            p { class: "fm-set-lede",
+                "Network plumbing, logs, factory reset. Most users will never come here."
+            }
+            Card { title: "Node connection",
+                SettingRow {
+                    label: "Local node",
+                    help: "127.0.0.1:7509 · ML-KEM · ML-DSA · WebSocket alive",
+                    control: rsx! { button { class: "fm-btn-secondary", "Reconnect" } },
+                }
+                SettingRow {
+                    label: "Use custom relay",
+                    help: "By default we connect to the local Freenet node. Override only if you know what you're doing.",
+                    control: rsx! { Toggle { on: custom_relay } },
+                }
+            }
+            Card {
+                title: "Storage",
+                sub: "Everything is local to this browser. Encrypted on disk only by the OS.",
+                SettingRow {
+                    label: "IndexedDB usage",
+                    help: "Messages, drafts, address book.",
+                    control: rsx! {
+                        span { style: "font-family: 'Geist Mono', monospace; font-size: 11px; color: var(--ink2);", "14.2 MB / 80 MB" }
+                    },
+                }
+                SettingRow {
+                    label: "Clear local cache",
+                    help: "Wipes cached contract state. Forces a full re-sync. Does not touch keys or messages.",
+                    control: rsx! { button { class: "fm-btn-secondary", "Clear cache" } },
+                }
+            }
+            Card {
+                title: "Diagnostics",
+                sub: "Last 8 events from this session. Useful when filing issues.",
+                div { class: "fm-term",
+                    for (i, (ts, lvl, txt)) in log.iter().enumerate() {
+                        div { key: "{i}",
+                            span { class: "ts", "{ts}" }
+                            " "
+                            span { class: "lvl-{lvl}", "{lvl.to_uppercase()}" }
+                            " "
+                            span { "{txt}" }
+                        }
+                    }
+                }
+                div { class: "fm-sub-row",
+                    span { class: "label", "Build" }
+                    span { class: "v", "ui v0.1.4-pre-alpha · wasm 1.4 MB" }
+                    span { style: "flex: 1" }
+                    button { class: "fm-btn-secondary", "Copy report" }
+                }
+            }
+            Card { title: "Danger zone",
+                SettingRow {
+                    label: "Factory reset",
+                    help: "Deletes all identities, contacts, messages, and the address book from this browser. Irreversible.",
+                    control: rsx! { button { class: "fm-btn-danger", "Reset everything…" } },
+                }
+            }
+        }
+    }
+}

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -96,6 +96,12 @@ pub(crate) const FM_IMPORT_CONTACT_MODAL: &str = "fm-import-contact-modal";
 pub(crate) const FM_IMPORT_FP: &str = "fm-import-fp";
 pub(crate) const FM_IMPORT_SUBMIT: &str = "fm-import-submit";
 
+// Settings
+pub(crate) const FM_SETTINGS_BTN: &str = "fm-settings-btn";
+pub(crate) const FM_SETTINGS_SHELL: &str = "fm-settings-shell";
+pub(crate) const FM_SETTINGS_BACK: &str = "fm-settings-back";
+pub(crate) const FM_SETTINGS_NAV_ITEM: &str = "fm-settings-nav-item";
+
 #[cfg(test)]
 mod tests {
     /// Guard against drift between the Rust constants in this module and
@@ -164,6 +170,10 @@ mod tests {
             ("fmImportContactModal", super::FM_IMPORT_CONTACT_MODAL),
             ("fmImportFp", super::FM_IMPORT_FP),
             ("fmImportSubmit", super::FM_IMPORT_SUBMIT),
+            ("fmSettingsBtn", super::FM_SETTINGS_BTN),
+            ("fmSettingsShell", super::FM_SETTINGS_SHELL),
+            ("fmSettingsBack", super::FM_SETTINGS_BACK),
+            ("fmSettingsNavItem", super::FM_SETTINGS_NAV_ITEM),
         ];
         assert_eq!(
             json.len(),


### PR DESCRIPTION
## Summary
- Port Claude Design handoff bundle (`screens.jsx` + `shell.jsx` + `atoms.jsx` + `settings.css`) into Dioxus as a full-screen takeover opened from a new gear icon in the topbar.
- Seven screens — Account, Privacy, AFT, Inbox, Contacts, Appearance, Advanced — with a left-rail nav split into GLOBAL + IDENTITY groups.
- Wired to real identity state for the Account keys card (ML-DSA + ML-KEM fingerprints + `FpGrid` seeded from `vk_bytes`); other settings stub-state via local `Signal`s for now (persistence is a fast-follow).

## What's in
- `ui/public/vendor/css/components/settings.css` — full CSS port, wrapped in `@layer components { @scope (.fm-app) { ... } }` to match the repo's scoped-component pattern.
- `ui/src/app/settings.rs` — `SettingsShell`, `BarHeader`, `NavBlock`, atoms (`Card`, `SettingRow`, `Toggle`, `FpGrid`) + the seven `Scr*` screen functions.
- `ui/src/app.rs` — `MenuSelection::settings: Option<SettingsScreen>` accessors, gear button in topbar, conditional shell render in `UserInbox`.
- 4 new testids (`fmSettingsBtn`, `fmSettingsShell`, `fmSettingsBack`, `fmSettingsNavItem`) paired in `testid.rs` ↔ `testids.json`.

## What's deferred (by request in the handoff chat)
- Mobile (`.fm-m*`) screens.
- Real backup / wipe / restore modals — buttons render but don't open dialogs yet.
- Persistence layer for non-identity settings.
- Identity switcher popover (caret renders, no popover behavior).

## Test plan
- [x] `cargo build -p freenet-email-ui --features example-data,no-sync --no-default-features`
- [x] `cargo build -p freenet-email-ui` (default `use-node`)
- [x] `cargo test -p freenet-email-ui --lib` — 26 passed (includes `testid::tests::json_matches_rust_consts`)
- [x] `cargo make clippy`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: open in dev-example, toggle gear, navigate all 7 screens, verify Account screen shows real alias + fingerprints + 8×8 grid for the active identity.