### PR TITLE
feat(ui): wire Appearance/Inbox/Privacy/Advanced settings to real behavior

### DIFF
--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -329,7 +329,12 @@ impl Default for AppearanceSettings {
 }
 
 /// Inbox-folder settings (global). Govern UI grouping / quarantine behavior.
-#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
+///
+/// Both fields default to `false`. `quarantine_unknown=true` would silently
+/// hide every unsigned/legacy inbound message until the user verifies the
+/// sender, which is hostile for first-run UX; users who want strict
+/// quarantine flip the toggle in Settings > Inbox.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Default)]
 pub struct InboxSettings {
     /// Show drafts inline in the inbox list rather than only in the
     /// Drafts folder.
@@ -337,15 +342,6 @@ pub struct InboxSettings {
     /// Move messages from senders not in the address book into a
     /// quarantine folder instead of the inbox.
     pub quarantine_unknown: bool,
-}
-
-impl Default for InboxSettings {
-    fn default() -> Self {
-        Self {
-            drafts_in_inbox: false,
-            quarantine_unknown: true,
-        }
-    }
 }
 
 /// Advanced / node-connection settings.
@@ -909,7 +905,7 @@ mod boundary_tests {
         let s: LocalState = serde_json::from_slice(json).expect("should deserialise");
         assert!(matches!(s.settings.appearance.theme, Theme::System));
         assert!(s.settings.appearance.serif_subjects);
-        assert!(s.settings.inbox.quarantine_unknown);
+        assert!(!s.settings.inbox.quarantine_unknown);
         assert!(!s.settings.advanced.custom_relay);
     }
 

--- a/ui/public/vendor/css/components/tokens.css
+++ b/ui/public/vendor/css/components/tokens.css
@@ -65,4 +65,62 @@
     textarea { font-family: inherit; outline: none; }
 
   }
+
+  /* Theme overrides driven by data-theme attr on .fm-app. The Settings UI
+     writes theme to mail_local_state.GlobalSettings.appearance.theme;
+     ui/src/app.rs sets the attr at render time. */
+  .fm-app[data-theme="dark"] {
+    --c0: #0b1220;
+    --c1: #111a2e;
+    --c2: #1f2a44;
+    --c3: #2c3a5a;
+    --ink0: #f1f5f9;
+    --ink1: #e2e8f0;
+    --ink2: #cbd5e1;
+    --ink3: #94a3b8;
+    --ink4: #64748b;
+    --accent: #3b82f6;
+    --accent-bg: #1e293b;
+    --accent-mid: #1d4ed8;
+    --trust: #22c55e;
+    --trust-bg: #14532d;
+    --line: rgba(148, 163, 184, 0.18);
+    --line2: rgba(148, 163, 184, 0.10);
+    --unread: #fbbf24;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .fm-app[data-theme="system"] {
+      --c0: #0b1220;
+      --c1: #111a2e;
+      --c2: #1f2a44;
+      --c3: #2c3a5a;
+      --ink0: #f1f5f9;
+      --ink1: #e2e8f0;
+      --ink2: #cbd5e1;
+      --ink3: #94a3b8;
+      --ink4: #64748b;
+      --accent: #3b82f6;
+      --accent-bg: #1e293b;
+      --accent-mid: #1d4ed8;
+      --trust: #22c55e;
+      --trust-bg: #14532d;
+      --line: rgba(148, 163, 184, 0.18);
+      --line2: rgba(148, 163, 184, 0.10);
+      --unread: #fbbf24;
+    }
+  }
+
+  /* Density override: compact tightens row spacing in lists. */
+  .fm-app[data-density="compact"] .msg-list-row,
+  .fm-app[data-density="compact"] .fm-msg-row {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+
+  /* Serif subject lines opt-out: when class absent, force sans on subject. */
+  .fm-app:not(.serif-subjects) .msg-subject,
+  .fm-app:not(.serif-subjects) .fm-msg-subject {
+    font-family: "DM Sans", system-ui, sans-serif;
+  }
 }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -66,7 +66,14 @@ impl WebApi {
             "https:" => "wss",
             _ => "ws",
         };
-        let url = format!("{scheme}://{host}/v1/contract/command?encodingProtocol=native");
+        // GlobalSettings.advanced.custom_relay overrides the default
+        // gateway-served WS endpoint. Empty string disables the override.
+        let advanced = crate::local_state::global_settings().advanced;
+        let url = if advanced.custom_relay && !advanced.custom_relay_url.trim().is_empty() {
+            advanced.custom_relay_url.trim().to_string()
+        } else {
+            format!("{scheme}://{host}/v1/contract/command?encodingProtocol=native")
+        };
         let conn = web_sys::WebSocket::new(&url).unwrap();
         let (send_host_responses, host_responses) = futures::channel::mpsc::unbounded();
         let (send_half, requests) = futures::channel::mpsc::unbounded();

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -958,8 +958,30 @@ fn UserInbox() -> Element {
     let menu_selection = use_context::<Signal<menu::MenuSelection>>();
     let settings_open = menu_selection.read().settings().is_some();
 
+    let _local_gen = crate::local_state::GENERATION.load(std::sync::atomic::Ordering::Relaxed);
+    let appearance = crate::local_state::global_settings().appearance;
+    let theme_attr = match appearance.theme {
+        ::mail_local_state::Theme::System => "system",
+        ::mail_local_state::Theme::Light => "light",
+        ::mail_local_state::Theme::Dark => "dark",
+    };
+    let density_attr = match appearance.density {
+        ::mail_local_state::Density::Comfortable => "comfortable",
+        ::mail_local_state::Density::Compact => "compact",
+    };
+    let serif_class = if appearance.serif_subjects {
+        " serif-subjects"
+    } else {
+        ""
+    };
+    let app_class = format!("fm-app{serif_class}");
+
     rsx! {
-        div { class: "fm-app", "data-testid": testid::FM_APP,
+        div {
+            class: "{app_class}",
+            "data-testid": testid::FM_APP,
+            "data-theme": theme_attr,
+            "data-density": density_attr,
             Topbar {}
             div { class: "main",
                 Sidebar {}
@@ -1223,6 +1245,8 @@ fn MessageList() -> Element {
         .logged_id()
         .map(|id| id.alias.to_string())
         .unwrap_or_default();
+    let inbox_settings = crate::local_state::global_settings().inbox;
+    let privacy_prefs = crate::local_state::identity_settings_for(&active_alias).privacy;
     let visible: Vec<Message> = if matches!(folder, menu::Folder::Inbox) {
         let mut v: Vec<Message> = emails
             .iter()
@@ -1234,6 +1258,30 @@ fn MessageList() -> Element {
             .filter(|m| !crate::local_state::is_archived(&active_alias, m.id))
             .filter(|m| !crate::local_state::is_deleted(&active_alias, m.id))
             .filter(|m| matches_search(m, &search))
+            // IdentityPrivacyPrefs.hide_unsigned: drop rows whose signature
+            // didn't validate. Sender-vk empty also counts as unsigned.
+            .filter(|m| {
+                if !privacy_prefs.hide_unsigned {
+                    return true;
+                }
+                m.signature_valid && !m.sender_vk.is_empty()
+            })
+            // GlobalSettings.inbox.quarantine_unknown: when set, hide rows
+            // from senders not in the verified address book. Until a
+            // dedicated Quarantine folder ships, "hide" is the safe
+            // interpretation — visible drops, count drops, no surface.
+            .filter(|m| {
+                if !inbox_settings.quarantine_unknown {
+                    return true;
+                }
+                if m.sender_vk.is_empty() {
+                    return false;
+                }
+                matches!(
+                    address_book::contact_by_vk(&m.sender_vk),
+                    Some(c) if c.verified
+                )
+            })
             .cloned()
             .collect();
         // Newest first (#49). Sender-stamped time is what the design assumes.
@@ -1242,7 +1290,9 @@ fn MessageList() -> Element {
     } else {
         Vec::new()
     };
-    let drafts: Vec<(String, mail_local_state::Draft)> = if matches!(folder, menu::Folder::Drafts) {
+    let drafts: Vec<(String, mail_local_state::Draft)> = if matches!(folder, menu::Folder::Drafts)
+        || (matches!(folder, menu::Folder::Inbox) && inbox_settings.drafts_in_inbox)
+    {
         let mut d = crate::local_state::drafts_for(&active_alias);
         // Newest first.
         d.sort_by_key(|b| std::cmp::Reverse(b.1.updated_at));
@@ -1270,6 +1320,7 @@ fn MessageList() -> Element {
         menu::Folder::Drafts => drafts.len(),
         menu::Folder::Sent => sent_msgs.len(),
         menu::Folder::Archive => archived_msgs.len(),
+        menu::Folder::Inbox if inbox_settings.drafts_in_inbox => visible.len() + drafts.len(),
         _ => visible.len(),
     };
     let selected_sent_id = menu_selection.read().sent_id().map(str::to_string);
@@ -1410,11 +1461,48 @@ fn MessageList() -> Element {
                             })
                         }
                     }
-                } else if visible.is_empty() {
+                } else if visible.is_empty() && drafts.is_empty() {
                     div { style: "padding:24px 18px; font-family:'Geist Mono',monospace; font-size:10px; letter-spacing:0.1em; text-transform:uppercase; color:var(--ink4);",
                         "No messages"
                     }
                 } else {
+                    // GlobalSettings.inbox.drafts_in_inbox = true → drafts
+                    // render at top of Inbox alongside received messages.
+                    if matches!(folder, menu::Folder::Inbox) && inbox_settings.drafts_in_inbox {
+                        {
+                            drafts.iter().map(|(id, d)| {
+                                let to_disp = if d.to.is_empty() { "(no recipient)".to_string() } else { d.to.clone() };
+                                let subj_disp = if d.subject.is_empty() { "(no subject)".to_string() } else { d.subject.clone() };
+                                let preview = d.body.clone();
+                                let time_short = chrono::DateTime::from_timestamp_millis(d.updated_at)
+                                    .map(format_time_short)
+                                    .unwrap_or_default();
+                                let prefill = menu::ComposePrefill {
+                                    to: d.to.clone(),
+                                    subject: d.subject.clone(),
+                                    body: d.body.clone(),
+                                    draft_id: Some(id.clone()),
+                                };
+                                let id_for_dom = id.clone();
+                                rsx! {
+                                    article {
+                                        class: "msg-card",
+                                        "data-testid": testid::FM_DRAFT_CARD,
+                                        "data-draft-id": "{id_for_dom}",
+                                        onclick: move |_| {
+                                            menu_selection.write().open_draft(prefill.clone());
+                                        },
+                                        div { class: "msg-row1",
+                                            span { class: "msg-sender", "Draft → {to_disp}" }
+                                            span { class: "msg-time", "{time_short}" }
+                                        }
+                                        div { class: "msg-subj", "{subj_disp}" }
+                                        div { class: "msg-prev", "{preview}" }
+                                    }
+                                }
+                            })
+                        }
+                    }
                     {
                         visible.into_iter().map(|email| {
                             let id = email.id;
@@ -2190,6 +2278,20 @@ fn ComposeSheet() -> Element {
                 return;
             }
         };
+        // IdentityPrivacyPrefs.verify_on_send: refuse to send if the
+        // address-book contact has not been confirmed by the user. Own-
+        // identity sends bypass (no verification required to message self).
+        let id_privacy = crate::local_state::identity_settings_for(&alias).privacy;
+        if id_privacy.verify_on_send && !recipient.verified && !recipient.is_own {
+            crate::log::error(
+                format!("verify_on_send is on; recipient `{to_val}` is not a verified contact"),
+                Some(TryNodeAction::GetAlias),
+            );
+            toast.set(Some(format!(
+                "Recipient `{to_val}` is not verified. Verify the fingerprint in Contacts before sending."
+            )));
+            return;
+        }
         let recipient_ek = match address_book::ek_from_bytes(&recipient.ml_kem_ek_bytes) {
             Ok(ek) => ek,
             Err(e) => {
@@ -2211,7 +2313,22 @@ fn ComposeSheet() -> Element {
             }
         };
         let title_val = title.read().clone();
-        let content_val = content.read().clone();
+        let mut content_val = content.read().clone();
+
+        // IdentitySettings.auto_sign + signature: append a separator + the
+        // signature block when enabled and the user hasn't already pasted
+        // the signature into the body. Idempotent against re-send/forward.
+        let id_settings = crate::local_state::identity_settings_for(&alias);
+        if id_settings.auto_sign && !id_settings.signature.trim().is_empty() {
+            let sig = id_settings.signature.trim_end();
+            if !content_val.contains(sig) {
+                if !content_val.ends_with('\n') {
+                    content_val.push('\n');
+                }
+                content_val.push_str("\n-- \n");
+                content_val.push_str(sig);
+            }
+        }
 
         // Derive the recipient's inbox key BEFORE moving `recipient_vk` into
         // `send_message` so we can pair the eventual UpdateResponse back to


### PR DESCRIPTION
## Summary

Settings panels merged in #97 read/write `mail-local-state` correctly but
nothing in the rest of the UI consumed those values. This PR plumbs the
existing settings into actual behavior.

- **Appearance** → `.fm-app` gains `data-theme` / `data-density` attrs +
  `serif-subjects` class. `tokens.css` adds explicit dark-theme override,
  `prefers-color-scheme` fallback for `theme=system`, compact-density
  row spacing, and sans-serif subject opt-out.
- **Inbox** →
  - `drafts_in_inbox`: drafts render inline at top of Inbox folder
    list; Inbox count includes them.
  - `quarantine_unknown`: hide rows from senders not in the verified
    address book (same hide semantic until a dedicated Quarantine
    folder ships).
- **Privacy** →
  - `hide_unsigned`: drop unsigned/forged rows from Inbox list.
  - `verify_on_send`: block compose send to non-verified contacts
    (own-identity bypass), surface toast on refusal.
- **Advanced** → `custom_relay` + `custom_relay_url` override the
  gateway-served WS URL in `api.rs` when both set.
- **Identity** → `signature` + `auto_sign` append signature on send,
  idempotent against re-send/forward.

Deliberately not wired (need protocol/encryption work):
- `IdentityPrivacyPrefs.pad_length` — touches `inbox.rs` ciphertext
  pipeline.
- `IdentityPrivacyPrefs.read_receipts` — no receipt protocol exists.

## Test plan

- [x] `cargo make clippy` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` all green
- [x] Both feature combos build (`use-node` default + `example-data,no-sync`)
- [ ] Manual: toggle theme=Dark → palette inverts
- [ ] Manual: drafts_in_inbox on → inbox shows drafts at top
- [ ] Manual: hide_unsigned on → mock unsigned message disappears from list
- [ ] Manual: verify_on_send on, send to unverified contact → toast + refused
- [ ] Manual: signature + auto_sign on → outgoing body has trailing `-- \n<sig>`