### PR TITLE
ci: move heavy jobs to ubicloud-standard-8 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,11 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    # ubicloud-standard-8 mirrors freenet-core's CI runner choice for the
+    # heavy Rust + WASM compile path. ~3× faster wall-clock vs the free
+    # ubuntu-latest tier (which queues unpredictably and lacks the cores
+    # to parallelise the workspace build).
+    runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v4
         with:
@@ -92,7 +96,7 @@ jobs:
         run: cargo make test-inbox
 
   ui-playwright-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-8
     needs: build-and-test
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-contract-wasm.yml
+++ b/.github/workflows/check-contract-wasm.yml
@@ -25,7 +25,10 @@ on:
 
 jobs:
   check-drift:
-    runs-on: ubuntu-latest
+    # ubicloud-standard-8 — rebuilding the published contract from
+    # source involves a full wasm32 compile of the web-container +
+    # webapp, same compile-bound profile as build.yml.
+    runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e-real-node.yml
+++ b/.github/workflows/e2e-real-node.yml
@@ -30,7 +30,10 @@ env:
 
 jobs:
   e2e-real-node:
-    runs-on: ubuntu-latest
+    # ubicloud-standard-8 — full Freenet network + dx build + headed
+    # browser. The free tier's 2 cores struggle with the parallel build
+    # and frequently push the run past the timeout.
+    runs-on: ubicloud-standard-8
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Switches the compile-bound jobs (build-and-test, ui-playwright-tests, check-drift, e2e-real-node) to \`ubicloud-standard-8\`, mirroring freenet-core's runner choice.
- Free \`ubuntu-latest\` queues unpredictably and lacks the cores to parallelise the workspace build — multiple PRs today sat 10+ min before any workflow queued. ubicloud's 8-core machines have been the proven choice in core for the same compile profile.
- Lightweight jobs (CLA, plus future fmt / conv-commits) stay on \`ubuntu-latest\`, same split as core's ci.yml.

## Test plan
- [ ] Watch this PR's check run for build-and-test + ui-playwright-tests on ubicloud and compare wall-clock to recent ubuntu-latest runs (#88 ubuntu-latest: build-and-test 1m57s, ui-playwright 2m58s).
- [ ] check-contract-wasm: same.
- [ ] e2e-real-node won't fire on this PR (paths gate); will validate on next tag/nightly.