### PR TITLE
ci: bump freenet pin to v0.2.54, drop download-fix gate (closes #96)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
             ~/.cargo/bin/cargo-binstall
             ~/.cargo/bin/fdev
             ~/.cargo/bin/dx
-          key: ${{ runner.os }}-cargo-bins-fnet-v0.2.50-dx-0.7.3-v1
+          key: ${{ runner.os }}-cargo-bins-fnet-v0.2.54-dx-0.7.3-v1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -71,7 +71,7 @@ jobs:
         # fdev's crates.io versions don't carry binstall metadata; the
         # matching freenet-core release tag is what ships the binary.
         run: |
-          REL="v0.2.50"
+          REL="v0.2.54"
           BASE="https://github.com/freenet/freenet-core/releases/download/${REL}"
           mkdir -p "$HOME/.cargo/bin"
           curl -fsSL "${BASE}/fdev-x86_64-unknown-linux-musl.tar.gz" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,22 @@ jobs:
 
       - name: Install Playwright browser system deps (cached hit)
         if: steps.cache-playwright.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        timeout-minutes: 15
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          # Retry up to 3× with per-attempt timeout — apt mirror on
+          # ubicloud runners has hung this step for >1h on occasion.
+          # Fail fast (4min/attempt) and surface the apt error rather
+          # than blocking the run.
+          for i in 1 2 3; do
+            if timeout 240 npx playwright install-deps chromium; then
+              exit 0
+            fi
+            echo "attempt $i failed, retrying"
+            sleep 10
+          done
+          exit 1
         working-directory: ./ui/tests
 
       - name: Build UI in offline mode

--- a/.github/workflows/e2e-real-node.yml
+++ b/.github/workflows/e2e-real-node.yml
@@ -55,7 +55,7 @@ jobs:
             ~/.cargo/bin/fdev
             ~/.cargo/bin/dx
             ~/.cargo/bin/freenet
-          key: ${{ runner.os }}-cargo-bins-e2e-fnet-v0.2.50-dx-0.7.3-v1
+          key: ${{ runner.os }}-cargo-bins-e2e-fnet-v0.2.54-dx-0.7.3-v1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -89,7 +89,7 @@ jobs:
           # The matching version is the freenet-core release tag — fdev
           # crates.io versions (0.3.x) don't track 1:1 and don't carry
           # binstall metadata, so we go direct to the release artifact.
-          REL="v0.2.50"
+          REL="v0.2.54"
           BASE="https://github.com/freenet/freenet-core/releases/download/${REL}"
           mkdir -p "$HOME/.cargo/bin"
           for bin in fdev freenet; do
@@ -138,7 +138,7 @@ jobs:
         working-directory: ./ui/tests
 
       - name: Block freenet auto-update GitHub probe
-        # The pinned `freenet` binary (0.2.50) polls
+        # The pinned `freenet` binary (0.2.54) polls
         # https://api.github.com/repos/freenet/freenet-core/releases/latest
         # ~30s into startup and gracefully shuts down if a newer release
         # exists. That race kills the iso gateway mid-test on any PR

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -155,23 +155,17 @@ test.describe("Live node E2E", () => {
       ).toBe(false);
 
       // ── Step 5: regression for #77 (export download blocked) ──────
-      // Gated on FREENET_HAS_DOWNLOAD_FIX. The CI-pinned freenet
-      // binary (v0.2.50 / v0.2.51) predates freenet-core#4008
-      // (`allow-downloads` in iframe sandbox). Set the env var locally
-      // when running against a build that includes #4008, or wait for
-      // the next freenet release tag and bump the pin in build.yml +
-      // e2e-real-node.yml.
-      if (process.env.FREENET_HAS_DOWNLOAD_FIX) {
-        const downloadPromise = page.waitForEvent("download", { timeout: 5_000 });
-        await appAfterReload
-          .locator('[data-testid="fm-id-row"][data-alias="alice"] [data-testid="fm-id-backup"]')
-          .click();
-        const download = await downloadPromise;
-        expect(
-          download.suggestedFilename(),
-          "backup filename matches freenet-identity-<alias>.json (regression for #77)",
-        ).toMatch(/freenet-identity-.+\.json/);
-      }
+      // freenet-core#4008 (`allow-downloads` in iframe sandbox) shipped
+      // in v0.2.54.
+      const downloadPromise = page.waitForEvent("download", { timeout: 5_000 });
+      await appAfterReload
+        .locator('[data-testid="fm-id-row"][data-alias="alice"] [data-testid="fm-id-backup"]')
+        .click();
+      const download = await downloadPromise;
+      expect(
+        download.suggestedFilename(),
+        "backup filename matches freenet-identity-<alias>.json (regression for #77)",
+      ).toMatch(/freenet-identity-.+\.json/);
     } finally {
       stopPermissionPump();
     }


### PR DESCRIPTION
## Summary
- Bump pinned `fdev` / `freenet` binary fetches + cache-key suffixes in `build.yml` and `e2e-real-node.yml` from `v0.2.50` → `v0.2.54`. v0.2.54 includes freenet-core#4008 (`allow-downloads` in iframe sandbox).
- Drop the `FREENET_HAS_DOWNLOAD_FIX` env gate around the regression-for-#77 backup-download assert in `live-node.spec.ts` so it runs unconditionally.

Closes #96.

## Test plan
- [ ] CI green (`build-and-test`, `e2e-real-node`).
- [ ] `cargo make test-e2e-real-node` passes locally with no env vars set; the `freenet-identity-<alias>.json` download assert in test 1 step 5 fires.