### PR TITLE
fix(ui): tombstone optimistic kept entries (#113 partial)

### DIFF
--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -39,7 +39,13 @@ thread_local! {
 pub(crate) static GENERATION: GlobalSignal<usize> = Signal::global(|| 0);
 
 fn bump() {
-    *GENERATION.write() += 1;
+    // GlobalSignal::write() requires a live Dioxus runtime. The unit
+    // tests in this module exercise the SNAPSHOT round-trip without
+    // mounting a Dioxus app, so guard the bump and skip it when no
+    // runtime is present.
+    if dioxus::core::Runtime::try_current().is_some() {
+        *GENERATION.write() += 1;
+    }
 }
 
 pub(crate) fn replace_snapshot(new: LocalState) {
@@ -527,4 +533,129 @@ pub(crate) fn new_draft_id() -> String {
 
 pub(crate) fn new_sent_id() -> String {
     uuid::Uuid::new_v4().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mail_local_state::KeptMessage;
+
+    fn fresh_snapshot() {
+        SNAPSHOT.with(|s| *s.borrow_mut() = LocalState::default());
+    }
+
+    fn kept(from: &str, title: &str) -> KeptMessage {
+        KeptMessage {
+            from: from.into(),
+            title: title.into(),
+            content: "body".into(),
+            kept_at: 0,
+        }
+    }
+
+    /// Regression for #113: `local_mark_read` must make the row visible
+    /// to the inbox-list rebuild path (`kept_for`) immediately, before
+    /// any delegate echo. The UI relies on this so that clicking a
+    /// message that is then evicted from the live contract still
+    /// surfaces the row in the Inbox folder as `read=true`.
+    #[test]
+    fn local_mark_read_round_trips_via_kept_for() {
+        fresh_snapshot();
+        local_mark_read("alice", 42, kept("bob", "round one"));
+
+        let entries = kept_for("alice");
+        assert_eq!(entries.len(), 1, "exactly one kept entry");
+        let (mid, k) = &entries[0];
+        assert_eq!(*mid, 42);
+        assert_eq!(k.title, "round one");
+        assert!(is_read("alice", 42), "marked read");
+    }
+
+    /// `kept_for` must isolate by alias — bob's read state is NOT
+    /// visible from alice's Inbox.
+    #[test]
+    fn kept_for_is_alias_scoped() {
+        fresh_snapshot();
+        local_mark_read("alice", 1, kept("bob", "for alice"));
+        local_mark_read("bob", 2, kept("alice", "for bob"));
+
+        let alice = kept_for("alice");
+        let bob = kept_for("bob");
+        assert_eq!(alice.len(), 1);
+        assert_eq!(alice[0].0, 1);
+        assert_eq!(bob.len(), 1);
+        assert_eq!(bob[0].0, 2);
+    }
+
+    /// Idempotent: marking the same message read twice produces a
+    /// single kept entry, not duplicates. The live UI path runs
+    /// `OpenMessage` on every render, which re-fires `local_mark_read`
+    /// — that must be a no-op on second call.
+    #[test]
+    fn local_mark_read_is_idempotent() {
+        fresh_snapshot();
+        local_mark_read("alice", 7, kept("bob", "once"));
+        local_mark_read("alice", 7, kept("bob", "twice"));
+
+        let entries = kept_for("alice");
+        assert_eq!(entries.len(), 1, "single kept entry after repeat call");
+        assert_eq!(entries[0].1.title, "twice", "latest kept payload wins");
+    }
+
+    /// `replace_snapshot` (delegate `GetAll` echo) must NOT clobber
+    /// kept entries that the UI optimistically wrote. In the bug for
+    /// #113, the local_mark_read entry only lives in SNAPSHOT until
+    /// the delegate write round-trips; if the delegate's echoed
+    /// snapshot omits it, the UI loses the row. This test pins the
+    /// expected behavior: incoming snapshot wins, so the delegate
+    /// MUST contain the persisted entry by the time it echoes back.
+    /// Pure round-trip — confirms the data path, not the timing.
+    #[test]
+    fn replace_snapshot_preserves_kept_when_delegate_includes_it() {
+        fresh_snapshot();
+        local_mark_read("alice", 5, kept("bob", "kept"));
+
+        // Simulate delegate echo with the kept entry persisted.
+        let mut echoed = LocalState::default();
+        let entry = echoed
+            .aliases_mut()
+            .entry("alice".to_string())
+            .or_default();
+        entry.read.push(5);
+        entry.kept.insert("5".to_string(), kept("bob", "kept"));
+        replace_snapshot(echoed);
+
+        let entries = kept_for("alice");
+        assert_eq!(entries.len(), 1, "kept entry survives delegate echo");
+        assert!(is_read("alice", 5));
+    }
+
+    /// The race in #113: delegate echo arrives BEFORE `local_mark_read`
+    /// has had time to dispatch + persist its write. Echoed snapshot
+    /// has no kept entry → `replace_snapshot` clobbers the optimistic
+    /// write → `kept_for` returns empty. This test pins the failure
+    /// mode so a future fix (e.g. merging optimistic kept entries
+    /// back in on replace, like `DELETED_DRAFTS` does for drafts) has
+    /// a regression target.
+    #[test]
+    #[ignore = "documents the #113 race; fails today by design"]
+    fn replace_snapshot_does_not_clobber_optimistic_kept() {
+        fresh_snapshot();
+        local_mark_read("alice", 9, kept("bob", "optimistic"));
+
+        // Stale delegate echo — alice exists but kept is empty.
+        let mut echoed = LocalState::default();
+        echoed
+            .aliases_mut()
+            .entry("alice".to_string())
+            .or_default();
+        replace_snapshot(echoed);
+
+        let entries = kept_for("alice");
+        assert_eq!(
+            entries.len(),
+            1,
+            "optimistic kept entry must survive a stale echo (#113)",
+        );
+    }
 }

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -669,10 +669,7 @@ mod tests {
 
         // Simulate delegate echo with the kept entry persisted.
         let mut echoed = LocalState::default();
-        let entry = echoed
-            .aliases_mut()
-            .entry("alice".to_string())
-            .or_default();
+        let entry = echoed.aliases_mut().entry("alice".to_string()).or_default();
         entry.read.push(5);
         entry.kept.insert("5".to_string(), kept("bob", "kept"));
         replace_snapshot(echoed);
@@ -701,10 +698,7 @@ mod tests {
 
         // Stale delegate echo — alice exists but kept is empty.
         let mut echoed = LocalState::default();
-        echoed
-            .aliases_mut()
-            .entry("alice".to_string())
-            .or_default();
+        echoed.aliases_mut().entry("alice".to_string()).or_default();
         replace_snapshot(echoed);
 
         let entries = kept_for("alice");
@@ -730,11 +724,10 @@ mod tests {
 
         // Authoritative echo — delegate has the kept entry.
         let mut echoed = LocalState::default();
-        let entry = echoed
-            .aliases_mut()
-            .entry("alice".to_string())
-            .or_default();
-        entry.kept.insert("11".to_string(), kept("bob", "transient"));
+        let entry = echoed.aliases_mut().entry("alice".to_string()).or_default();
+        entry
+            .kept
+            .insert("11".to_string(), kept("bob", "transient"));
         entry.read.push(11);
         replace_snapshot(echoed);
 

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -9,7 +9,7 @@
 //! `LocalState` value (`AliasState` keyed by alias string).
 
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use dioxus::prelude::*;
 use mail_local_state::{
@@ -29,6 +29,16 @@ thread_local! {
     /// the delegate echoes a snapshot that no longer contains the id (#107).
     /// Key: (alias, draft_id).
     static DELETED_DRAFTS: RefCell<HashSet<(String, String)>> = RefCell::new(HashSet::new());
+
+    /// Optimistic `local_mark_read` writes that haven't yet round-tripped
+    /// through the delegate. A stale `GetAll` echo that lands BEFORE the
+    /// `MarkRead` write was persisted would otherwise clobber them, and
+    /// the inbox-list rebuild path (`kept_for`) would return empty — the
+    /// row evaporates from the UI even though the contract has already
+    /// evicted it (#113). Held until an echo includes the kept entry.
+    /// Key: (alias, msg_id_string).
+    static PENDING_KEPT: RefCell<HashMap<(String, String), KeptMessage>> =
+        RefCell::new(HashMap::new());
 }
 
 /// Bumped on every snapshot mutation. Components read this signal so Dioxus
@@ -62,6 +72,27 @@ pub(crate) fn replace_snapshot(new: LocalState) {
                 return true;
             }
             false
+        });
+    });
+    PENDING_KEPT.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        pending.retain(|(alias, msg_id), kept| {
+            let entry = new.aliases_mut().entry(alias.clone()).or_default();
+            if entry.kept.contains_key(msg_id) {
+                // Delegate echo includes this kept entry — `MarkRead`
+                // round-tripped, drop the optimistic stash.
+                return false;
+            }
+            // Stale echo — re-merge the optimistic write so `kept_for`
+            // keeps surfacing the row. Also re-apply `read=true` so the
+            // inbox list shows the row as read on the next rebuild.
+            entry.kept.insert(msg_id.clone(), kept.clone());
+            if let Ok(parsed) = msg_id.parse::<MessageId>()
+                && !entry.read.contains(&parsed)
+            {
+                entry.read.push(parsed);
+            }
+            true
         });
     });
     SNAPSHOT.with(|s| *s.borrow_mut() = new);
@@ -420,6 +451,13 @@ pub(crate) fn local_archive_message(alias: &str, msg_id: MessageId, archived: Ar
         }
         entry.archived.insert(msg_id.to_string(), archived);
     });
+    // Archive supersedes a pending kept tombstone — drop it so a stale
+    // echo doesn't re-insert the kept entry under the archived row.
+    PENDING_KEPT.with(|pending| {
+        pending
+            .borrow_mut()
+            .remove(&(alias.to_string(), msg_id.to_string()));
+    });
     bump();
 }
 
@@ -445,6 +483,12 @@ pub(crate) fn local_delete_message(alias: &str, msg_id: MessageId) {
             entry.deleted.push(msg_id);
         }
     });
+    // Same as archive: delete supersedes a pending kept tombstone.
+    PENDING_KEPT.with(|pending| {
+        pending
+            .borrow_mut()
+            .remove(&(alias.to_string(), msg_id.to_string()));
+    });
     bump();
 }
 
@@ -455,7 +499,15 @@ pub(crate) fn local_mark_read(alias: &str, msg_id: MessageId, kept: KeptMessage)
         if !entry.read.contains(&msg_id) {
             entry.read.push(msg_id);
         }
-        entry.kept.insert(msg_id.to_string(), kept);
+        entry.kept.insert(msg_id.to_string(), kept.clone());
+    });
+    // Tombstone the optimistic write until the delegate echoes back a
+    // snapshot that includes it — guards against the #113 race where a
+    // stale `GetAll` reply lands before `MarkRead` persists.
+    PENDING_KEPT.with(|pending| {
+        pending
+            .borrow_mut()
+            .insert((alias.to_string(), msg_id.to_string()), kept);
     });
     bump();
 }
@@ -630,17 +682,21 @@ mod tests {
         assert!(is_read("alice", 5));
     }
 
+    fn fresh_pending() {
+        PENDING_KEPT.with(|p| p.borrow_mut().clear());
+    }
+
     /// The race in #113: delegate echo arrives BEFORE `local_mark_read`
     /// has had time to dispatch + persist its write. Echoed snapshot
-    /// has no kept entry → `replace_snapshot` clobbers the optimistic
-    /// write → `kept_for` returns empty. This test pins the failure
-    /// mode so a future fix (e.g. merging optimistic kept entries
-    /// back in on replace, like `DELETED_DRAFTS` does for drafts) has
-    /// a regression target.
+    /// has no kept entry → without the `PENDING_KEPT` tombstone path,
+    /// `replace_snapshot` would clobber the optimistic write and
+    /// `kept_for` would return empty. With the tombstone, the entry
+    /// survives the stale echo and surfaces on the next inbox-list
+    /// rebuild.
     #[test]
-    #[ignore = "documents the #113 race; fails today by design"]
     fn replace_snapshot_does_not_clobber_optimistic_kept() {
         fresh_snapshot();
+        fresh_pending();
         local_mark_read("alice", 9, kept("bob", "optimistic"));
 
         // Stale delegate echo — alice exists but kept is empty.
@@ -656,6 +712,88 @@ mod tests {
             entries.len(),
             1,
             "optimistic kept entry must survive a stale echo (#113)",
+        );
+        assert_eq!(entries[0].0, 9);
+        assert!(is_read("alice", 9), "read flag re-applied after merge");
+    }
+
+    /// Once the delegate echoes a snapshot that includes the kept entry,
+    /// the `PENDING_KEPT` tombstone is dropped — subsequent stale echoes
+    /// (e.g. an in-flight `GetAll` from before the `MarkRead` round-trip)
+    /// no longer re-insert the entry. Pins the lifecycle so the
+    /// tombstone doesn't leak forever and resurrect deleted entries.
+    #[test]
+    fn pending_kept_drops_after_delegate_echo_includes_entry() {
+        fresh_snapshot();
+        fresh_pending();
+        local_mark_read("alice", 11, kept("bob", "transient"));
+
+        // Authoritative echo — delegate has the kept entry.
+        let mut echoed = LocalState::default();
+        let entry = echoed
+            .aliases_mut()
+            .entry("alice".to_string())
+            .or_default();
+        entry.kept.insert("11".to_string(), kept("bob", "transient"));
+        entry.read.push(11);
+        replace_snapshot(echoed);
+
+        // Now a second, *older* echo arrives that lacks the entry —
+        // simulating a network reorder. Without the tombstone drop,
+        // we'd resurrect the kept row indefinitely.
+        let mut stale = LocalState::default();
+        stale.aliases_mut().entry("alice".to_string()).or_default();
+        replace_snapshot(stale);
+
+        assert!(
+            kept_for("alice").is_empty(),
+            "tombstone must be dropped once delegate confirms the entry",
+        );
+    }
+
+    /// Archive supersedes kept — the pending tombstone for a freshly
+    /// read message must drop when the user archives it, otherwise a
+    /// later stale echo would re-insert the kept row alongside the
+    /// archived one.
+    #[test]
+    fn local_archive_drops_pending_kept_tombstone() {
+        fresh_snapshot();
+        fresh_pending();
+        local_mark_read("alice", 13, kept("bob", "read then archive"));
+        local_archive_message(
+            "alice",
+            13,
+            ArchivedMessage {
+                from: "bob".into(),
+                title: "read then archive".into(),
+                content: "body".into(),
+                archived_at: 1,
+            },
+        );
+
+        let stale = LocalState::default();
+        replace_snapshot(stale);
+
+        assert!(
+            kept_for("alice").is_empty(),
+            "archived message must not be re-merged as kept on stale echo",
+        );
+    }
+
+    /// Same shape as the archive test but for deletion.
+    #[test]
+    fn local_delete_drops_pending_kept_tombstone() {
+        fresh_snapshot();
+        fresh_pending();
+        local_mark_read("alice", 17, kept("bob", "read then delete"));
+        local_delete_message("alice", 17);
+
+        let stale = LocalState::default();
+        replace_snapshot(stale);
+
+        assert!(
+            kept_for("alice").is_empty(),
+            "deleted message must not be re-merged as kept on stale echo",
         );
     }
 }

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -357,10 +357,31 @@ test.describe("Live node E2E", () => {
     );
     const stopGwPump = startPermissionPump(ISO_GW_ORIGIN);
     const stopPeerPump = startPermissionPump(ISO_PEER_ORIGIN);
+    // Per-context tracing — captures DOM snapshots, console messages, and
+    // network activity for both browser contexts. Saved alongside other
+    // playwright artifacts so #113 (kept_for rebuild miss after click-
+    // to-read) can be diagnosed from CI logs without local repro.
     const aliceCtx = await browser.newContext();
     const bobCtx = await browser.newContext();
+    await aliceCtx.tracing.start({ screenshots: true, snapshots: true });
+    await bobCtx.tracing.start({ screenshots: true, snapshots: true });
     const alicePage = await aliceCtx.newPage();
     const bobPage = await bobCtx.newPage();
+    // Mirror every console message verbatim into the test log so that
+    // crash-time error_context.md captures what each side saw — narrows
+    // down whether the row vanished due to a wasm panic, a delegate
+    // dispatch failure, or a quiet `kept_for` returning empty.
+    for (const [page, label] of [
+      [alicePage, "alice"],
+      [bobPage, "bob"],
+    ] as const) {
+      page.on("console", (m) => {
+        console.log(`[console:${label}:${m.type()}] ${m.text()}`);
+      });
+      page.on("pageerror", (e) => {
+        console.log(`[pageerror:${label}] ${e.message}`);
+      });
+    }
 
     // Surface WASM panics + console errors immediately so test failure
     // points at the original panic frame, not a downstream timeout.
@@ -514,6 +535,16 @@ test.describe("Live node E2E", () => {
         `no WASM panics in either browser context: ${consoleErrors.join("\n")}`,
       ).toEqual([]);
     } finally {
+      // Stop + persist traces before context close so they survive
+      // even when the test fails mid-flow. Filenames land under
+      // test-results/ so they're picked up by the e2e-real-node CI
+      // artifact upload step.
+      await aliceCtx.tracing
+        .stop({ path: "test-results/multi-round-alice-trace.zip" })
+        .catch(() => {});
+      await bobCtx.tracing
+        .stop({ path: "test-results/multi-round-bob-trace.zip" })
+        .catch(() => {});
       await aliceCtx.close().catch(() => {});
       await bobCtx.close().catch(() => {});
       stopGwPump();


### PR DESCRIPTION
## Summary

Refs #113. **Partial** fix — the kept_for race documented in #113 is real and now has both unit-test coverage and a working repair. However, end-to-end verification on the iso harness still trips on a separate duplicate-inbox bug filed as #114, so the multi-round Playwright test still fails. Landing this anyway because the race fix is independently correct.

### What changed

- Adds \`PENDING_KEPT\` tombstone map in \`ui/src/local_state.rs\`, mirroring the \`DELETED_DRAFTS\` shape from #107. \`local_mark_read\` writes optimistically to \`SNAPSHOT.kept\` and stashes a tombstone keyed by \`(alias, msg_id)\`. On every \`replace_snapshot\`:
  - if the delegate's echo includes the kept entry, the round-trip is durable → drop the tombstone.
  - if not, this is a stale echo from before the write → re-merge the optimistic kept entry into the new snapshot so \`kept_for\` keeps surfacing the row. Re-applies \`read=true\` too.
- \`local_archive_message\` and \`local_delete_message\` drop the pending tombstone so a stale echo doesn't resurrect kept rows under archived/deleted ids.
- 4 new unit tests pin the new behavior. The previously-\`#[ignore]\`'d \`replace_snapshot_does_not_clobber_optimistic_kept\` is now active and passes.
- \`bump()\` is now a runtime-aware no-op when called outside Dioxus, so the SNAPSHOT mutators can be exercised in plain unit tests without mounting an app.
- Adds Playwright tracing + per-context console mirroring to the multi-round live-node spec so #114 (and any future regression) has artifacts useful for diagnosis.

### Why this is partial

After landing the fix, the iso harness multi-round test still fails the same way. Bob's UI is subscribed to **two** distinct inbox contracts both registered against \`alias=bob\` — see #114 for the gateway-log evidence. \`mark_as_read\` then targets the wrong inbox via \`inbox_data[active_id]\`, and the row disappears regardless of \`kept_for\`. The race fix is necessary but not sufficient for the full click-to-read end-to-end story.

## Test plan

- [x] \`cargo test -p freenet-email-ui --lib --no-default-features --features example-data,no-sync local_state::tests::\` — all 8 tests pass
- [x] \`cargo clippy -p freenet-email-ui --lib --no-default-features --features example-data,no-sync --tests\` — clean
- [x] \`cargo check -p freenet-email-ui --lib --target wasm32-unknown-unknown\` — clean
- [ ] \`FREENET_LIVE_E2E_SEND=1 cargo make test-e2e-real-node\` test 3 passes — blocked on #114