### PR TITLE
fix(ui): decode UpdateNotification(Delta) as UpdateInbox

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -29,7 +29,6 @@
   "fmArchiveBody": "fm-archive-body",
   "fmArchiveDelete": "fm-archive-delete",
   "fmArchiveReply": "fm-archive-reply",
-  "fmArchiveUnarchive": "fm-archive-unarchive",
   "fmComposeSheet": "fm-compose-sheet",
   "fmSend": "fm-send",
   "fmToast": "fm-toast",

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1081,29 +1081,39 @@ pub(crate) async fn node_comms(
                     Some(identity) => {
                         match update {
                             UpdateData::Delta(delta) => {
-                                let delta: StoredInbox =
-                                    serde_json::from_slice(delta.as_ref()).unwrap();
-                                let updated_model = InboxModel::from_state(
-                                    Arc::clone(&identity.ml_dsa_signing_key),
-                                    identity.ml_kem_dk.clone(),
-                                    delta,
-                                    key,
-                                )
-                                .unwrap();
-                                let mut models = inboxes.0.write();
-                                if let Some(pos) = models.iter().position(|e| e.borrow().key == key)
-                                {
-                                    let mut inbox = models[pos].borrow_mut();
-                                    inbox.merge(updated_model);
-                                    crate::log::debug!(
-                                        "updated inbox {key} with {} messages",
-                                        inbox.messages.len()
-                                    );
-                                } else {
-                                    // Notification raced the initial GetResponse;
-                                    // insert as a fresh entry. Replaces the
-                                    // assert!(found) panic from earlier (#45).
-                                    models.push(Rc::new(RefCell::new(updated_model)));
+                                match serde_json::from_slice::<freenet_email_inbox::UpdateInbox>(
+                                    delta.as_ref(),
+                                ) {
+                                    Ok(parsed) => {
+                                        let models = inboxes.0.write();
+                                        if let Some(pos) =
+                                            models.iter().position(|e| e.borrow().key == key)
+                                        {
+                                            let mut inbox = models[pos].borrow_mut();
+                                            inbox.apply_delta(&identity.ml_kem_dk, parsed);
+                                            crate::log::debug!(
+                                                "applied delta to inbox {key} -> {} messages",
+                                                inbox.messages.len()
+                                            );
+                                        } else {
+                                            // Notification raced GetResponse: a
+                                            // Delta on its own can't materialise
+                                            // the inbox (no settings, no key on
+                                            // the wire). The follow-up
+                                            // GetResponse will populate it.
+                                            crate::log::debug!(
+                                                "UpdateNotification(Delta) before GetResponse for {key}; dropping"
+                                            );
+                                        }
+                                    }
+                                    Err(e) => {
+                                        crate::log::error(
+                                            format!(
+                                                "UpdateNotification: failed to decode UpdateInbox delta for {key}: {e}"
+                                            ),
+                                            None,
+                                        );
+                                    }
                                 }
                             }
                             UpdateData::State(state) => {

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1675,16 +1675,9 @@ fn OpenArchivedMessage(msg_id: u64, msg: mail_local_state::ArchivedMessage) -> E
                     },
                     "Reply"
                 }
-                // Unarchive lives behind issue #60 (inbox contract OwnerInsert
-                // variant). Disabled here so the affordance is visible without
-                // mis-promising round-trippable archives.
-                button {
-                    class: "btn btn-secondary",
-                    "data-testid": testid::FM_ARCHIVE_UNARCHIVE,
-                    disabled: true,
-                    title: "Unarchive requires inbox contract OwnerInsert (#60)",
-                    "Unarchive"
-                }
+                // Unarchive intentionally hidden: blocked on inbox contract
+                // OwnerInsert (#60). Showing a no-op button is more confusing
+                // than no affordance at all.
                 button {
                     class: "btn btn-secondary",
                     "data-testid": testid::FM_ARCHIVE_DELETE,

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -697,23 +697,6 @@ impl InboxModel {
         }
     }
 
-    pub fn merge(&mut self, other: InboxModel) {
-        for m in other.messages {
-            if !self
-                .messages
-                .iter()
-                .any(|c| c.content.time == m.content.time)
-            {
-                self.add_received_message(
-                    m.content,
-                    m.token_assignment,
-                    m.sender_vk,
-                    m.signature_valid,
-                );
-            }
-        }
-    }
-
     // TODO: only used when an inbox is created first time when putting the contract
     #[allow(dead_code)]
     fn to_state(&self) -> Result<State<'static>, DynError> {
@@ -771,6 +754,45 @@ impl InboxModel {
             key,
             messages,
         })
+    }
+
+    /// Apply an `UpdateInbox` delta received via UpdateNotification (or
+    /// the cross-node UPDATE_PROPAGATION path) to this in-memory model.
+    /// Decrypts AddMessages and de-dups by `token_assignment.assignment_hash`;
+    /// drops RemoveMessages by hash; ignores ModifySettings (sender-only).
+    pub fn apply_delta(&mut self, ml_kem_dk: &DecapsulationKey<MlKem768>, delta: UpdateInbox) {
+        match delta {
+            UpdateInbox::AddMessages { messages } => {
+                for m in messages {
+                    let hash = m.token_assignment.assignment_hash;
+                    if self
+                        .messages
+                        .iter()
+                        .any(|c| c.token_assignment.assignment_hash == hash)
+                    {
+                        continue;
+                    }
+                    let content = DecryptedMessage::from_stored(ml_kem_dk, m.content.clone());
+                    let signature_valid =
+                        verify_message_signature(&m.content, &m.sender_vk, &m.signature);
+                    self.add_received_message(
+                        content,
+                        m.token_assignment,
+                        m.sender_vk,
+                        signature_valid,
+                    );
+                }
+            }
+            UpdateInbox::RemoveMessages { ids, .. } => {
+                let drop: HashSet<TokenAssignmentHash> = HashSet::from_iter(ids);
+                self.messages
+                    .retain(|m| !drop.contains(&m.token_assignment.assignment_hash));
+            }
+            UpdateInbox::ModifySettings { .. } => {
+                // Settings deltas come from this identity only; ignore on
+                // the receive path.
+            }
+        }
     }
 
     /// This only affects in-memory messages, changes are not persisted.

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -59,7 +59,6 @@ pub(crate) const FM_SENT_RESEND: &str = "fm-sent-resend";
 pub(crate) const FM_ARCHIVE_BODY: &str = "fm-archive-body";
 pub(crate) const FM_ARCHIVE_DELETE: &str = "fm-archive-delete";
 pub(crate) const FM_ARCHIVE_REPLY: &str = "fm-archive-reply";
-pub(crate) const FM_ARCHIVE_UNARCHIVE: &str = "fm-archive-unarchive";
 
 // Compose
 pub(crate) const FM_COMPOSE_SHEET: &str = "fm-compose-sheet";
@@ -148,7 +147,6 @@ mod tests {
             ("fmArchiveBody", super::FM_ARCHIVE_BODY),
             ("fmArchiveDelete", super::FM_ARCHIVE_DELETE),
             ("fmArchiveReply", super::FM_ARCHIVE_REPLY),
-            ("fmArchiveUnarchive", super::FM_ARCHIVE_UNARCHIVE),
             ("fmComposeSheet", super::FM_COMPOSE_SHEET),
             ("fmSend", super::FM_SEND),
             ("fmToast", super::FM_TOAST),

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -1094,9 +1094,11 @@ test.describe("Archive folder (#47c)", () => {
     await expect(page.locator(".detail-subj")).toContainText(
       "Welcome to the offline preview",
     );
-    // Unarchive is wired but disabled until #60 lands.
+    // Unarchive button is intentionally hidden (not just disabled)
+    // until #60 lands — the dead affordance was confusing per user
+    // feedback. Assert it's absent rather than disabled.
     const unarchive = page.locator('[data-testid="fm-archive-unarchive"]');
-    await expect(unarchive).toBeDisabled();
+    await expect(unarchive).toHaveCount(0);
   });
 
   test("Delete from Inbox does not produce an Archive entry", async ({

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -192,7 +192,7 @@ test.describe("Live node E2E", () => {
   }) => {
     test.skip(
       !process.env.FREENET_LIVE_E2E_SEND,
-      "cross-node send still under harness debug; set FREENET_LIVE_E2E_SEND=1 to run",
+      "cross-node send still flaky on iso harness; set FREENET_LIVE_E2E_SEND=1 to run",
     );
     test.skip(
       !PEER_BASE_URL,
@@ -324,7 +324,207 @@ test.describe("Live node E2E", () => {
       stopPeerPump();
     }
   });
+
+  // Multi-round cross-node flow: send, click-to-read, reply, archive.
+  // Catches the regression class where (a) clicking a received message
+  // makes it disappear instead of staying visible as read, (b) replies
+  // back to the sender don't surface, (c) archive doesn't move the row
+  // into the Archive folder, (d) UpdateNotification decode panics
+  // (#102 follow-up: api.rs:1085 was unwrapping a StoredInbox decode of
+  // a Delta wire payload that's actually `UpdateInbox::AddMessages`).
+  test("multi-round + read + archive across nodes", async ({ browser }) => {
+    // Same gate as the basic alice → bob test: cross-node send is
+    // currently flaky against the iso harness (the api.rs decode panic
+    // was the most visible failure but bob's UI still doesn't surface
+    // the message in CI even with the fix; manual repro on a real
+    // browser does work). Re-enable once the cross-node send
+    // round-trip is reliable on the iso harness.
+    test.skip(
+      !process.env.FREENET_LIVE_E2E_SEND,
+      "cross-node multi-round still under harness debug; set FREENET_LIVE_E2E_SEND=1 to run",
+    );
+    test.skip(
+      !PEER_BASE_URL,
+      "cross-node test requires FREENET_EMAIL_BASE_URL to include the contract id",
+    );
+    const stopGwPump = startPermissionPump(ISO_GW_ORIGIN);
+    const stopPeerPump = startPermissionPump(ISO_PEER_ORIGIN);
+    const aliceCtx = await browser.newContext();
+    const bobCtx = await browser.newContext();
+    const alicePage = await aliceCtx.newPage();
+    const bobPage = await bobCtx.newPage();
+
+    // Surface WASM panics + console errors immediately so test failure
+    // points at the original panic frame, not a downstream timeout.
+    const consoleErrors: string[] = [];
+    for (const [page, label] of [
+      [alicePage, "alice"],
+      [bobPage, "bob"],
+    ] as const) {
+      page.on("console", (m) => {
+        const t = m.text();
+        if (
+          /WASM PANIC|RuntimeError: unreachable executed|Result::unwrap.*on an .Err/.test(
+            t,
+          )
+        ) {
+          consoleErrors.push(`[${label}] ${t}`);
+        }
+      });
+    }
+
+    try {
+      await Promise.all([alicePage.goto(""), bobPage.goto(PEER_BASE_URL)]);
+      await Promise.all([
+        createIdentity(alicePage, "alice"),
+        createIdentity(bobPage, "bob"),
+      ]);
+
+      const aliceApp = alicePage.frameLocator("iframe#app");
+      const bobApp = bobPage.frameLocator("iframe#app");
+
+      // Exchange contacts BOTH ways: alice imports bob, bob imports alice.
+      await bobApp.locator('[data-testid="fm-id-share"]').first().click();
+      const bobShare = bobApp.locator('[data-testid="fm-share-modal"]');
+      await bobShare.waitFor({ timeout: 5_000 });
+      const bobCard = (await bobShare.getAttribute("data-share-text")) ?? "";
+      await bobShare.locator(".modal-x").click();
+
+      await aliceApp.locator('[data-testid="fm-id-share"]').first().click();
+      const aliceShare = aliceApp.locator('[data-testid="fm-share-modal"]');
+      await aliceShare.waitFor({ timeout: 5_000 });
+      const aliceCard =
+        (await aliceShare.getAttribute("data-share-text")) ?? "";
+      await aliceShare.locator(".modal-x").click();
+
+      await aliceApp.locator('[data-testid="fm-contact-import"]').click();
+      await aliceApp
+        .locator('[data-testid="fm-import-contact-modal"] textarea')
+        .fill(bobCard);
+      await aliceApp
+        .locator('input[placeholder="e.g. Alice (work)"]')
+        .fill("bob");
+      await aliceApp.locator('[data-testid="fm-import-submit"]').click();
+
+      await bobApp.locator('[data-testid="fm-contact-import"]').click();
+      await bobApp
+        .locator('[data-testid="fm-import-contact-modal"] textarea')
+        .fill(aliceCard);
+      await bobApp
+        .locator('input[placeholder="e.g. Alice (work)"]')
+        .fill("alice");
+      await bobApp.locator('[data-testid="fm-import-submit"]').click();
+
+      // Open both inboxes.
+      await aliceApp
+        .locator(
+          '[data-testid="fm-id-row"][data-alias="alice"] [data-testid="fm-id-open"]',
+        )
+        .first()
+        .click();
+      await bobApp
+        .locator(
+          '[data-testid="fm-id-row"][data-alias="bob"] [data-testid="fm-id-open"]',
+        )
+        .first()
+        .click();
+
+      // ── Round 1: alice → bob ────────────────────────────────────
+      await composeAndSend(aliceApp, "bob", "round one", "first body");
+      await expect(
+        bobApp.getByText(/round one/i),
+        "bob receives round one",
+      ).toBeVisible({ timeout: 60_000 });
+
+      // Click to open: message must NOT vanish from the inbox list.
+      // Regression target: post-#102 click-to-read deletes the row
+      // from the in-memory model + bumps local-state, but the inbox
+      // list rebuild is supposed to merge the kept-locally copy back
+      // in. If kept_for() doesn't fire or the rebuild doesn't run,
+      // the row disappears entirely.
+      await bobApp.getByText(/round one/i).click();
+      await bobApp.locator('[data-testid="fm-detail-time"]').waitFor({
+        timeout: 5_000,
+      });
+      // Navigate back to inbox list. The message should still be
+      // visible (read=true), not gone.
+      await bobPage.goBack().catch(() => {});
+      await bobApp
+        .locator(
+          '[data-testid="fm-id-row"][data-alias="bob"] [data-testid="fm-id-open"]',
+        )
+        .first()
+        .click()
+        .catch(() => {});
+      await expect(
+        bobApp.getByText(/round one/i),
+        "round one stays visible after click-to-read",
+      ).toBeVisible({ timeout: 10_000 });
+
+      // ── Round 2: bob → alice (reply path) ────────────────────────
+      await composeAndSend(bobApp, "alice", "round two reply", "reply body");
+      await expect(
+        aliceApp.getByText(/round two reply/i),
+        "alice receives bob's reply",
+      ).toBeVisible({ timeout: 60_000 });
+
+      // ── Round 3: alice → bob again (no AFT cap regression) ───────
+      await composeAndSend(aliceApp, "bob", "round three", "third body");
+      await expect(
+        bobApp.getByText(/round three/i),
+        "bob receives round three (AFT slot still free)",
+      ).toBeVisible({ timeout: 60_000 });
+
+      // ── Archive: bob archives round one. Should leave the inbox
+      // list and surface in the Archive folder.
+      await bobApp.getByText(/round one/i).click();
+      const archiveBtn = bobApp.locator('[data-testid="fm-archive"]');
+      if (await archiveBtn.isVisible().catch(() => false)) {
+        await archiveBtn.click();
+        await expect(
+          bobApp.getByText(/round one/i),
+          "round one no longer in inbox after archive",
+        ).toHaveCount(0, { timeout: 10_000 });
+        // Switch to Archive folder via menu.
+        await bobApp.getByText(/^Archive$/).click();
+        await expect(
+          bobApp.getByText(/round one/i),
+          "round one visible in Archive folder",
+        ).toBeVisible({ timeout: 10_000 });
+      }
+
+      expect(
+        consoleErrors,
+        `no WASM panics in either browser context: ${consoleErrors.join("\n")}`,
+      ).toEqual([]);
+    } finally {
+      await aliceCtx.close().catch(() => {});
+      await bobCtx.close().catch(() => {});
+      stopGwPump();
+      stopPeerPump();
+    }
+  });
 });
+
+async function composeAndSend(
+  app: import("@playwright/test").FrameLocator,
+  recipientAlias: string,
+  subject: string,
+  body: string,
+) {
+  await app.locator('[data-testid="fm-compose-btn"]').click();
+  const sheet = app.locator('[data-testid="fm-compose-sheet"]');
+  await sheet
+    .locator('input[placeholder="alias or address"]')
+    .fill(recipientAlias);
+  await expect(
+    app.getByTestId("compose-recipient-fingerprint"),
+    `fingerprint badge resolves for ${recipientAlias}`,
+  ).toBeVisible({ timeout: 15_000 });
+  await sheet.locator('input[placeholder="subject"]').fill(subject);
+  await sheet.locator("textarea.sheet-textarea").fill(body);
+  await sheet.locator('[data-testid="fm-send"]').click();
+}
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 

--- a/ui/tests/repro-106-107.spec.ts
+++ b/ui/tests/repro-106-107.spec.ts
@@ -1,0 +1,333 @@
+// Focused repro spec for #106 (disappear-on-click) and #107
+// (sent-leaking-into-drafts). Drives the iso 2-node harness with
+// extensive console + screenshot logging so each failure points at a
+// concrete UI/log state. Not part of the standard CI suite — run
+// manually via:
+//
+//   FREENET_EMAIL_BASE_URL=http://127.0.0.1:7510/v1/contract/web/<id>/ \
+//     npx playwright test --config ui/tests/playwright.config.ts \
+//     --project=chromium ui/tests/repro-106-107.spec.ts --headed
+//
+// Or non-headed with traces:
+//
+//   FREENET_EMAIL_BASE_URL=... npx playwright test \
+//     --config ui/tests/playwright.config.ts --project=chromium \
+//     ui/tests/repro-106-107.spec.ts --trace on
+import { test, expect, type FrameLocator, type Page } from "@playwright/test";
+import { APP_NAME } from "./app-name";
+
+const ISO_GW_PORT = parseInt(process.env.FREENET_ISO_GW_PORT ?? "7510", 10);
+const ISO_PEER_PORT = parseInt(process.env.FREENET_ISO_PEER_PORT ?? "7511", 10);
+const ISO_GW_ORIGIN = `http://127.0.0.1:${ISO_GW_PORT}`;
+const ISO_PEER_ORIGIN = `http://127.0.0.1:${ISO_PEER_PORT}`;
+
+const BASE_URL = process.env.FREENET_EMAIL_BASE_URL ?? "";
+const CONTRACT_ID_MATCH = BASE_URL.match(/\/v1\/contract\/web\/([^/]+)\//);
+const CONTRACT_ID = CONTRACT_ID_MATCH ? CONTRACT_ID_MATCH[1] : "";
+const PEER_BASE_URL = CONTRACT_ID
+  ? `${ISO_PEER_ORIGIN}/v1/contract/web/${CONTRACT_ID}/`
+  : "";
+
+function startPermissionPump(origin: string) {
+  let stopped = false;
+  void (async () => {
+    while (!stopped) {
+      try {
+        const r = await fetch(`${origin}/permission/pending`);
+        if (r.ok) {
+          const data = (await r.json()) as { nonce?: string }[];
+          for (const item of data) {
+            if (item.nonce) {
+              await fetch(`${origin}/permission/${item.nonce}/respond`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ index: 0 }),
+              }).catch(() => {});
+            }
+          }
+        }
+      } catch {
+        /* ignore */
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  })();
+  return () => {
+    stopped = true;
+  };
+}
+
+function attachConsole(page: Page, label: string, sink: string[]) {
+  page.on("console", (m) => {
+    sink.push(`[${label}/${m.type()}] ${m.text()}`);
+  });
+  page.on("pageerror", (e) => {
+    sink.push(`[${label}/pageerror] ${e.message}`);
+  });
+}
+
+async function createIdentity(page: Page, alias: string) {
+  const app = page.frameLocator("iframe#app");
+  await expect(app.locator(".brand-name").first()).toContainText(APP_NAME, {
+    timeout: 60_000,
+  });
+  await app.locator('[data-testid="fm-id-create"]').click();
+  await app.locator('[data-testid="fm-create-alias-input"]').fill(alias);
+  await app.locator('[data-testid="fm-create-submit"]').click();
+  await app.locator('[data-testid="fm-create-confirm"]').click();
+  await expect(
+    app.locator(`[data-testid="fm-id-row"][data-alias="${alias}"]`),
+    `${alias} surfaces after create`,
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+async function shareCard(app: FrameLocator): Promise<string> {
+  await app.locator('[data-testid="fm-id-share"]').first().click();
+  const modal = app.locator('[data-testid="fm-share-modal"]');
+  await modal.waitFor({ timeout: 5_000 });
+  const card = (await modal.getAttribute("data-share-text")) ?? "";
+  await modal.locator(".modal-x").click();
+  return card;
+}
+
+async function importContact(app: FrameLocator, card: string, label: string) {
+  await app.locator('[data-testid="fm-contact-import"]').click();
+  await app
+    .locator('[data-testid="fm-import-contact-modal"] textarea')
+    .fill(card);
+  await app
+    .locator('input[placeholder="e.g. Alice (work)"]')
+    .fill(label);
+  // Tick the "I verified these six words" checkbox so the imported
+  // contact is marked verified — `verify_on_send` defaults to true so
+  // an unverified import would silently drop the send (the compose
+  // veil stays up and no toast surfaces). The checkbox only renders
+  // once `fingerprint_words` resolves from the card; wait for it.
+  const verifyCheck = app.locator('[data-testid="fm-verify-check"]');
+  await verifyCheck.waitFor({ timeout: 15_000 });
+  await verifyCheck.click();
+  await app.locator('[data-testid="fm-import-submit"]').click();
+}
+
+async function openIdentity(app: FrameLocator, alias: string) {
+  await app
+    .locator(
+      `[data-testid="fm-id-row"][data-alias="${alias}"] [data-testid="fm-id-open"]`,
+    )
+    .first()
+    .click();
+}
+
+async function compose(
+  app: FrameLocator,
+  to: string,
+  subject: string,
+  body: string,
+) {
+  await app.locator('[data-testid="fm-compose-btn"]').click();
+  const sheet = app.locator('[data-testid="fm-compose-sheet"]');
+  await sheet.locator('input[placeholder="alias or address"]').fill(to);
+  await expect(
+    app.getByTestId("compose-recipient-fingerprint"),
+    `fingerprint resolves for ${to}`,
+  ).toBeVisible({ timeout: 30_000 });
+  await sheet.locator('input[placeholder="subject"]').fill(subject);
+  await sheet.locator("textarea.sheet-textarea").fill(body);
+  await sheet.locator('[data-testid="fm-send"]').click();
+}
+
+test.describe.configure({ retries: 0 });
+test.describe("Repro #106 + #107", () => {
+  test.skip(
+    !CONTRACT_ID,
+    "set FREENET_EMAIL_BASE_URL to the iso gw contract URL",
+  );
+  test.beforeEach(async ({}, info) => {
+    test.skip(
+      info.project.name !== "chromium",
+      "repro spec runs on chromium only",
+    );
+  });
+
+  test("alice sends to bob → bob clicks → row disappears (#106) + alice's draft persists (#107)", async ({
+    browser,
+  }, testInfo) => {
+    test.setTimeout(360_000);
+    const stopGw = startPermissionPump(ISO_GW_ORIGIN);
+    const stopPeer = startPermissionPump(ISO_PEER_ORIGIN);
+    const aliceCtx = await browser.newContext();
+    const bobCtx = await browser.newContext();
+    const alicePage = await aliceCtx.newPage();
+    const bobPage = await bobCtx.newPage();
+
+    const aliceLog: string[] = [];
+    const bobLog: string[] = [];
+    attachConsole(alicePage, "alice", aliceLog);
+    attachConsole(bobPage, "bob", bobLog);
+
+    try {
+      await Promise.all([alicePage.goto(""), bobPage.goto(PEER_BASE_URL)]);
+      await Promise.all([
+        createIdentity(alicePage, "alice"),
+        createIdentity(bobPage, "bob"),
+      ]);
+
+      const aliceApp = alicePage.frameLocator("iframe#app");
+      const bobApp = bobPage.frameLocator("iframe#app");
+
+      const bobCard = await shareCard(bobApp);
+      await importContact(aliceApp, bobCard, "bob");
+
+      await openIdentity(aliceApp, "alice");
+      await openIdentity(bobApp, "bob");
+
+      await compose(aliceApp, "bob", "round one", "first body");
+
+      // Snapshot post-send so we can see what alice sees before any
+      // poll on bob (catches drafts-leak in #107 even if cross-node
+      // delivery never lands).
+      await alicePage.screenshot({
+        path: testInfo.outputPath("alice-post-send.png"),
+        fullPage: true,
+      });
+      await bobPage.screenshot({
+        path: testInfo.outputPath("bob-post-send.png"),
+        fullPage: true,
+      });
+      const fs = await import("node:fs/promises");
+
+      // Probe alice's Drafts BEFORE waiting on bob. #107 may repro even
+      // when cross-node delivery doesn't, because Drafts is alice's
+      // local state alone.
+      const draftsLink = aliceApp.getByText(/^Drafts$/).first();
+      if (await draftsLink.isVisible().catch(() => false)) {
+        await draftsLink.click();
+        await alicePage.screenshot({
+          path: testInfo.outputPath("alice-drafts-immediately.png"),
+          fullPage: true,
+        });
+        const sentInDrafts = await aliceApp
+          .getByText(/round one/i)
+          .first()
+          .isVisible()
+          .catch(() => false);
+        console.log(
+          `[#107 immediate] sent in Drafts after Send: ${sentInDrafts}`,
+        );
+        // Go back to inbox so the rest of the test can continue.
+        const inboxLink = aliceApp.getByText(/^Inbox$/).first();
+        if (await inboxLink.isVisible().catch(() => false)) {
+          await inboxLink.click();
+        }
+      }
+
+      // Wait for inbox row on bob.
+      const subjectLocator = bobApp.getByText(/round one/i).first();
+      let bobReceived = true;
+      try {
+        await expect(subjectLocator, "bob receives round one").toBeVisible({
+          timeout: 90_000,
+        });
+      } catch (e) {
+        bobReceived = false;
+        await bobPage.screenshot({
+          path: testInfo.outputPath("bob-no-receive-timeout.png"),
+          fullPage: true,
+        });
+        await fs.writeFile(
+          testInfo.outputPath("alice-console.log"),
+          aliceLog.join("\n"),
+        );
+        await fs.writeFile(
+          testInfo.outputPath("bob-console.log"),
+          bobLog.join("\n"),
+        );
+        console.log("[#106 unreproducible — bob never received]");
+        console.log(`bob console tail: ${bobLog.slice(-30).join("\n")}`);
+      }
+      if (!bobReceived) {
+        // Bail before #106 click flow — can't repro click-disappear
+        // without a row to click. #107 already probed above.
+        return;
+      }
+
+      await bobPage.screenshot({
+        path: testInfo.outputPath("bob-inbox-pre-click.png"),
+        fullPage: true,
+      });
+
+      // Click the row on bob.
+      await subjectLocator.click();
+      // Wait for detail open (detail timestamp surfaces).
+      await bobApp
+        .locator('[data-testid="fm-detail-time"]')
+        .waitFor({ timeout: 10_000 });
+
+      await bobPage.screenshot({
+        path: testInfo.outputPath("bob-detail-open.png"),
+        fullPage: true,
+      });
+
+      // Navigate back to inbox list. There's no testid'd Back button —
+      // click the brand to go home then re-enter inbox via the id-row.
+      await bobApp.locator(".brand-name").first().click();
+      await openIdentity(bobApp, "bob");
+
+      await bobPage.screenshot({
+        path: testInfo.outputPath("bob-inbox-post-back.png"),
+        fullPage: true,
+      });
+
+      // ── #106 assertion: row should still be visible (read=true).
+      const stillVisible = await bobApp
+        .getByText(/round one/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+      console.log(
+        `[#106 result] row visible after click+back: ${stillVisible}`,
+      );
+
+      // ── #107 assertion: alice's Drafts should still be empty after
+      // sending (also probed immediately above; this re-probes after
+      // bob's click round-trip in case the leak is async).
+      await alicePage.screenshot({
+        path: testInfo.outputPath("alice-pre-drafts.png"),
+        fullPage: true,
+      });
+      const draftsLink2 = aliceApp.getByText(/^Drafts$/).first();
+      if (await draftsLink2.isVisible().catch(() => false)) {
+        await draftsLink2.click();
+      }
+      await alicePage.screenshot({
+        path: testInfo.outputPath("alice-drafts.png"),
+        fullPage: true,
+      });
+      const draftsHasSent = await aliceApp
+        .getByText(/round one/i)
+        .first()
+        .isVisible()
+        .catch(() => false);
+      console.log(`[#107 result] sent message in Drafts: ${draftsHasSent}`);
+
+      // Dump console logs to test artifacts for inspection.
+      await fs.writeFile(
+        testInfo.outputPath("alice-console.log"),
+        aliceLog.join("\n"),
+      );
+      await fs.writeFile(
+        testInfo.outputPath("bob-console.log"),
+        bobLog.join("\n"),
+      );
+
+      // Soft assertions so we always reach the artifact dump.
+      expect.soft(stillVisible, "#106: row stays visible after click+back").toBe(true);
+      expect.soft(draftsHasSent, "#107: sent message NOT in Drafts").toBe(false);
+    } finally {
+      await aliceCtx.close().catch(() => {});
+      await bobCtx.close().catch(() => {});
+      stopGw();
+      stopPeer();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`api.rs:1085` was unwrapping `serde_json::from_slice::<StoredInbox>(delta)` on the wire payload of an inbox `UpdateNotification`. The sender writes `UpdateInbox::AddMessages` (an enum), not the full `Inbox` struct, so the decode panicked with \`missing field \"messages\"\` and the executor task died. The visible symptom: cross-node sends required a hard refresh on the receiver to surface, and reverse-direction sends never surfaced because the panic killed the WS task before the second arm could run.

Add \`InboxModel::apply_delta\` that handles \`AddMessages\` (decrypt + push, de-dupe by \`assignment_hash\`) and \`RemoveMessages\` (filter by hash). Drop the now-dead \`merge\` helper and the disabled \"Unarchive\" affordance (#60 is still pending; the dead button was confusing per user feedback).

Browser console error this fixes:

\`\`\`
WASM PANIC: panicked at ui/src/api.rs:1085:76:
called \`Result::unwrap()\` on an \`Err\` value: Error(\"missing field \`messages\`\", line: 1, column: 31)
\`\`\`

## Caveat — cross-node E2E still flaky

The new \`multi-round + read + archive\` test (and the pre-existing \`alice → bob\` test from #94) reproduce a deeper cross-node delivery flake on the iso harness even with this decode fix in place. Both are gated behind \`FREENET_LIVE_E2E_SEND=1\`. Manual repro on a real browser does work post-fix; iso harness coverage is being chased separately.

## Test plan

- [x] \`cargo make clippy\` — clean
- [x] \`cargo test --workspace --lib\` — 26/26 passing (incl. the testid-drift guard)
- [x] \`cargo make test-e2e-real-node\` — 1/1 passing (cross-node send tests gated, identity-create + reload-persist passes)
- [ ] Cross-node send end-to-end: manual repro green, iso harness flake tracked separately