### PR TITLE
feat(ui): add Contacts entry to inbox sidebar

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -16,6 +16,7 @@
   "fmAddToAb": "fm-add-to-ab",
   "fmComposeSendingAs": "fm-compose-sending-as",
   "fmSidebarFingerprint": "fm-sidebar-fingerprint",
+  "fmSidebarContacts": "fm-sidebar-contacts",
   "fmReply": "fm-reply",
   "fmDelete": "fm-delete",
   "fmArchive": "fm-archive",

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1097,6 +1097,19 @@ fn Sidebar() -> Element {
                         })
                 }
             }
+            div { class: "sect-label", "People" }
+            div { class: "nav",
+                button {
+                    class: "nav-item",
+                    "data-testid": testid::FM_SIDEBAR_CONTACTS,
+                    onclick: move |_| {
+                        menu_selection.write().open_settings(menu::SettingsScreen::Contacts);
+                    },
+                    span { class: "icon", "☺" }
+                    span { class: "label", "Contacts" }
+                    span { class: "count", "" }
+                }
+            }
             div { class: "sidebar-bottom",
                 div { class: "conn-card",
                     div { class: "conn-row",

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -40,6 +40,7 @@ pub(crate) const FM_COMPOSE_SENDING_AS: &str = "fm-compose-sending-as";
 
 // Sidebar
 pub(crate) const FM_SIDEBAR_FINGERPRINT: &str = "fm-sidebar-fingerprint";
+pub(crate) const FM_SIDEBAR_CONTACTS: &str = "fm-sidebar-contacts";
 
 // Detail / open message
 pub(crate) const FM_REPLY: &str = "fm-reply";
@@ -134,6 +135,7 @@ mod tests {
             ("fmAddToAb", super::FM_ADD_TO_AB),
             ("fmComposeSendingAs", super::FM_COMPOSE_SENDING_AS),
             ("fmSidebarFingerprint", super::FM_SIDEBAR_FINGERPRINT),
+            ("fmSidebarContacts", super::FM_SIDEBAR_CONTACTS),
             ("fmReply", super::FM_REPLY),
             ("fmDelete", super::FM_DELETE),
             ("fmArchive", super::FM_ARCHIVE),


### PR DESCRIPTION
## Summary
- Adds a "People → Contacts" button to the inbox sidebar so the address book is reachable in one click instead of via Settings
- Reuses the existing `ScrContacts` pane (search, Import…, Share my card, remove); no new UI built
- Adds `FM_SIDEBAR_CONTACTS` testid + matching JSON entry

## Test plan
- [x] `cargo check -p freenet-email-ui --features example-data,no-sync --no-default-features --target wasm32-unknown-unknown`
- [x] `cargo test -p freenet-email-ui --lib json_matches_rust_consts`
- [ ] Manual: click sidebar Contacts, verify settings shell opens on Contacts pane