### PR TITLE
feat(ui): mark imported contact verified after import (closes #87)

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -3,44 +3,35 @@
   "fmAvatar": "fm-avatar",
   "fmLogout": "fm-logout",
   "fmSearch": "fm-search",
-
   "fmComposeBtn": "fm-compose-btn",
-
   "fmList": "fm-list",
   "fmMsgCard": "fm-msg-card",
   "fmMsgTime": "fm-msg-time",
   "fmDraftCard": "fm-draft-card",
   "fmSentCard": "fm-sent-card",
   "fmArchiveCard": "fm-archive-card",
-
   "fmDetailTime": "fm-detail-time",
   "fmDetailFingerprint": "fm-detail-fingerprint",
   "fmDetailVerif": "fm-detail-verif",
   "fmAddToAb": "fm-add-to-ab",
   "fmComposeSendingAs": "fm-compose-sending-as",
   "fmSidebarFingerprint": "fm-sidebar-fingerprint",
-
   "fmReply": "fm-reply",
   "fmDelete": "fm-delete",
   "fmArchive": "fm-archive",
-
   "fmSentBody": "fm-sent-body",
   "fmSentDelivery": "fm-sent-delivery",
   "fmSentFingerprint": "fm-sent-fingerprint",
   "fmSentForward": "fm-sent-forward",
   "fmSentReply": "fm-sent-reply",
   "fmSentResend": "fm-sent-resend",
-
   "fmArchiveBody": "fm-archive-body",
   "fmArchiveDelete": "fm-archive-delete",
   "fmArchiveReply": "fm-archive-reply",
   "fmArchiveUnarchive": "fm-archive-unarchive",
-
   "fmComposeSheet": "fm-compose-sheet",
   "fmSend": "fm-send",
-
   "fmToast": "fm-toast",
-
   "fmActionCreate": "fm-action-create",
   "fmActionImport": "fm-action-import",
   "fmCreateAliasInput": "fm-create-alias-input",
@@ -49,7 +40,6 @@
   "fmVerifyCheck": "fm-verify-check",
   "fmRestoreFile": "fm-restore-file",
   "fmRestoreSubmit": "fm-restore-submit",
-
   "fmIdRow": "fm-id-row",
   "fmIdOpen": "fm-id-open",
   "fmIdCreate": "fm-id-create",
@@ -70,5 +60,9 @@
   "fmSettingsBtn": "fm-settings-btn",
   "fmSettingsShell": "fm-settings-shell",
   "fmSettingsBack": "fm-settings-back",
-  "fmSettingsNavItem": "fm-settings-nav-item"
+  "fmSettingsNavItem": "fm-settings-nav-item",
+
+  "fmContactVerify": "fm-contact-verify",
+  "fmVerifyContactModal": "fm-verify-contact-modal",
+  "fmVerifyContactSubmit": "fm-verify-contact-submit"
 }

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -503,6 +503,13 @@ struct SharePendingData {
 
 struct ImportContact(bool);
 
+/// Carries the `Contact` whose verified flag the user is about to flip.
+/// `None` while the modal is closed; populated by the row-level Verify
+/// button. Holding the full `Contact` here (rather than just the alias)
+/// avoids a second lookup against `ADDRESS_BOOK` when we re-send it.
+#[derive(Clone, Default)]
+struct VerifyContactPending(Option<crate::app::address_book::Contact>);
+
 #[derive(Debug, Clone)]
 pub struct LoginController {
     pub updated: bool,
@@ -521,6 +528,7 @@ pub(super) fn IdentifiersList() -> Element {
     use_context_provider(|| Signal::new(ShareContact(false)));
     use_context_provider(|| Signal::new(SharePending::default()));
     use_context_provider(|| Signal::new(ImportContact(false)));
+    use_context_provider(|| Signal::new(VerifyContactPending::default()));
     // ImportForm is shared between the hub flow (toggled by ImportBackup
     // here) and the first-run flow (toggled by ImportId in
     // GetOrCreateIdentity). Provide both contexts so the same component
@@ -530,6 +538,7 @@ pub(super) fn IdentifiersList() -> Element {
     let import_backup_form = use_context::<Signal<ImportBackup>>();
     let share_contact_form = use_context::<Signal<ShareContact>>();
     let import_contact_form = use_context::<Signal<ImportContact>>();
+    let verify_contact_pending = use_context::<Signal<VerifyContactPending>>();
 
     rsx! {
         div { class: "fm-pre",
@@ -551,6 +560,9 @@ pub(super) fn IdentifiersList() -> Element {
             }
             if import_contact_form.read().0 {
                 ImportContactForm {}
+            }
+            if verify_contact_pending.read().0.is_some() {
+                VerifyContactModal {}
             }
         }
     }
@@ -1534,10 +1546,110 @@ fn ImportContactForm() -> Element {
     }
 }
 
+/// Confirm-verification modal. Re-renders the existing six-word
+/// fingerprint and asks the user to tick the same checkbox the import
+/// flow uses. On submit, re-creates the contact with `verified = true`,
+/// reusing the delegate's overwrite-on-same-keys semantics so no new
+/// op type is needed (issue #87).
+#[allow(non_snake_case)]
+fn VerifyContactModal() -> Element {
+    let mut verify_pending = use_context::<Signal<VerifyContactPending>>();
+    let actions = use_coroutine_handle::<NodeAction>();
+    let mut confirmed = use_signal(|| false);
+
+    let pending = verify_pending.read().0.clone();
+    let Some(contact) = pending else { return rsx! {}; };
+    let alias_str = contact.local_alias.to_string();
+    let words = contact.fingerprint();
+
+    let close = move |_| {
+        verify_pending.write().0 = None;
+        confirmed.set(false);
+    };
+    let check_class = if *confirmed.read() {
+        "verify-check checked"
+    } else {
+        "verify-check"
+    };
+
+    rsx! {
+        div { class: "veil",
+            onclick: close,
+            div { class: "modal",
+                "data-testid": testid::FM_VERIFY_CONTACT_MODAL,
+                onclick: move |ev| { ev.stop_propagation(); },
+                div { class: "modal-head",
+                    span { class: "modal-title", "Mark contact verified" }
+                    button { class: "modal-x", onclick: close, "✕" }
+                }
+                div { class: "modal-body",
+                    p { class: "field-help", style: "margin: -4px 0 14px;",
+                        "Confirm these six words with {alias_str} through a separate channel — phone, in person, Signal, anything but this app."
+                    }
+                    div { class: "verify-words",
+                        div { class: "verify-words-label",
+                            span { class: "pulse-dot" }
+                            "Fingerprint"
+                        }
+                        div { class: "verify-words-grid",
+                            {
+                                words.iter().enumerate().map(|(i, w)| rsx! {
+                                    div { class: "verify-word",
+                                        span { class: "num", "{i + 1:02}" }
+                                        span { class: "w", "{w}" }
+                                    }
+                                })
+                            }
+                        }
+                    }
+                    label {
+                        class: "{check_class}",
+                        "data-testid": testid::FM_VERIFY_CHECK,
+                        onclick: move |_| {
+                            let v = *confirmed.read();
+                            confirmed.set(!v);
+                        },
+                        div { class: "verify-box",
+                            span { class: "tick", "✓" }
+                        }
+                        div { class: "verify-text",
+                            span { class: "verify-headline",
+                                "I verified these six words with {alias_str}"
+                            }
+                        }
+                    }
+                }
+                div { class: "modal-foot",
+                    button { class: "btn btn-ghost", onclick: close, "Cancel" }
+                    {
+                        let submit_contact = contact.clone();
+                        rsx! {
+                            button {
+                                class: "btn btn-primary",
+                                "data-testid": testid::FM_VERIFY_CONTACT_SUBMIT,
+                                disabled: !*confirmed.read(),
+                                onclick: move |_| {
+                                    let mut updated = submit_contact.clone();
+                                    updated.verified = true;
+                                    actions.send(NodeAction::CreateContact { contact: updated });
+                                    verify_pending.write().0 = None;
+                                    confirmed.set(false);
+                                },
+                                "Mark verified"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Address book section showing all imported contacts.
 #[allow(non_snake_case)]
 fn ContactsSection() -> Element {
     let mut import_contact_form = use_context::<Signal<ImportContact>>();
+    let mut verify_pending = use_context::<Signal<VerifyContactPending>>();
     let actions = use_coroutine_handle::<NodeAction>();
     let contacts = crate::app::address_book::all_contacts();
     let mut login_controller = use_context::<Signal<LoginController>>();
@@ -1597,6 +1709,22 @@ fn ContactsSection() -> Element {
                                     span { class: "badge badge-warn",
                                         "data-testid": "contact-verify-badge",
                                         "⚠ unverified"
+                                    }
+                                }
+                                if !verified {
+                                    {
+                                        let pending_contact = contact.clone();
+                                        rsx! {
+                                            button {
+                                                class: "btn btn-ghost btn-xs",
+                                                title: "Confirm fingerprint with sender and mark verified",
+                                                "data-testid": testid::FM_CONTACT_VERIFY,
+                                                onclick: move |_| {
+                                                    verify_pending.write().0 = Some(pending_contact.clone());
+                                                },
+                                                "Verify"
+                                            }
+                                        }
                                     }
                                 }
                                 button {

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -1558,7 +1558,9 @@ fn VerifyContactModal() -> Element {
     let mut confirmed = use_signal(|| false);
 
     let pending = verify_pending.read().0.clone();
-    let Some(contact) = pending else { return rsx! {}; };
+    let Some(contact) = pending else {
+        return rsx! {};
+    };
     let alias_str = contact.local_alias.to_string();
     let words = contact.fingerprint();
 

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -95,6 +95,9 @@ pub(crate) const FM_CONTACT_IMPORT: &str = "fm-contact-import";
 pub(crate) const FM_IMPORT_CONTACT_MODAL: &str = "fm-import-contact-modal";
 pub(crate) const FM_IMPORT_FP: &str = "fm-import-fp";
 pub(crate) const FM_IMPORT_SUBMIT: &str = "fm-import-submit";
+pub(crate) const FM_CONTACT_VERIFY: &str = "fm-contact-verify";
+pub(crate) const FM_VERIFY_CONTACT_MODAL: &str = "fm-verify-contact-modal";
+pub(crate) const FM_VERIFY_CONTACT_SUBMIT: &str = "fm-verify-contact-submit";
 
 // Settings
 pub(crate) const FM_SETTINGS_BTN: &str = "fm-settings-btn";
@@ -174,6 +177,9 @@ mod tests {
             ("fmSettingsShell", super::FM_SETTINGS_SHELL),
             ("fmSettingsBack", super::FM_SETTINGS_BACK),
             ("fmSettingsNavItem", super::FM_SETTINGS_NAV_ITEM),
+            ("fmContactVerify", super::FM_CONTACT_VERIFY),
+            ("fmVerifyContactModal", super::FM_VERIFY_CONTACT_MODAL),
+            ("fmVerifyContactSubmit", super::FM_VERIFY_CONTACT_SUBMIT),
         ];
         assert_eq!(
             json.len(),

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -745,6 +745,75 @@ test.describe("Import contact verify-check (#52)", () => {
       row.locator('[data-testid="contact-verify-badge"]'),
     ).toContainText("✓");
   });
+
+  // Regression for #87 — promote an unverified contact via the row's
+  // Verify button. The row had no escape from `⚠ unverified` short of
+  // delete-and-reimport, which also dropped the local description.
+  test("Verify button promotes an unverified contact in place (#87)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const contactCard = await page.evaluate(() => {
+      const mlDsaVk = new Array(1952)
+        .fill(0)
+        .map((_, i) => (i * 17 + 31) & 0xff);
+      const mlKemEk = new Array(1184)
+        .fill(0)
+        .map((_, i) => (i * 19 + 37) & 0xff);
+      const card = {
+        version: 1,
+        ml_dsa_vk_bytes: mlDsaVk,
+        ml_kem_ek_bytes: mlKemEk,
+        suggested_alias: "echo",
+        suggested_description: "Verify-after-import test",
+      };
+      return `verify: foo-bar-baz-qux-quux-corge\ncontact://${btoa(
+        JSON.stringify(card),
+      )}`;
+    });
+
+    // Import without ticking the verify checkbox.
+    await page.locator('[data-testid="fm-contact-import"]').click();
+    const importModal = page.locator('[data-testid="fm-import-contact-modal"]');
+    await importModal.locator("textarea").fill(contactCard);
+    await page
+      .locator('input[placeholder="e.g. Alice (work)"]')
+      .fill("echo-test");
+    await page.locator('[data-testid="fm-import-submit"]').click();
+
+    const row = page.locator(
+      '[data-testid="contact-row"][data-alias="echo-test"]',
+    );
+    await expect(row).toBeVisible({ timeout: 5_000 });
+    await expect(
+      row.locator('[data-testid="contact-verify-badge"]'),
+    ).toContainText("⚠");
+
+    // Row exposes a Verify button only while the badge is amber.
+    await row.locator('[data-testid="fm-contact-verify"]').click();
+
+    const verifyModal = page.locator('[data-testid="fm-verify-contact-modal"]');
+    await expect(verifyModal).toBeVisible({ timeout: 5_000 });
+
+    // Submit is disabled until the same six-word checkbox is ticked.
+    const submit = page.locator('[data-testid="fm-verify-contact-submit"]');
+    await expect(submit).toBeDisabled();
+    await page.locator('[data-testid="fm-verify-check"]').click();
+    await expect(submit).toBeEnabled();
+    await submit.click();
+
+    // Modal closes, badge flips to green ✓, and the Verify button is
+    // gone (only rendered for unverified rows).
+    await expect(verifyModal).toBeHidden();
+    await expect(
+      row.locator('[data-testid="contact-verify-badge"]'),
+    ).toContainText("✓", { timeout: 5_000 });
+    await expect(row.locator('[data-testid="fm-contact-verify"]')).toHaveCount(
+      0,
+    );
+  });
 });
 
 test.describe("Restore backup card (#52)", () => {

--- a/ui/tests/testids.ts
+++ b/ui/tests/testids.ts
@@ -59,6 +59,9 @@ interface TestIds {
   fmImportContactModal: string;
   fmImportFp: string;
   fmImportSubmit: string;
+  fmContactVerify: string;
+  fmVerifyContactModal: string;
+  fmVerifyContactSubmit: string;
 }
 
 export const TID: TestIds = JSON.parse(


### PR DESCRIPTION
## Summary
- Closes #87. Imported-as-unverified contacts had no escape from the amber `⚠ unverified` badge other than delete + re-import, which also dropped any local description/notes.
- Adds a "Verify" button to each unverified contact row that opens a six-word confirm modal (same look-and-feel as the import-time check). Submitting re-sends `NodeAction::CreateContact` with `verified = true` against the same keys; the local store and the identity-management delegate both already accept this as an overwrite, so no new op type is needed.
- New testids: `fmContactVerify`, `fmVerifyContactModal`, `fmVerifyContactSubmit` (with matching JSON + Rust + TS entries).

## Test plan
- [x] `cargo test -p freenet-email-ui --features example-data,no-sync --no-default-features --target=$(rustc -vV | sed -n 's/host: //p') json_matches_rust_consts` (testid drift)
- [x] `cargo make build-ui-example-no-sync` (offline release wasm)
- [x] `npx playwright test email-app.spec.ts -g "contact|Contact|verify|Verify|Import" --project=chromium` — 4/4 pass, including the new "Verify button promotes an unverified contact in place (#87)" regression.
- [ ] Live-node iso harness: import a contact with the box unchecked, click Verify, tick the box, assert the badge flips and the delegate persists (re-login keeps the verified flag).