### PR TITLE
chore(release): opt-in real-node E2E gate before publish (#81)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -139,6 +139,21 @@ cargo make test-inbox
 cargo make clippy
 echo "  ✓ cargo make test, test-inbox, clippy green"
 
+# Real-node E2E (opt-in via FREENET_RELEASE_E2E=1). Heavy: spins up
+# a 2-node iso Freenet network + dx build + headed chromium, runs
+# 5–10min. Off by default so a routine release isn't gated on the
+# iso harness, but recommended before tagging anything user-facing.
+# CI runs the same target on tag push (.github/workflows/e2e-real-node.yml),
+# so the post-push gate stays in place either way.
+if [ "${FREENET_RELEASE_E2E:-0}" = "1" ]; then
+    echo ""
+    echo "═══ Real-node E2E (FREENET_RELEASE_E2E=1) ════════════════════"
+    cargo make test-e2e-real-node
+    echo "  ✓ test-e2e-real-node green"
+else
+    echo "  • skipped test-e2e-real-node (set FREENET_RELEASE_E2E=1 to run)"
+fi
+
 # ─── Confirmation ──────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Wire \`cargo make test-e2e-real-node\` into \`scripts/release.sh\` as an opt-in preflight (\`FREENET_RELEASE_E2E=1\`). Off by default — the iso harness is heavy (5–10min, full Freenet network + headed Chromium) and a routine release shouldn't be gated on it. CI already runs the same target on tag push (e2e-real-node.yml), so the post-tag gate stays unchanged.

Useful before changes that touch contracts, delegates, or the permission flow, where the iso harness is the only meaningful check.

Closes one of the #81 followup checklist items.

## Test plan
- [x] bash -n scripts/release.sh (syntax)
- [ ] Manual: \`FREENET_RELEASE_E2E=1 scripts/release.sh\` runs the e2e step
- [ ] Manual: default invocation skips the e2e step