### PR TITLE
feat(ui): gate WIP settings behind `wip-settings` cargo feature

### DIFF
--- a/.claude/skills/freenet-mail-qa/SKILL.md
+++ b/.claude/skills/freenet-mail-qa/SKILL.md
@@ -55,6 +55,33 @@ delete the row if the behavior is gone.
 Iso harness is heavy (~5–10 min, full freenet net + dx build + headed
 browser). Don't run on every change — gate to tags / nightly.
 
+## WIP settings gating
+
+Settings controls whose backend isn't fully wired live behind the
+`wip-settings` cargo feature (off by default). When you add or modify
+a Settings control:
+
+1. **Has a real consumer in non-Settings code?** Ship it ungated. Verify
+   by grepping the persisted field name across `ui/src/` excluding
+   `settings.rs` — if zero hits, it's WIP.
+2. **No consumer yet?** Gate with `#[cfg(feature = "wip-settings")]` on
+   the enum variant / route / nav entry / locals / SettingRow rsx
+   block. Cite the blocking issue (#69, #85, etc.) in the surrounding
+   comment.
+3. **Backend just landed?** Drop the gate, add row to the matrix as
+   `manual` (with recipe) or `auto` (with test link).
+
+Verify all three configs build clean before pushing:
+
+```bash
+cargo check -p freenet-email-ui
+cargo check -p freenet-email-ui --features wip-settings
+cargo check -p freenet-email-ui --no-default-features --features example-data,no-sync
+```
+
+The matrix's "Settings" section flags WIP rows with `(gated behind
+\`wip-settings\`)` and status `blocked` + the issue link.
+
 ## Anti-patterns
 
 - **Don't** add a test that requires `--features example-data,no-sync` for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ supported build target and what it's used for.
 | `use-node`    | Default. Enables the WebSocket bridge to a local Freenet node and all contract calls.    |
 | `example-data`| Seeds the UI with two mock identities (`address1`, `address2`) and mock inboxes.          |
 | `no-sync`     | Disables the WebSocket bridge entirely. Must be combined with `example-data` to be useful.|
+| `wip-settings`| Surfaces Settings controls whose backend isn't fully wired (AFT screen, read_receipts, pad_length, display_name). Off by default so released builds don't expose no-op toggles. |
 | `contract`    | (inbox crate, not ui) Enables the inbox contract's `ContractInterface` impl.             |
 
 **Supported combinations:**

--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -121,15 +121,28 @@ manual gap by adding a test, flip status to `auto` and link the test.
 
 ### Settings
 
+WIP controls (AFT screen, read_receipts, pad_length, display_name) are
+gated behind the `wip-settings` cargo feature and hidden in default
+builds. Build with `--features wip-settings` to surface them. See the
+"WIP settings gating" section in the `freenet-mail-qa` skill for the
+add/remove protocol.
+
 | Behavior | Status | Test / recipe |
 |---|---|---|
 | Identity privacy: verify_on_send toggle | manual | Settings → Privacy, toggle, send to unverified contact, confirm send proceeds vs blocks |
 | Identity privacy: hide_unsigned toggle | manual | Toggle, observe Inbox |
-| Identity privacy: quarantine_unknown toggle | manual | Toggle, observe Inbox |
+| Inbox: drafts_in_inbox toggle | manual | Settings → Inbox, toggle, observe Drafts surface in Inbox folder |
+| Inbox: quarantine_unknown toggle | manual | Toggle, observe Inbox filters unknown senders |
 | Auto-sign + signature persists | manual | Set, send, reload, send again, confirm sig still appended |
-| Appearance: density / theme | manual | Settings → Appearance, change density/theme, confirm UI reflects |
-| Inbox global settings | manual | Settings → Inbox, change retention / fetch options, confirm |
+| Appearance: theme switch (data-theme attr) | manual | Settings → Appearance, change theme, confirm `.fm-app[data-theme]` reflects |
+| Appearance: density (data-density attr) | manual | Change density, confirm `.fm-app[data-density]` reflects + row heights change |
+| Appearance: serif_subjects toggle | manual | Toggle, confirm subjects flip font |
+| Advanced: custom relay URL takes effect on reload | manual | Set custom_relay + URL, reload, WS connects to that URL |
 | Settings round-trip across reload | manual | Set value, reload, value persists |
+| WIP: AFT tier picker (gated) | blocked | Issue #85 — recipient inbox params not configurable |
+| WIP: read receipts toggle (gated) | blocked | Issue #69 — feature not implemented |
+| WIP: pad_length toggle (gated) | blocked | No implementation; gated until designed |
+| WIP: display_name field (gated) | blocked | No consumer of the field; gated until wired into Sent/Inbox surfaces |
 
 ### Layout / chrome
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -78,3 +78,13 @@ example-data = []
 # (and `--no-default-features`) for the offline dev loop.
 no-sync = []
 use-node = []
+# Show Settings controls whose backend isn't fully wired yet. Off by
+# default so released builds don't surface no-op toggles. Enable for
+# dev/preview to keep the UI shape visible while contract/delegate
+# work catches up. Items gated:
+#  - AFT screen (entire screen + nav entry; #85 blocks tier+max_age
+#    becoming recipient-configurable via InboxParams)
+#  - Privacy → read_receipts (#69 not implemented)
+#  - Privacy → pad_length (no impl)
+#  - Account → display_name (no consumer of the field)
+wip-settings = []

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -758,6 +758,7 @@ mod menu {
         #[default]
         Account,
         Privacy,
+        #[cfg(feature = "wip-settings")]
         Aft,
         Inbox,
         Contacts,
@@ -770,6 +771,7 @@ mod menu {
             match self {
                 Self::Account => "Account & profile",
                 Self::Privacy => "Privacy & security",
+                #[cfg(feature = "wip-settings")]
                 Self::Aft => "Anti-Flood (AFT)",
                 Self::Inbox => "Inbox & folders",
                 Self::Contacts => "Contacts",

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -172,6 +172,7 @@ pub(crate) fn SettingsShell() -> Element {
                     match screen {
                         menu::SettingsScreen::Account => rsx! { ScrAccount {} },
                         menu::SettingsScreen::Privacy => rsx! { ScrPrivacy {} },
+                        #[cfg(feature = "wip-settings")]
                         menu::SettingsScreen::Aft => rsx! { ScrAft {} },
                         menu::SettingsScreen::Inbox => rsx! { ScrInbox {} },
                         menu::SettingsScreen::Contacts => rsx! { ScrContacts {} },
@@ -210,25 +211,20 @@ fn BarHeader(current: menu::SettingsScreen, alias: String) -> Element {
 fn NavBlock(current: menu::SettingsScreen) -> Element {
     let mut menu_selection = use_context::<Signal<menu::MenuSelection>>();
 
-    let groups: &[(&str, &[(menu::SettingsScreen, &str)])] = &[
-        (
-            "GLOBAL",
-            &[
-                (menu::SettingsScreen::Appearance, "◐ Appearance"),
-                (menu::SettingsScreen::Advanced, "≡ Advanced & Diagnostics"),
-            ],
-        ),
-        (
-            "IDENTITY",
-            &[
-                (menu::SettingsScreen::Account, "◉ Account & profile"),
-                (menu::SettingsScreen::Privacy, "▣ Privacy & security"),
-                (menu::SettingsScreen::Aft, "▶ Anti-Flood (AFT)"),
-                (menu::SettingsScreen::Inbox, "◌ Inbox & folders"),
-                (menu::SettingsScreen::Contacts, "· Contacts"),
-            ],
-        ),
+    let identity_items: Vec<(menu::SettingsScreen, &str)> = vec![
+        (menu::SettingsScreen::Account, "◉ Account & profile"),
+        (menu::SettingsScreen::Privacy, "▣ Privacy & security"),
+        #[cfg(feature = "wip-settings")]
+        (menu::SettingsScreen::Aft, "▶ Anti-Flood (AFT)"),
+        (menu::SettingsScreen::Inbox, "◌ Inbox & folders"),
+        (menu::SettingsScreen::Contacts, "· Contacts"),
     ];
+    let global_items: Vec<(menu::SettingsScreen, &str)> = vec![
+        (menu::SettingsScreen::Appearance, "◐ Appearance"),
+        (menu::SettingsScreen::Advanced, "≡ Advanced & Diagnostics"),
+    ];
+    let groups: Vec<(&str, Vec<(menu::SettingsScreen, &str)>)> =
+        vec![("GLOBAL", global_items), ("IDENTITY", identity_items)];
 
     rsx! {
         div { class: "fm-set-nav",
@@ -383,6 +379,7 @@ fn ScrAccount() -> Element {
         .unwrap_or_default();
 
     let (alias_key, ident) = use_identity_settings();
+    #[cfg(feature = "wip-settings")]
     let display_name = ident.display_name.clone();
     let signature = ident.signature.clone();
     let auto_sign = ident.auto_sign;
@@ -395,8 +392,11 @@ fn ScrAccount() -> Element {
         None => "Never".to_string(),
     };
 
+    #[cfg(feature = "wip-settings")]
     let alias_key_dn = alias_key.clone();
+    #[cfg(feature = "wip-settings")]
     let ident_dn = ident.clone();
+    #[cfg(feature = "wip-settings")]
     let on_display_name = move |ev: Event<FormData>| {
         let mut next = ident_dn.clone();
         next.display_name = ev.value();
@@ -476,17 +476,26 @@ fn ScrAccount() -> Element {
                     help: "The handle others type to reach you. Bound to this identity's keys; cannot be changed without rotating.",
                     control: rsx! { input { class: "fm-input mono", value: "{alias}", disabled: true, style: "width: 180px" } },
                 }
-                SettingRow {
-                    label: "Display name",
-                    help: "Shown next to your alias in recipients' inboxes. Plain text, no verification.",
-                    control: rsx! {
-                        input {
-                            class: "fm-input",
-                            value: "{display_name}",
-                            style: "width: 180px",
-                            oninput: on_display_name,
+                {
+                    #[cfg(feature = "wip-settings")]
+                    {
+                        rsx! {
+                            SettingRow {
+                                label: "Display name",
+                                help: "Shown next to your alias in recipients' inboxes. Plain text, no verification.",
+                                control: rsx! {
+                                    input {
+                                        class: "fm-input",
+                                        value: "{display_name}",
+                                        style: "width: 180px",
+                                        oninput: on_display_name,
+                                    }
+                                },
+                            }
                         }
-                    },
+                    }
+                    #[cfg(not(feature = "wip-settings"))]
+                    rsx! {}
                 }
                 SettingRow {
                     label: "Signature",
@@ -566,7 +575,9 @@ fn ScrPrivacy() -> Element {
     let priv_now = ident.privacy.clone();
     let verify_on_send = priv_now.verify_on_send;
     let hide_unsigned = priv_now.hide_unsigned;
+    #[cfg(feature = "wip-settings")]
     let pad_length = priv_now.pad_length;
+    #[cfg(feature = "wip-settings")]
     let read_receipts = priv_now.read_receipts;
 
     let mk_toggle = move |mutate: fn(&mut IdentityPrivacyPrefs)| {
@@ -580,7 +591,9 @@ fn ScrPrivacy() -> Element {
     };
     let on_verify = mk_toggle(|p| p.verify_on_send = !p.verify_on_send);
     let on_hide_unsigned = mk_toggle(|p| p.hide_unsigned = !p.hide_unsigned);
+    #[cfg(feature = "wip-settings")]
     let on_pad = mk_toggle(|p| p.pad_length = !p.pad_length);
+    #[cfg(feature = "wip-settings")]
     let on_receipts = mk_toggle(|p| p.read_receipts = !p.read_receipts);
     rsx! {
         div { class: "fm-set-inner",
@@ -599,19 +612,28 @@ fn ScrPrivacy() -> Element {
                     control: rsx! { Toggle { on: hide_unsigned, ontoggle: on_hide_unsigned } },
                 }
             }
-            Card {
-                title: "Linkability",
-                sub: "Information that reveals patterns across your identities.",
-                SettingRow {
-                    label: "Share read receipts",
-                    help: "Senders see when you opened the message. Off by default; off is the unlinkable option.",
-                    control: rsx! { Toggle { on: read_receipts, ontoggle: on_receipts } },
+            {
+                #[cfg(feature = "wip-settings")]
+                {
+                    rsx! {
+                        Card {
+                            title: "Linkability",
+                            sub: "Information that reveals patterns across your identities.",
+                            SettingRow {
+                                label: "Share read receipts",
+                                help: "Senders see when you opened the message. Off by default; off is the unlinkable option.",
+                                control: rsx! { Toggle { on: read_receipts, ontoggle: on_receipts } },
+                            }
+                            SettingRow {
+                                label: "Pad message length",
+                                help: "Round ciphertext size to fixed buckets so observers can't infer content size. Adds ~5% bandwidth.",
+                                control: rsx! { Toggle { on: pad_length, ontoggle: on_pad } },
+                            }
+                        }
+                    }
                 }
-                SettingRow {
-                    label: "Pad message length",
-                    help: "Round ciphertext size to fixed buckets so observers can't infer content size. Adds ~5% bandwidth.",
-                    control: rsx! { Toggle { on: pad_length, ontoggle: on_pad } },
-                }
+                #[cfg(not(feature = "wip-settings"))]
+                rsx! {}
             }
         }
     }
@@ -622,6 +644,7 @@ fn ScrPrivacy() -> Element {
 /// `tokens_per_period` getter on the enum, so the period text is encoded
 /// here rather than in `freenet-aft-interface` to keep the AFT crate from
 /// taking on UI vocabulary.
+#[cfg(feature = "wip-settings")]
 const TIER_ROWS: &[(&str, &str)] = &[
     ("Min1", "1 / minute"),
     ("Min5", "1 / 5 minutes"),
@@ -641,6 +664,7 @@ const TIER_ROWS: &[(&str, &str)] = &[
 ];
 
 #[allow(non_snake_case)]
+#[cfg(feature = "wip-settings")]
 fn ScrAft() -> Element {
     let (alias_key, ident) = use_identity_settings();
     let aft_now = ident.aft.clone();


### PR DESCRIPTION
## Summary

Settings UI shipped controls whose backends aren't wired yet. They write to local-state but nothing reads. Hide them in default builds.

Hidden behind new \`wip-settings\` cargo feature (off by default):

- **AFT screen** — entire screen + nav entry. Tier picker, allow_known/allow_anon toggles, bounce_message all no-op. Blocked on #85 (recipient inbox params not configurable).
- **Privacy → Share read receipts** — blocked on #69.
- **Privacy → Pad message length** — no impl; designed only.
- **Account → Display name** — \`display_name\` field persisted but never read anywhere in rendering code.

Wired controls keep showing: \`verify_on_send\`, \`hide_unsigned\`, \`drafts_in_inbox\`, \`quarantine_unknown\`, \`auto_sign\` + \`signature\`, theme, density, \`serif_subjects\`, \`custom_relay\`.

## Test plan

- [x] \`cargo check\` default
- [x] \`cargo check --features wip-settings\`
- [x] \`cargo check --no-default-features --features example-data,no-sync\`
- [x] \`cargo clippy\` clean on all three
- [x] \`cargo test\` 26 pass

## Follow-up

Once #85 / #69 land, drop the gate per affected control and surface them by default again.