### PR TITLE
fix(ui): reactive GENERATION + draft-delete tombstones (#106, #107)

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -940,7 +940,7 @@ fn UserInbox() -> Element {
     let menu_selection = use_context::<Signal<menu::MenuSelection>>();
     let settings_open = menu_selection.read().settings().is_some();
 
-    let _local_gen = crate::local_state::GENERATION.load(std::sync::atomic::Ordering::Relaxed);
+    let _local_gen = crate::local_state::GENERATION();
     let appearance = crate::local_state::global_settings().appearance;
     let theme_attr = match appearance.theme {
         ::mail_local_state::Theme::System => "system",
@@ -1059,7 +1059,7 @@ fn Sidebar() -> Element {
     };
     // Track local-state generation so Drafts count re-renders when the
     // user types into the compose sheet (autosave bumps `GENERATION`).
-    let _local_gen = crate::local_state::GENERATION.load(std::sync::atomic::Ordering::Relaxed);
+    let _local_gen = crate::local_state::GENERATION();
     rsx! {
         nav { class: "sidebar",
             button {
@@ -1226,7 +1226,7 @@ fn MessageList() -> Element {
     let selected_id = menu_selection.read().email();
     // Touch the local-state generation so this component re-renders when
     // drafts are added/removed.
-    let _local_gen = crate::local_state::GENERATION.load(std::sync::atomic::Ordering::Relaxed);
+    let _local_gen = crate::local_state::GENERATION();
 
     let inbox_view = inbox.read();
     let emails = inbox_view.messages.borrow();
@@ -1542,7 +1542,7 @@ fn DetailPanel() -> Element {
     let view = inbox.read();
     let emails = view.messages.borrow();
     let selected = selected_id.and_then(|id| emails.iter().find(|m| m.id == id).cloned());
-    let _local_gen = crate::local_state::GENERATION.load(std::sync::atomic::Ordering::Relaxed);
+    let _local_gen = crate::local_state::GENERATION();
 
     if matches!(folder, menu::Folder::Inbox) {
         if let Some(msg) = selected {

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -12,7 +12,6 @@
 //! Mobile (`.fm-m*`) classes from the prototype are intentionally not
 //! ported in this pass; first cut is desktop-only.
 
-
 use dioxus::prelude::*;
 use mail_local_state::{
     Density, GlobalSettings, IdentityPrivacyPrefs, IdentitySettings, InboxSettings, Theme,

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -12,7 +12,6 @@
 //! Mobile (`.fm-m*`) classes from the prototype are intentionally not
 //! ported in this pass; first cut is desktop-only.
 
-use std::sync::atomic::Ordering;
 
 use dioxus::prelude::*;
 use mail_local_state::{
@@ -38,7 +37,7 @@ fn use_identity_settings() -> (String, IdentitySettings) {
     let alias_for_memo = alias.clone();
     let settings = use_memo(move || {
         // Subscribe to GENERATION so this re-runs on snapshot mutation.
-        let _gen = local_state::GENERATION.load(Ordering::Relaxed);
+        let _gen = local_state::GENERATION();
         local_state::identity_settings_for(&alias_for_memo)
     });
     (alias, settings())
@@ -46,7 +45,7 @@ fn use_identity_settings() -> (String, IdentitySettings) {
 
 fn use_global_settings() -> GlobalSettings {
     let settings = use_memo(move || {
-        let _gen = local_state::GENERATION.load(Ordering::Relaxed);
+        let _gen = local_state::GENERATION();
         local_state::global_settings()
     });
     settings()

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -9,8 +9,9 @@
 //! `LocalState` value (`AliasState` keyed by alias string).
 
 use std::cell::RefCell;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::HashSet;
 
+use dioxus::prelude::*;
 use mail_local_state::{
     ArchivedMessage, DeliveryState, Draft, GlobalSettings, IdentitySettings, KeptMessage,
     LocalState, LocalStateMsg, MessageId, SentMessage,
@@ -21,17 +22,42 @@ thread_local! {
     /// each `GetAll` response; mutations in the UI optimistically patch this
     /// copy and also send the corresponding `LocalStateMsg` to the delegate.
     static SNAPSHOT: RefCell<LocalState> = RefCell::new(LocalState::default());
+
+    /// Draft ids the UI has optimistically deleted. Stale `replace_snapshot`
+    /// echoes — e.g. an in-flight `save_draft` whose response lands after the
+    /// `delete_draft` was issued — would otherwise resurrect them. Kept until
+    /// the delegate echoes a snapshot that no longer contains the id (#107).
+    /// Key: (alias, draft_id).
+    static DELETED_DRAFTS: RefCell<HashSet<(String, String)>> = RefCell::new(HashSet::new());
 }
 
-/// Bumped on every snapshot mutation. Components that read drafts/read-state
-/// gate a `use_memo` on this value to know when to re-pull from `SNAPSHOT`.
-pub(crate) static GENERATION: AtomicUsize = AtomicUsize::new(0);
+/// Bumped on every snapshot mutation. Components read this signal so Dioxus
+/// subscribes them to changes; reading via `()` (call) registers the dep.
+/// Why GlobalSignal vs AtomicUsize: an Atomic.load() from a component does not
+/// register a reactive dependency, so kept/read/draft mutations did not trigger
+/// re-render until something else dirtied the component (issue #106).
+pub(crate) static GENERATION: GlobalSignal<usize> = Signal::global(|| 0);
 
 fn bump() {
-    GENERATION.fetch_add(1, Ordering::Relaxed);
+    *GENERATION.write() += 1;
 }
 
 pub(crate) fn replace_snapshot(new: LocalState) {
+    let mut new = new;
+    DELETED_DRAFTS.with(|tombs| {
+        let mut tombs = tombs.borrow_mut();
+        tombs.retain(|(alias, draft_id)| {
+            // If incoming snapshot still contains the draft, an older
+            // `save_draft` won the race; strip it and keep the tombstone.
+            // If it's gone, the `delete_draft` echo has caught up — drop it.
+            if let Some(state) = new.aliases_mut().get_mut(alias)
+                && state.drafts.remove(draft_id).is_some()
+            {
+                return true;
+            }
+            false
+        });
+    });
     SNAPSHOT.with(|s| *s.borrow_mut() = new);
     bump();
 }
@@ -331,6 +357,11 @@ pub(crate) fn local_delete_draft(alias: &str, id: &str) {
         if let Some(entry) = state.aliases_mut().get_mut(alias) {
             entry.drafts.remove(id);
         }
+    });
+    // Tombstone protects against a stale `save_draft` echo that would
+    // otherwise re-add this draft via `replace_snapshot` (#107).
+    DELETED_DRAFTS.with(|t| {
+        t.borrow_mut().insert((alias.to_string(), id.to_string()));
     });
     bump();
 }


### PR DESCRIPTION
## Summary

- **#106**: `local_state::GENERATION` was an `AtomicUsize`. Components calling `.load(Relaxed)` did not register a Dioxus reactive dep, so kept/read mutations didn't trigger re-render. Switched to `GlobalSignal<usize>` — readers use `GENERATION()` to subscribe.
- **#107**: `delete_draft_now` race with debounced `save_draft` echo could resurrect a deleted draft. Added a `DELETED_DRAFTS` tombstone set; `replace_snapshot` strips matching ids until the delegate echo confirms deletion.

Closes #106
Closes #107

## Test plan

- [x] `cargo check -p freenet-email-ui` (use-node) clean
- [x] `cargo check -p freenet-email-ui --no-default-features --features example-data,no-sync` clean
- [x] `cargo clippy -p freenet-email-ui -- -D warnings` (both feature sets) clean
- [x] `cargo test -p freenet-email-ui --features example-data,no-sync` 26 pass
- [ ] Manual iso 2-node: alice → bob, bob clicks → row stays as read
- [ ] Manual iso 2-node: alice → bob, alice's Drafts stays empty after Send