### PR TITLE
fix(ui): silence noisy SubscribeResponse "message not handled" warning

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1555,6 +1555,11 @@ pub(crate) async fn node_comms(
                 }
             }
             HostResponse::Ok => {}
+            HostResponse::ContractResponse(ContractResponse::SubscribeResponse { .. }) => {
+                // Confirms a subscription bookkeeping ack; nothing to drive
+                // off it on the UI side. Logging produces a noisy "message
+                // not handled" line every time we subscribe to inbox/AFT.
+            }
             other => {
                 crate::log::error(format!("message not handled: {other:?}"), None);
             }


### PR DESCRIPTION
## Summary
- `HostResponse::ContractResponse(ContractResponse::SubscribeResponse { .. })` was hitting the default `other` arm in `node_comms`, logging `message not handled: …` once per subscribe (inbox + AFT record + token contract per identity).
- Added an explicit no-op arm. The general "unknown variant" path keeps its diagnostic value.

## Test plan
- [x] `cargo check -p freenet-email-ui --no-default-features --features use-node --target wasm32-unknown-unknown`
- [ ] Live-node iso harness: console no longer shows `message not handled: ContractResponse(SubscribeResponse {…})` after login.