### PR TITLE
feat(ui): persist Settings via mail-local-state delegate

### DIFF
--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -154,6 +154,101 @@ pub struct KeptMessage {
     pub kept_at: i64,
 }
 
+/// Per-identity AFT preferences. The required tier and the allow-known /
+/// allow-anonymous flags govern which incoming messages this identity will
+/// accept; `bounce_message` is shown to senders whose tier is below the
+/// requirement (the chain itself just refuses; the bounce text is informational
+/// and rendered locally on the sender side via the address book).
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+pub struct IdentityAftPrefs {
+    /// Minimum tier the identity will accept. Stored as the canonical
+    /// freenet-aft-interface tier name (`Min1`, `Min2`, `Mid1`, `Mid2`,
+    /// `Max1`, `Max2`).
+    pub required_tier: String,
+    /// Accept messages from contacts in the address book regardless of tier.
+    pub allow_known: bool,
+    /// Accept messages from senders not in the address book.
+    pub allow_anon: bool,
+    /// Optional bounce message shown to senders below the required tier.
+    pub bounce_message: String,
+}
+
+impl Default for IdentityAftPrefs {
+    fn default() -> Self {
+        Self {
+            required_tier: "Mid1".to_string(),
+            allow_known: true,
+            allow_anon: false,
+            bounce_message: String::new(),
+        }
+    }
+}
+
+/// Per-identity privacy preferences. Govern client-side composition and
+/// display behavior; nothing here is enforced by the chain.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+pub struct IdentityPrivacyPrefs {
+    /// Verify the recipient's signing key against the address book before
+    /// sending. Refuse to compose if the verifying key has changed since
+    /// import.
+    pub verify_on_send: bool,
+    /// Hide unsigned / unverifiable inbound messages from the inbox list.
+    pub hide_unsigned: bool,
+    /// Pad outgoing ciphertexts to a length-class boundary to reduce
+    /// linkability of message size.
+    pub pad_length: bool,
+    /// Send a read receipt automatically when an inbox row is opened.
+    pub read_receipts: bool,
+}
+
+impl Default for IdentityPrivacyPrefs {
+    fn default() -> Self {
+        Self {
+            verify_on_send: true,
+            hide_unsigned: false,
+            pad_length: true,
+            read_receipts: false,
+        }
+    }
+}
+
+/// Per-identity settings: the parts of Settings that are scoped to a single
+/// alias rather than to the whole device.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+pub struct IdentitySettings {
+    /// Display name shown to recipients alongside the alias. Empty means
+    /// "use the alias verbatim".
+    #[serde(default)]
+    pub display_name: String,
+    /// Signature appended to outgoing messages. Empty means no signature.
+    #[serde(default)]
+    pub signature: String,
+    /// Whether to append the signature automatically. If false, the user
+    /// has to opt in per-message in the compose form.
+    #[serde(default = "default_true")]
+    pub auto_sign: bool,
+    #[serde(default)]
+    pub aft: IdentityAftPrefs,
+    #[serde(default)]
+    pub privacy: IdentityPrivacyPrefs,
+}
+
+impl Default for IdentitySettings {
+    fn default() -> Self {
+        Self {
+            display_name: String::new(),
+            signature: String::new(),
+            auto_sign: true,
+            aft: IdentityAftPrefs::default(),
+            privacy: IdentityPrivacyPrefs::default(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
 /// Per-alias local state: drafts, the set of read message ids, a local
 /// snapshot of those messages so the UI can keep displaying them after the
 /// inbox contract has evicted them, and outgoing-message snapshots for the
@@ -178,11 +273,105 @@ pub struct AliasState {
     /// by the number of messages the user has touched.
     #[serde(default)]
     pub deleted: Vec<MessageId>,
+    /// Per-identity Settings buckets (Account, Privacy, AFT). `#[serde(default)]`
+    /// so older serialized state without this field still loads.
+    #[serde(default)]
+    pub settings: IdentitySettings,
+}
+
+/// UI theme preference. `System` follows the OS dark/light setting.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Theme {
+    #[default]
+    System,
+    Light,
+    Dark,
+}
+
+/// UI density preference. Controls row spacing in the inbox list.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Density {
+    #[default]
+    Comfortable,
+    Compact,
+}
+
+/// Appearance settings (global, not per-identity).
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+pub struct AppearanceSettings {
+    #[serde(default)]
+    pub theme: Theme,
+    #[serde(default)]
+    pub density: Density,
+    /// Render subject lines in the serif display face.
+    #[serde(default = "default_true")]
+    pub serif_subjects: bool,
+}
+
+impl Default for AppearanceSettings {
+    fn default() -> Self {
+        Self {
+            theme: Theme::default(),
+            density: Density::default(),
+            serif_subjects: true,
+        }
+    }
+}
+
+/// Inbox-folder settings (global). Govern UI grouping / quarantine behavior.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+pub struct InboxSettings {
+    /// Show drafts inline in the inbox list rather than only in the
+    /// Drafts folder.
+    pub drafts_in_inbox: bool,
+    /// Move messages from senders not in the address book into a
+    /// quarantine folder instead of the inbox.
+    pub quarantine_unknown: bool,
+}
+
+impl Default for InboxSettings {
+    fn default() -> Self {
+        Self {
+            drafts_in_inbox: false,
+            quarantine_unknown: true,
+        }
+    }
+}
+
+/// Advanced / node-connection settings.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Default)]
+pub struct AdvancedSettings {
+    /// Use a non-default Freenet node WebSocket endpoint. When false the
+    /// UI talks to the bundled host page's relay.
+    #[serde(default)]
+    pub custom_relay: bool,
+    /// Optional override URL for the Freenet node WebSocket. Used only
+    /// when `custom_relay` is true.
+    #[serde(default)]
+    pub custom_relay_url: String,
+}
+
+/// Global (device-scoped) settings buckets.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Default)]
+pub struct GlobalSettings {
+    #[serde(default)]
+    pub appearance: AppearanceSettings,
+    #[serde(default)]
+    pub inbox: InboxSettings,
+    #[serde(default)]
+    pub advanced: AdvancedSettings,
 }
 
 #[derive(Deserialize, Serialize, Debug, Default)]
 pub struct LocalState {
     aliases: HashMap<Alias, AliasState>,
+    /// Device-scoped Settings (Appearance, Inbox/Folders, Advanced).
+    /// `#[serde(default)]` so older serialized state without this field
+    /// still loads.
+    #[serde(default)]
+    settings: GlobalSettings,
 }
 
 impl LocalState {
@@ -237,6 +426,27 @@ impl LocalState {
         self.aliases
             .get(alias)
             .is_some_and(|s| s.deleted.contains(&id))
+    }
+
+    /// Per-identity settings for `alias`. Returns `IdentitySettings::default()`
+    /// for unknown aliases — callers don't need to special-case absence.
+    pub fn identity_settings(&self, alias: &str) -> IdentitySettings {
+        self.aliases
+            .get(alias)
+            .map(|s| s.settings.clone())
+            .unwrap_or_default()
+    }
+
+    /// Device-scoped settings.
+    pub fn global_settings(&self) -> &GlobalSettings {
+        &self.settings
+    }
+
+    /// Mutable global settings. Same caveat as `aliases_mut`: only the UI
+    /// optimistic-update path goes through this; the delegate owns the
+    /// canonical state.
+    pub fn global_settings_mut(&mut self) -> &mut GlobalSettings {
+        &mut self.settings
     }
 }
 
@@ -311,6 +521,19 @@ pub enum LocalStateMsg {
     DeleteMessage {
         alias: Alias,
         msg_id: MessageId,
+    },
+    /// Replace the per-identity Settings bucket for `alias`. The whole
+    /// bucket is sent rather than diffed: the bucket is small (a few
+    /// flags + two strings) and last-write-wins is the right semantic for
+    /// UI-driven preference edits.
+    SetIdentitySettings {
+        alias: Alias,
+        settings: IdentitySettings,
+    },
+    /// Replace the device-scoped Settings (Appearance / Inbox / Advanced).
+    /// Same last-write-wins rationale as `SetIdentitySettings`.
+    SetGlobalSettings {
+        settings: GlobalSettings,
     },
     /// Returns the entire `LocalState` JSON via an `ApplicationMessage`
     /// response. UI filters per active alias.
@@ -463,6 +686,18 @@ impl DelegateInterface for LocalState {
                         {
                             sent.delivery_state = ds;
                         }
+                        store(ctx, &secret_key, &state)?;
+                        Ok(vec![])
+                    }
+                    LocalStateMsg::SetIdentitySettings { alias, settings } => {
+                        let mut state = load_or_default(ctx, &secret_key)?;
+                        state.aliases.entry(alias).or_default().settings = settings;
+                        store(ctx, &secret_key, &state)?;
+                        Ok(vec![])
+                    }
+                    LocalStateMsg::SetGlobalSettings { settings } => {
+                        let mut state = load_or_default(ctx, &secret_key)?;
+                        state.settings = settings;
                         store(ctx, &secret_key, &state)?;
                         Ok(vec![])
                     }
@@ -632,6 +867,92 @@ mod boundary_tests {
         let archived: Vec<_> = back.archived_of("alice").collect();
         assert_eq!(archived.len(), 1);
         assert_eq!(archived[0].1.content.as_str(), "stash");
+    }
+
+    /// `AliasState` written before the Settings feature deserialises with
+    /// default `settings` (Mid1, allow-known on, signature off, etc.).
+    /// Pre-Settings state must keep loading.
+    #[test]
+    fn alias_state_missing_settings_defaults_loaded() {
+        let json = br#"{"drafts":{},"read":[],"kept":{},"sent":{},"archived":{},"deleted":[]}"#;
+        let s: AliasState = serde_json::from_slice(json).expect("should deserialise");
+        assert_eq!(s.settings.aft.required_tier, "Mid1");
+        assert!(s.settings.aft.allow_known);
+        assert!(!s.settings.aft.allow_anon);
+        assert!(s.settings.privacy.verify_on_send);
+        assert!(s.settings.auto_sign);
+    }
+
+    /// `LocalState` written before the global-Settings feature deserialises
+    /// with default appearance / inbox / advanced.
+    #[test]
+    fn local_state_missing_settings_defaults_loaded() {
+        let json = br#"{"aliases":{}}"#;
+        let s: LocalState = serde_json::from_slice(json).expect("should deserialise");
+        assert!(matches!(s.settings.appearance.theme, Theme::System));
+        assert!(s.settings.appearance.serif_subjects);
+        assert!(s.settings.inbox.quarantine_unknown);
+        assert!(!s.settings.advanced.custom_relay);
+    }
+
+    #[test]
+    fn round_trip_identity_settings() {
+        let mut state = LocalState::default();
+        let alias = state.aliases.entry("alice".into()).or_default();
+        alias.settings = IdentitySettings {
+            display_name: "Alice in Wonderland".into(),
+            signature: "— A".into(),
+            auto_sign: false,
+            aft: IdentityAftPrefs {
+                required_tier: "Mid2".into(),
+                allow_known: true,
+                allow_anon: true,
+                bounce_message: "rate-limited".into(),
+            },
+            privacy: IdentityPrivacyPrefs {
+                verify_on_send: false,
+                hide_unsigned: true,
+                pad_length: false,
+                read_receipts: true,
+            },
+        };
+        let bytes = serde_json::to_vec(&state).unwrap();
+        let back = LocalState::try_from(bytes.as_slice()).unwrap();
+        let s = back.identity_settings("alice");
+        assert_eq!(s.display_name, "Alice in Wonderland");
+        assert!(!s.auto_sign);
+        assert_eq!(s.aft.required_tier, "Mid2");
+        assert!(s.aft.allow_anon);
+        assert!(s.privacy.hide_unsigned);
+    }
+
+    #[test]
+    fn round_trip_global_settings() {
+        let mut state = LocalState::default();
+        *state.global_settings_mut() = GlobalSettings {
+            appearance: AppearanceSettings {
+                theme: Theme::Dark,
+                density: Density::Compact,
+                serif_subjects: false,
+            },
+            inbox: InboxSettings {
+                drafts_in_inbox: true,
+                quarantine_unknown: false,
+            },
+            advanced: AdvancedSettings {
+                custom_relay: true,
+                custom_relay_url: "ws://localhost:7510".into(),
+            },
+        };
+        let bytes = serde_json::to_vec(&state).unwrap();
+        let back = LocalState::try_from(bytes.as_slice()).unwrap();
+        let g = back.global_settings();
+        assert!(matches!(g.appearance.theme, Theme::Dark));
+        assert!(matches!(g.appearance.density, Density::Compact));
+        assert!(!g.appearance.serif_subjects);
+        assert!(g.inbox.drafts_in_inbox);
+        assert!(g.advanced.custom_relay);
+        assert_eq!(g.advanced.custom_relay_url, "ws://localhost:7510");
     }
 
     #[test]

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -1,20 +1,56 @@
 //! Settings shell — full-screen takeover inside `.fm-app`. Ported from
 //! the Claude Design handoff bundle (`mail-config-ui-design`).
 //!
-//! Scope of this module: visual + interaction parity with the prototype,
-//! wired to the real active identity for the keys/profile cards. Most
-//! per-screen toggles are still local `Signal<...>` state — persistence
-//! to IndexedDB / contract is a fast-follow.
+//! Persistence: settings live in the `mail-local-state` delegate's
+//! encrypted secret store (same stash as drafts / sent / read-tracking,
+//! never broadcast to the network). Each on-change handler issues
+//! `local_state::persist_identity_settings` / `persist_global_settings`,
+//! which optimistically patches the in-memory snapshot for an immediate
+//! re-render and fires a fire-and-forget delegate dispatch under
+//! `use-node`. Under `example-data,no-sync` the dispatch is a no-op.
 //!
 //! Mobile (`.fm-m*`) classes from the prototype are intentionally not
 //! ported in this pass; first cut is desktop-only.
 
+use std::sync::atomic::Ordering;
+
 use dioxus::prelude::*;
+use mail_local_state::{
+    Density, GlobalSettings, IdentityPrivacyPrefs, IdentitySettings, InboxSettings, Theme,
+};
 
 use crate::app::User;
 use crate::app::address_book;
 use crate::app::menu;
+use crate::local_state;
 use crate::testid;
+
+/// Read the identity-settings bucket for the active identity. Re-runs when
+/// `local_state::GENERATION` advances, so an external refresh of the
+/// snapshot (e.g. delegate `GetAll` reply) re-renders dependent screens.
+fn use_identity_settings() -> (String, IdentitySettings) {
+    let user = use_context::<Signal<User>>();
+    let alias = user
+        .read()
+        .logged_id()
+        .map(|id| id.alias.to_string())
+        .unwrap_or_default();
+    let alias_for_memo = alias.clone();
+    let settings = use_memo(move || {
+        // Subscribe to GENERATION so this re-runs on snapshot mutation.
+        let _gen = local_state::GENERATION.load(Ordering::Relaxed);
+        local_state::identity_settings_for(&alias_for_memo)
+    });
+    (alias, settings())
+}
+
+fn use_global_settings() -> GlobalSettings {
+    let settings = use_memo(move || {
+        let _gen = local_state::GENERATION.load(Ordering::Relaxed);
+        local_state::global_settings()
+    });
+    settings()
+}
 
 #[allow(non_snake_case)]
 pub(crate) fn SettingsShell() -> Element {
@@ -208,18 +244,15 @@ fn SettingRow(
 }
 
 #[component]
-fn Toggle(on: Signal<bool>) -> Element {
-    let cls = if on() { "fm-toggle on" } else { "fm-toggle" };
+fn Toggle(on: bool, ontoggle: EventHandler<()>) -> Element {
+    let cls = if on { "fm-toggle on" } else { "fm-toggle" };
     rsx! {
         button {
             class: "{cls}",
             r#type: "button",
             role: "switch",
-            "aria-checked": "{on()}",
-            onclick: move |_| {
-                let v = on();
-                on.clone().set(!v);
-            },
+            "aria-checked": "{on}",
+            onclick: move |_| ontoggle.call(()),
         }
     }
 }
@@ -286,13 +319,36 @@ fn ScrAccount() -> Element {
         })
         .unwrap_or_default();
 
-    let display_name = use_signal(String::new);
-    let signature = use_signal(|| String::from("Sent from a node I trust."));
-    let auto_sign = use_signal(|| true);
+    let (alias_key, ident) = use_identity_settings();
+    let display_name = ident.display_name.clone();
+    let signature = ident.signature.clone();
+    let auto_sign = ident.auto_sign;
     // Backups not yet wired — treat every identity as un-backed-up so the
     // amber banner shows. Real value will read from a per-identity local
     // record once #51 lands.
     let backed_up = false;
+
+    let alias_key_dn = alias_key.clone();
+    let ident_dn = ident.clone();
+    let on_display_name = move |ev: Event<FormData>| {
+        let mut next = ident_dn.clone();
+        next.display_name = ev.value();
+        local_state::persist_identity_settings(alias_key_dn.clone(), next);
+    };
+    let alias_key_sig = alias_key.clone();
+    let ident_sig = ident.clone();
+    let on_signature = move |ev: Event<FormData>| {
+        let mut next = ident_sig.clone();
+        next.signature = ev.value();
+        local_state::persist_identity_settings(alias_key_sig.clone(), next);
+    };
+    let alias_key_as = alias_key.clone();
+    let ident_as = ident.clone();
+    let on_auto_sign = move |_| {
+        let mut next = ident_as.clone();
+        next.auto_sign = !next.auto_sign;
+        local_state::persist_identity_settings(alias_key_as.clone(), next);
+    };
 
     rsx! {
         div { class: "fm-set-inner",
@@ -325,9 +381,9 @@ fn ScrAccount() -> Element {
                     control: rsx! {
                         input {
                             class: "fm-input",
-                            value: "{display_name()}",
+                            value: "{display_name}",
                             style: "width: 180px",
-                            oninput: move |ev| display_name.clone().set(ev.value()),
+                            oninput: on_display_name,
                         }
                     },
                 }
@@ -338,15 +394,15 @@ fn ScrAccount() -> Element {
                     control: rsx! {
                         textarea {
                             class: "fm-textarea",
-                            value: "{signature()}",
-                            oninput: move |ev| signature.clone().set(ev.value()),
+                            value: "{signature}",
+                            oninput: on_signature,
                         }
                     },
                 }
                 SettingRow {
                     label: "Append signature to new messages",
                     help: "Disable per-message in the compose footer.",
-                    control: rsx! { Toggle { on: auto_sign } },
+                    control: rsx! { Toggle { on: auto_sign, ontoggle: on_auto_sign } },
                 }
             }
             Card {
@@ -426,10 +482,26 @@ fn ScrAccount() -> Element {
 
 #[allow(non_snake_case)]
 fn ScrPrivacy() -> Element {
-    let verify_on_send = use_signal(|| true);
-    let hide_unsigned = use_signal(|| false);
-    let pad_length = use_signal(|| true);
-    let read_receipts = use_signal(|| false);
+    let (alias_key, ident) = use_identity_settings();
+    let priv_now = ident.privacy.clone();
+    let verify_on_send = priv_now.verify_on_send;
+    let hide_unsigned = priv_now.hide_unsigned;
+    let pad_length = priv_now.pad_length;
+    let read_receipts = priv_now.read_receipts;
+
+    let mk_toggle = move |mutate: fn(&mut IdentityPrivacyPrefs)| {
+        let alias_key = alias_key.clone();
+        let ident = ident.clone();
+        move |_| {
+            let mut next = ident.clone();
+            mutate(&mut next.privacy);
+            local_state::persist_identity_settings(alias_key.clone(), next);
+        }
+    };
+    let on_verify = mk_toggle(|p| p.verify_on_send = !p.verify_on_send);
+    let on_hide_unsigned = mk_toggle(|p| p.hide_unsigned = !p.hide_unsigned);
+    let on_pad = mk_toggle(|p| p.pad_length = !p.pad_length);
+    let on_receipts = mk_toggle(|p| p.read_receipts = !p.read_receipts);
     rsx! {
         div { class: "fm-set-inner",
             p { class: "fm-set-lede",
@@ -439,12 +511,12 @@ fn ScrPrivacy() -> Element {
                 SettingRow {
                     label: "Require known key to send",
                     help: "Block compose to recipients whose ML-DSA-65 key isn't in your known-keys set. Forces you to verify out-of-band first.",
-                    control: rsx! { Toggle { on: verify_on_send } },
+                    control: rsx! { Toggle { on: verify_on_send, ontoggle: on_verify } },
                 }
                 SettingRow {
                     label: "Hide unsigned messages",
                     help: "Move messages with no ML-DSA signature directly to a quarantine folder.",
-                    control: rsx! { Toggle { on: hide_unsigned } },
+                    control: rsx! { Toggle { on: hide_unsigned, ontoggle: on_hide_unsigned } },
                 }
                 SettingRow {
                     label: "Auto-accept new keys",
@@ -464,12 +536,12 @@ fn ScrPrivacy() -> Element {
                 SettingRow {
                     label: "Share read receipts",
                     help: "Senders see when you opened the message. Off by default; off is the unlinkable option.",
-                    control: rsx! { Toggle { on: read_receipts } },
+                    control: rsx! { Toggle { on: read_receipts, ontoggle: on_receipts } },
                 }
                 SettingRow {
                     label: "Pad message length",
                     help: "Round ciphertext size to fixed buckets so observers can't infer content size. Adds ~5% bandwidth.",
-                    control: rsx! { Toggle { on: pad_length } },
+                    control: rsx! { Toggle { on: pad_length, ontoggle: on_pad } },
                 }
             }
             Card {
@@ -514,12 +586,43 @@ fn ScrAft() -> Element {
         ("Mid2", "10K", "/ day", "Power tier. Requires reputation."),
     ];
 
-    let selected_tier = use_signal(|| "Mid1".to_string());
-    let allow_known = use_signal(|| true);
-    let allow_anon = use_signal(|| false);
-    let bounce = use_signal(|| {
-        String::from("Recipient requires Mid1 or higher to send. (https://freenet.org/aft)")
-    });
+    let (alias_key, ident) = use_identity_settings();
+    let aft_now = ident.aft.clone();
+    let selected_tier = aft_now.required_tier.clone();
+    let allow_known = aft_now.allow_known;
+    let allow_anon = aft_now.allow_anon;
+    let bounce = aft_now.bounce_message.clone();
+
+    let alias_key_t = alias_key.clone();
+    let ident_t = ident.clone();
+    let on_tier = move |new_tier: String| {
+        let mut next = ident_t.clone();
+        next.aft.required_tier = new_tier;
+        local_state::persist_identity_settings(alias_key_t.clone(), next);
+    };
+    let alias_key_k = alias_key.clone();
+    let ident_k = ident.clone();
+    let on_allow_known = move |_| {
+        let mut next = ident_k.clone();
+        next.aft.allow_known = !next.aft.allow_known;
+        local_state::persist_identity_settings(alias_key_k.clone(), next);
+    };
+    let alias_key_a = alias_key.clone();
+    let ident_a = ident.clone();
+    let on_allow_anon = move |_| {
+        let mut next = ident_a.clone();
+        next.aft.allow_anon = !next.aft.allow_anon;
+        local_state::persist_identity_settings(alias_key_a.clone(), next);
+    };
+    let alias_key_b = alias_key.clone();
+    let ident_b = ident.clone();
+    let on_bounce = move |ev: Event<FormData>| {
+        let mut next = ident_b.clone();
+        next.aft.bounce_message = ev.value();
+        local_state::persist_identity_settings(alias_key_b.clone(), next);
+    };
+    // Silence unused-variable warnings when only one of the two refs is read.
+    let _ = (&aft_now, &alias_key);
 
     rsx! {
         div { class: "fm-set-inner",
@@ -583,15 +686,16 @@ fn ScrAft() -> Element {
                     for (id, rate, per, help) in tiers.iter() {
                         {
                             let id_str = id.to_string();
-                            let active = selected_tier() == id_str;
+                            let active = selected_tier == id_str;
                             let cls = if active { "fm-tier is-active" } else { "fm-tier" };
+                            let on_tier_click = on_tier.clone();
                             rsx! {
                                 button {
                                     key: "{id}",
                                     class: "{cls}",
                                     r#type: "button",
                                     style: "all: unset; display: flex; flex-direction: column; gap: 4px; cursor: default; border: 1px solid var(--line); border-radius: 11px; padding: 12px 12px 10px; background: #fff;",
-                                    onclick: move |_| selected_tier.clone().set(id_str.clone()),
+                                    onclick: move |_| on_tier_click(id_str.clone()),
                                     div { class: "fm-tier-name", "{id}" }
                                     div { class: "fm-tier-rate",
                                         "{rate}"
@@ -610,24 +714,31 @@ fn ScrAft() -> Element {
                 SettingRow {
                     label: "Minimum tier",
                     help: "Tighten this if you're seeing spam. Loosen it if you're being bounced from senders who don't carry your floor.",
-                    control: rsx! {
-                        select { class: "fm-select",
-                            option { value: "Min1", "Min1" }
-                            option { value: "Min2", selected: true, "Min2" }
-                            option { value: "Mid1", "Mid1" }
-                            option { value: "Mid2", "Mid2" }
+                    control: {
+                        let on_tier_select = on_tier.clone();
+                        let cur = selected_tier.clone();
+                        rsx! {
+                            select {
+                                class: "fm-select",
+                                value: "{cur}",
+                                onchange: move |ev| on_tier_select(ev.value()),
+                                option { value: "Min1", "Min1" }
+                                option { value: "Min2", "Min2" }
+                                option { value: "Mid1", "Mid1" }
+                                option { value: "Mid2", "Mid2" }
+                            }
                         }
                     },
                 }
                 SettingRow {
                     label: "Allow lower tiers from known contacts",
                     help: "People in your address book bypass the tier floor.",
-                    control: rsx! { Toggle { on: allow_known } },
+                    control: rsx! { Toggle { on: allow_known, ontoggle: on_allow_known } },
                 }
                 SettingRow {
                     label: "Allow no-tier (anonymous)",
                     help: "Off by default. Recommended only for public dropboxes.",
-                    control: rsx! { Toggle { on: allow_anon } },
+                    control: rsx! { Toggle { on: allow_anon, ontoggle: on_allow_anon } },
                 }
                 SettingRow {
                     label: "Bounce message",
@@ -636,8 +747,8 @@ fn ScrAft() -> Element {
                     control: rsx! {
                         textarea {
                             class: "fm-textarea",
-                            value: "{bounce()}",
-                            oninput: move |ev| bounce.clone().set(ev.value()),
+                            value: "{bounce}",
+                            oninput: on_bounce,
                         }
                     },
                 }
@@ -648,8 +759,20 @@ fn ScrAft() -> Element {
 
 #[allow(non_snake_case)]
 fn ScrInbox() -> Element {
-    let drafts_in_inbox = use_signal(|| false);
-    let quarantine_unknown = use_signal(|| true);
+    let g = use_global_settings();
+    let drafts_in_inbox = g.inbox.drafts_in_inbox;
+    let quarantine_unknown = g.inbox.quarantine_unknown;
+
+    let mk_global_toggle = move |mutate: fn(&mut InboxSettings)| {
+        let g = g.clone();
+        move |_| {
+            let mut next = g.clone();
+            mutate(&mut next.inbox);
+            local_state::persist_global_settings(next);
+        }
+    };
+    let on_drafts_in_inbox = mk_global_toggle(|i| i.drafts_in_inbox = !i.drafts_in_inbox);
+    let on_quarantine = mk_global_toggle(|i| i.quarantine_unknown = !i.quarantine_unknown);
     rsx! {
         div { class: "fm-set-inner",
             p { class: "fm-set-lede", "How messages move through this inbox." }
@@ -680,7 +803,7 @@ fn ScrInbox() -> Element {
                 SettingRow {
                     label: "Show drafts in Inbox",
                     help: "Off: drafts stay in Drafts only. On: surface them in Inbox above the unread band.",
-                    control: rsx! { Toggle { on: drafts_in_inbox } },
+                    control: rsx! { Toggle { on: drafts_in_inbox, ontoggle: on_drafts_in_inbox } },
                 }
             }
             Card {
@@ -689,7 +812,7 @@ fn ScrInbox() -> Element {
                 SettingRow {
                     label: "Hold messages with unknown keys",
                     help: "Land them in Quarantine instead of Inbox. You'll see a count badge.",
-                    control: rsx! { Toggle { on: quarantine_unknown } },
+                    control: rsx! { Toggle { on: quarantine_unknown, ontoggle: on_quarantine } },
                 }
                 SettingRow {
                     label: "Auto-delete from Quarantine after",
@@ -823,7 +946,43 @@ fn ScrContacts() -> Element {
 
 #[allow(non_snake_case)]
 fn ScrAppearance() -> Element {
-    let serif_subjects = use_signal(|| true);
+    let g = use_global_settings();
+    let serif_subjects = g.appearance.serif_subjects;
+    let theme_value = match g.appearance.theme {
+        Theme::System => "auto",
+        Theme::Light => "light",
+        Theme::Dark => "dark",
+    };
+    let density_value = match g.appearance.density {
+        Density::Comfortable => "comfortable",
+        Density::Compact => "compact",
+    };
+
+    let g_theme = g.clone();
+    let on_theme = move |ev: Event<FormData>| {
+        let mut next = g_theme.clone();
+        next.appearance.theme = match ev.value().as_str() {
+            "light" => Theme::Light,
+            "dark" => Theme::Dark,
+            _ => Theme::System,
+        };
+        local_state::persist_global_settings(next);
+    };
+    let g_density = g.clone();
+    let on_density = move |ev: Event<FormData>| {
+        let mut next = g_density.clone();
+        next.appearance.density = match ev.value().as_str() {
+            "compact" => Density::Compact,
+            _ => Density::Comfortable,
+        };
+        local_state::persist_global_settings(next);
+    };
+    let g_serif = g.clone();
+    let on_serif = move |_| {
+        let mut next = g_serif.clone();
+        next.appearance.serif_subjects = !next.appearance.serif_subjects;
+        local_state::persist_global_settings(next);
+    };
     rsx! {
         div { class: "fm-set-inner",
             p { class: "fm-set-lede", "Visual settings shared across every identity on this device." }
@@ -832,8 +991,11 @@ fn ScrAppearance() -> Element {
                     label: "Color theme",
                     help: "Dark theme matches the system; nothing is themed per identity.",
                     control: rsx! {
-                        select { class: "fm-select",
-                            option { value: "auto", selected: true, "auto" }
+                        select {
+                            class: "fm-select",
+                            value: "{theme_value}",
+                            onchange: on_theme,
+                            option { value: "auto", "auto" }
                             option { value: "light", "light" }
                             option { value: "dark", "dark" }
                         }
@@ -843,9 +1005,11 @@ fn ScrAppearance() -> Element {
                     label: "Density",
                     help: "Affects row height and padding throughout the mailbox.",
                     control: rsx! {
-                        select { class: "fm-select",
+                        select {
+                            class: "fm-select",
+                            value: "{density_value}",
+                            onchange: on_density,
                             option { value: "compact", "compact" }
-                            option { value: "cozy", selected: true, "cozy" }
                             option { value: "comfortable", "comfortable" }
                         }
                     },
@@ -853,7 +1017,7 @@ fn ScrAppearance() -> Element {
                 SettingRow {
                     label: "Subjects in serif",
                     help: "Off: subjects render in DM Sans like the rest of the UI.",
-                    control: rsx! { Toggle { on: serif_subjects } },
+                    control: rsx! { Toggle { on: serif_subjects, ontoggle: on_serif } },
                 }
             }
             Card { title: "Typography",
@@ -875,7 +1039,14 @@ fn ScrAppearance() -> Element {
 
 #[allow(non_snake_case)]
 fn ScrAdvanced() -> Element {
-    let custom_relay = use_signal(|| false);
+    let g = use_global_settings();
+    let custom_relay = g.advanced.custom_relay;
+    let g_relay = g.clone();
+    let on_custom_relay = move |_| {
+        let mut next = g_relay.clone();
+        next.advanced.custom_relay = !next.advanced.custom_relay;
+        local_state::persist_global_settings(next);
+    };
     let log: &[(&str, &str, &str)] = &[
         (
             "14:32:01",
@@ -916,7 +1087,7 @@ fn ScrAdvanced() -> Element {
                 SettingRow {
                     label: "Use custom relay",
                     help: "By default we connect to the local Freenet node. Override only if you know what you're doing.",
-                    control: rsx! { Toggle { on: custom_relay } },
+                    control: rsx! { Toggle { on: custom_relay, ontoggle: on_custom_relay } },
                 }
             }
             Card {

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -12,8 +12,8 @@ use std::cell::RefCell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use mail_local_state::{
-    ArchivedMessage, DeliveryState, Draft, KeptMessage, LocalState, LocalStateMsg, MessageId,
-    SentMessage,
+    ArchivedMessage, DeliveryState, Draft, GlobalSettings, IdentitySettings, KeptMessage,
+    LocalState, LocalStateMsg, MessageId, SentMessage,
 };
 
 thread_local! {
@@ -86,6 +86,14 @@ pub(crate) fn kept_for(alias: &str) -> Vec<(MessageId, KeptMessage)> {
             .collect(),
         None => Vec::new(),
     })
+}
+
+pub(crate) fn identity_settings_for(alias: &str) -> IdentitySettings {
+    SNAPSHOT.with(|s| s.borrow().identity_settings(alias))
+}
+
+pub(crate) fn global_settings() -> GlobalSettings {
+    SNAPSHOT.with(|s| s.borrow().global_settings().clone())
 }
 
 #[cfg(feature = "use-node")]
@@ -268,6 +276,25 @@ mod wire {
         )
         .await
     }
+
+    pub(crate) async fn set_identity_settings(
+        client: &mut WebApiRequestClient,
+        alias: String,
+        settings: IdentitySettings,
+    ) -> Result<(), DynError> {
+        send_msg(
+            client,
+            &LocalStateMsg::SetIdentitySettings { alias, settings },
+        )
+        .await
+    }
+
+    pub(crate) async fn set_global_settings(
+        client: &mut WebApiRequestClient,
+        settings: GlobalSettings,
+    ) -> Result<(), DynError> {
+        send_msg(client, &LocalStateMsg::SetGlobalSettings { settings }).await
+    }
 }
 
 #[cfg(feature = "use-node")]
@@ -394,6 +421,73 @@ pub(crate) fn local_mark_read(alias: &str, msg_id: MessageId, kept: KeptMessage)
         entry.kept.insert(msg_id.to_string(), kept);
     });
     bump();
+}
+
+pub(crate) fn local_set_identity_settings(alias: &str, settings: IdentitySettings) {
+    SNAPSHOT.with(|s| {
+        let mut state = s.borrow_mut();
+        state
+            .aliases_mut()
+            .entry(alias.to_string())
+            .or_default()
+            .settings = settings;
+    });
+    bump();
+}
+
+pub(crate) fn local_set_global_settings(settings: GlobalSettings) {
+    SNAPSHOT.with(|s| {
+        *s.borrow_mut().global_settings_mut() = settings;
+    });
+    bump();
+}
+
+/// Apply a per-identity settings change everywhere: optimistically patch the
+/// in-memory snapshot for an immediate UI re-render, then (under `use-node`)
+/// fire-and-forget the delegate dispatch so the value persists. Errors from
+/// the dispatch are logged via `crate::log` but don't fail the call — the
+/// local snapshot is the source of truth for the current session and the
+/// delegate write is best-effort.
+pub(crate) fn persist_identity_settings(alias: String, settings: IdentitySettings) {
+    local_set_identity_settings(&alias, settings.clone());
+    #[cfg(feature = "use-node")]
+    {
+        let Some(client) = crate::api::WEB_API_SENDER.get() else {
+            return;
+        };
+        let mut client = client.clone();
+        dioxus::prelude::spawn(async move {
+            if let Err(e) = wire::set_identity_settings(&mut client, alias, settings).await {
+                crate::log::error(format!("set_identity_settings failed: {e}"), None);
+            }
+        });
+    }
+    #[cfg(not(feature = "use-node"))]
+    {
+        let _ = (alias, settings);
+    }
+}
+
+/// Apply a global settings change everywhere; same shape as
+/// [`persist_identity_settings`].
+pub(crate) fn persist_global_settings(settings: GlobalSettings) {
+    local_set_global_settings(settings.clone());
+    #[cfg(feature = "use-node")]
+    {
+        let Some(client) = crate::api::WEB_API_SENDER.get() else {
+            return;
+        };
+        let mut client = client.clone();
+        dioxus::prelude::spawn(async move {
+            if let Err(e) = wire::set_global_settings(&mut client, settings).await {
+                crate::log::error(format!("set_global_settings failed: {e}"), None);
+            }
+        });
+    }
+    #[cfg(not(feature = "use-node"))]
+    {
+        let _ = settings;
+    }
 }
 
 pub(crate) fn new_draft_id() -> String {


### PR DESCRIPTION
## Summary
- Wire the Settings shell (PR #90) to the existing `mail-local-state` delegate so toggles survive reload instead of resetting on every mount.
- Adds two settings buckets: `IdentitySettings` (per-identity: account, AFT, privacy) and `GlobalSettings` (device-scoped: appearance, inbox/folders, advanced).
- All edits flow through new `persist_identity_settings` / `persist_global_settings` helpers that optimistically patch the in-memory snapshot and dispatch to the delegate under `use-node` (no-op under `example-data,no-sync`).

## Storage / encryption

Settings live in the `mail-local-state` delegate's secret store — same place drafts, sent-message bodies, and read-tracking already live. Per `freenet-stdlib`'s `set_secret`/`get_secret` docs: "Persistent **encrypted** storage." Device-local only; never broadcast to the network. Settings are NOT in the inbox contract.

## Backward compat

All new fields are `#[serde(default)]` with custom `Default` impls where the natural zero is wrong (`auto_sign=true`, `quarantine_unknown=true`, `serif_subjects=true`, `required_tier="Mid1"`). New `boundary_tests` cover loading pre-Settings state.

Two new `LocalStateMsg` variants — `SetIdentitySettings`, `SetGlobalSettings` — replace the whole bucket on write (last-write-wins, no field diffing).

## What's wired

| Screen      | Bucket         | Fields persisted                                                  |
|-------------|----------------|-------------------------------------------------------------------|
| Account     | IdentitySettings | display_name, signature, auto_sign                              |
| Privacy     | IdentitySettings.privacy | verify_on_send, hide_unsigned, pad_length, read_receipts |
| AFT         | IdentitySettings.aft | required_tier, allow_known, allow_anon, bounce_message      |
| Inbox       | GlobalSettings.inbox | drafts_in_inbox, quarantine_unknown                         |
| Appearance  | GlobalSettings.appearance | theme, density, serif_subjects                          |
| Advanced    | GlobalSettings.advanced | custom_relay (url field staged but not surfaced yet)      |

## Toggle component

`Toggle` changed from `Signal<bool>` to `(on: bool, ontoggle: EventHandler<()>)`. Callers now route toggles through the appropriate persistence helper instead of mutating a local Signal.

## What's deferred

- `IdentitySettings.signature` is persisted but compose doesn't yet append it to outgoing messages.
- AFT `required_tier` is persisted but the inbox contract doesn't yet enforce it server-side; that's a separate AFT-side change (issue #85).
- Backup / wipe / restore modals.
- Identity switcher popover behavior.
- Mobile screens.

## Test plan
- [x] `cargo test -p mail-local-state --lib` — 17 passed (4 new: 2 round-trips + 2 missing-field-loads-defaults).
- [x] `cargo build -p freenet-email-ui` (default `use-node`).
- [x] `cargo build -p freenet-email-ui --features example-data,no-sync --no-default-features` (offline).
- [x] `cargo make clippy`.
- [x] `cargo fmt --all -- --check`.
- [ ] Manual `dev-example`: open gear → toggle Privacy/AFT/Appearance → reload → values persist (offline path uses in-memory snapshot only; no real persistence yet, expected).
- [ ] Manual against a real node: same flow → reload → values persist via the delegate.