### PR TITLE
refactor(aft): make recipient policy mutable via InboxSettings (#85 followup)

### DIFF
--- a/.github/workflows/e2e-real-node.yml
+++ b/.github/workflows/e2e-real-node.yml
@@ -177,4 +177,6 @@ jobs:
           path: |
             ~/freenet-mail-iso/gw/logs/
             ~/freenet-mail-iso/peer/logs/
+            ~/freenet-mail-iso/gw/data/secrets/
+            ~/freenet-mail-iso/peer/data/secrets/
           if-no-files-found: ignore

--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -37,45 +37,28 @@ const STATE_UPDATE: &[u8; 8] = &[168, 7, 13, 64, 168, 123, 142, 215];
 /// impl on the typed key. `pub_key_decoded()` reconstructs the typed
 /// `VerifyingKey<MlDsa65>` on demand.
 ///
-/// `required_tier` and `max_age_secs` express the recipient's anti-flood
-/// policy: senders must mint AFT tokens at this tier and `max_age` so the
-/// inbox owner controls the per-sender rate cap. They are part of the
-/// contract parameters, so changing them rotates the contract id and
-/// makes the policy authenticated by construction.
+/// This field is part of the contract parameters, so it participates in
+/// `hash(code, params)` and every bit change rotates the contract id.
 ///
-/// All fields participate in `hash(code, params)` — every bit change
-/// rotates the contract id.
+/// The recipient anti-flood policy lives on `InboxSettings` (mutable via
+/// `ModifySettings`) rather than here, so the inbox owner can re-tune
+/// their tier / max-age cap without rotating the contract id and forcing
+/// every existing sender to re-import.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct InboxParams {
     pub pub_key: Vec<u8>,
-    pub required_tier: Tier,
-    pub max_age_secs: u64,
 }
 
-/// Default seconds-component of `max_age` matching pre-#85 behavior
-/// (365 days). Used by `from_verifying_key` and any caller that wants
-/// the historical default without spelling out the constant.
+/// Default seconds-component of `max_age` (365 days). Used by
+/// callers that want the historical default without spelling out
+/// the constant.
 pub const DEFAULT_MAX_AGE_SECS: u64 = 365 * 24 * 3600;
 
 impl InboxParams {
-    /// Convenience constructor from a typed ML-DSA verifying key. Uses
-    /// the legacy default policy (`Tier::Day1`, 365d) so existing
-    /// call-sites that don't care about #85 keep their old behavior
-    /// until they're migrated to pick a policy.
+    /// Convenience constructor from a typed ML-DSA verifying key.
     pub fn from_verifying_key(vk: &MlDsaVerifyingKey<MlDsa65>) -> Self {
         Self {
             pub_key: vk.encode().to_vec(),
-            required_tier: Tier::Day1,
-            max_age_secs: DEFAULT_MAX_AGE_SECS,
-        }
-    }
-
-    /// Constructor that sets the recipient anti-flood policy explicitly.
-    pub fn new(vk: &MlDsaVerifyingKey<MlDsa65>, required_tier: Tier, max_age_secs: u64) -> Self {
-        Self {
-            pub_key: vk.encode().to_vec(),
-            required_tier,
-            max_age_secs,
         }
     }
 
@@ -122,15 +105,30 @@ pub enum UpdateInbox {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct InboxSettings {
+    /// AFT tier the recipient requires for incoming messages. Senders
+    /// must mint tokens at this exact tier; the contract rejects any
+    /// `AddMessages` whose token tier mismatches. Mutable via
+    /// `ModifySettings`, so the recipient can re-tune their flood cap
+    /// without rotating the inbox contract id.
     pub minimum_tier: Tier,
+    /// `max_age_secs` half of the recipient policy. The AFT delegate
+    /// uses it sender-side when computing free slots; the contract does
+    /// not enforce age (no clock available in WASM).
+    #[serde(default = "default_max_age_secs")]
+    pub max_age_secs: u64,
     #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::default")]
     pub private: EncryptedContent,
+}
+
+fn default_max_age_secs() -> u64 {
+    DEFAULT_MAX_AGE_SECS
 }
 
 impl Default for InboxSettings {
     fn default() -> Self {
         Self {
-            minimum_tier: Tier::Min30,
+            minimum_tier: Tier::Day1,
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
             private: Default::default(),
         }
     }
@@ -235,17 +233,23 @@ impl Display for VerificationError {
     }
 }
 
-/// Enforce recipient `InboxParams` policy on an incoming token. Currently
-/// gates on `required_tier`; `max_age_secs` is enforced sender-side
-/// inside the AFT delegate (which does have a clock) when computing
-/// `next_free_assignment`.
+/// Enforce recipient `InboxSettings` policy on an incoming token.
+/// Currently gates on `minimum_tier`; `max_age_secs` is enforced
+/// sender-side inside the AFT delegate (which does have a clock) when
+/// computing `next_free_assignment`.
+///
+/// Policy lives on settings rather than params so the inbox owner can
+/// re-tune it via `ModifySettings` without rotating the contract id.
+/// `can_update_settings` already gates settings updates on the owner's
+/// ML-DSA signature (verified against `params.pub_key`), so only the
+/// inbox owner can change the policy.
 fn verify_token_policy(
-    params: &InboxParams,
+    settings: &InboxSettings,
     assignment: &TokenAssignment,
 ) -> Result<(), VerificationError> {
-    if assignment.tier != params.required_tier {
+    if assignment.tier != settings.minimum_tier {
         return Err(VerificationError::PolicyTierMismatch {
-            expected: params.required_tier,
+            expected: settings.minimum_tier,
             got: assignment.tier,
         });
     }
@@ -293,7 +297,6 @@ impl Inbox {
 
     fn add_messages(
         &mut self,
-        params: &InboxParams,
         allocation_records: &HashMap<ContractInstanceId, TokenAllocationRecord>,
         messages: Vec<Message>,
     ) -> Result<(), VerificationError> {
@@ -321,14 +324,13 @@ impl Inbox {
             if !records.assignment_exists(&message.token_assignment) {
                 return Err(VerificationError::TokenAssignmentMismatch);
             }
-            self.add_message(params, message)?;
+            self.add_message(message)?;
         }
         Ok(())
     }
 
     fn verify_messages(
         &self,
-        params: &InboxParams,
         allocation_records: &HashMap<ContractInstanceId, TokenAllocationRecord>,
     ) -> Result<(), VerificationError> {
         let mut some_missing = false;
@@ -346,7 +348,7 @@ impl Inbox {
             if !records.assignment_exists(&message.token_assignment) {
                 return Err(VerificationError::TokenAssignmentMismatch);
             }
-            verify_token_policy(params, &message.token_assignment)?;
+            verify_token_policy(&self.settings, &message.token_assignment)?;
             let verifying_key = decode_token_generator_vk(&message.token_assignment.generator)
                 .ok_or(VerificationError::InvalidTokenGeneratorKey)?;
             message
@@ -360,12 +362,8 @@ impl Inbox {
         Ok(())
     }
 
-    fn add_message(
-        &mut self,
-        params: &InboxParams,
-        message: Message,
-    ) -> Result<(), VerificationError> {
-        verify_token_policy(params, &message.token_assignment)?;
+    fn add_message(&mut self, message: Message) -> Result<(), VerificationError> {
+        verify_token_policy(&self.settings, &message.token_assignment)?;
         let verifying_key = decode_token_generator_vk(&message.token_assignment.generator)
             .ok_or(VerificationError::InvalidTokenGeneratorKey)?;
         message
@@ -396,7 +394,7 @@ impl Inbox {
         Ok(StateSummary::from(serialized))
     }
 
-    fn merge(&mut self, params: &InboxParams, other: Self) -> Result<(), ContractError> {
+    fn merge(&mut self, other: Self) -> Result<(), ContractError> {
         // Accept any incoming messages we don't already have. The previous
         // gate (`self.messages.is_empty() && self.last_update < other.last_update`)
         // silently dropped the merge whenever both sides had a default
@@ -411,7 +409,7 @@ impl Inbox {
             .collect();
         for m in other.messages {
             if !known.contains(&m.token_assignment.assignment_hash) {
-                self.add_message(params, m)?;
+                self.add_message(m)?;
             }
         }
         if other.last_update > self.last_update {
@@ -537,7 +535,7 @@ impl ContractInterface for Inbox {
             return Ok(ValidateResult::RequestRelated(missing_related));
         }
 
-        match inbox.verify_messages(&params, &allocation_records) {
+        match inbox.verify_messages(&allocation_records) {
             Ok(_) => Ok(ValidateResult::Valid),
             Err(VerificationError::MissingContracts(ids)) => {
                 Ok(ValidateResult::RequestRelated(ids))
@@ -580,7 +578,7 @@ impl ContractInterface for Inbox {
             match update {
                 UpdateData::State(state) => {
                     let full_inbox = Inbox::try_from(&state)?;
-                    inbox.merge(&params, full_inbox)?;
+                    inbox.merge(full_inbox)?;
                 }
                 UpdateData::Delta(d) => match UpdateInbox::try_from(d)? {
                     UpdateInbox::AddMessages { mut messages } => {
@@ -656,7 +654,7 @@ impl ContractInterface for Inbox {
 
         if missing_related.is_empty() {
             inbox
-                .add_messages(&params, &allocation_records, new_messages)
+                .add_messages(&allocation_records, new_messages)
                 .map_err(|err| ContractError::Other(format!("{err}")))?;
             inbox.remove_messages(rm_messages);
             // FIXME: uncomment next line, right now it pulls the `time` dep on the web UI if we enable which is not what we want

--- a/contracts/inbox/tests/common/mod.rs
+++ b/contracts/inbox/tests/common/mod.rs
@@ -64,16 +64,17 @@ pub fn make_params(owner_vk: &MlDsaVerifyingKey<MlDsa65>) -> Parameters<'static>
         .expect("inbox params -> parameters")
 }
 
-/// `make_params` variant that pins an explicit recipient policy, used
-/// by tests that exercise the tier-mismatch enforcement path (#85).
-pub fn make_params_with_policy(
-    owner_vk: &MlDsaVerifyingKey<MlDsa65>,
-    required_tier: Tier,
-    max_age_secs: u64,
-) -> Parameters<'static> {
-    InboxParams::new(owner_vk, required_tier, max_age_secs)
-        .try_into()
-        .expect("inbox params -> parameters")
+/// Build an `InboxSettings` with explicit recipient policy. Used by
+/// tests that exercise the tier-mismatch enforcement path (#85). The
+/// policy lives on settings (mutable) rather than params (immutable),
+/// so this is what tests should tweak when simulating an owner that
+/// has tightened their flood cap.
+pub fn make_settings_with_policy(minimum_tier: Tier, max_age_secs: u64) -> InboxSettings {
+    InboxSettings {
+        minimum_tier,
+        max_age_secs,
+        private: Default::default(),
+    }
 }
 
 /// Pick a deterministic, valid `Tier::Min1` slot well in the past so that

--- a/contracts/inbox/tests/integration.rs
+++ b/contracts/inbox/tests/integration.rs
@@ -14,7 +14,7 @@ use chrono::{Duration, Utc};
 use common::{
     add_messages_delta, assignment_hash_for, fixed_valid_slot, inbox_verifying_key,
     make_inbox_keypair, make_inbox_state, make_inbox_value, make_message, make_params,
-    make_params_with_policy, make_token_assignment, make_token_generator_keypair,
+    make_settings_with_policy, make_token_assignment, make_token_generator_keypair,
     make_token_record, related_state_update, token_record_id_for,
 };
 use freenet_aft_interface::Tier;
@@ -193,22 +193,23 @@ fn update_rejects_token_with_invalid_slot() {
     );
 }
 
-/// #85: when `InboxParams.required_tier` is set to a non-default tier,
-/// any incoming AddMessages that carries a token minted at the default
-/// (Day1) tier must be rejected. This is the contract-side gate that
-/// makes the recipient's anti-flood policy authenticated by
-/// `hash(code, params)`.
+/// #85: when `InboxSettings.minimum_tier` is set to a non-default tier,
+/// any incoming AddMessages that carries a token minted at a different
+/// tier must be rejected. The policy lives on settings (mutable by the
+/// owner via `ModifySettings`) rather than params (immutable), so the
+/// contract id stays stable across policy tweaks.
 #[test]
 fn update_rejects_token_with_wrong_tier_for_recipient_policy() {
     let owner_sk = make_inbox_keypair();
     let owner_vk = inbox_verifying_key(&owner_sk);
     let (gen_sk, gen_vk_bytes) = make_token_generator_keypair();
-    // Recipient policy: Hour1, not Day1.
-    let params = make_params_with_policy(&owner_vk, Tier::Hour1, 365 * 24 * 3600);
+    let params = make_params(&owner_vk);
+    // Recipient policy carried on settings: Hour1, not Day1.
+    let settings = make_settings_with_policy(Tier::Hour1, 365 * 24 * 3600);
 
     let token_record_id = token_record_id_for(b"wrong-tier-record");
     // Sender mints at Day1 (the legacy default), which now mismatches
-    // the recipient's policy and should be rejected.
+    // the recipient's settings policy and should be rejected.
     let assignment = make_token_assignment(
         &gen_sk,
         gen_vk_bytes,
@@ -220,7 +221,7 @@ fn update_rejects_token_with_wrong_tier_for_recipient_policy() {
     let message = make_message(b"wrong-tier-payload".to_vec(), assignment.clone());
     let record = make_token_record(assignment);
 
-    let initial_state = make_inbox_state(&owner_sk, vec![], Utc::now(), InboxSettings::default());
+    let initial_state = make_inbox_state(&owner_sk, vec![], Utc::now(), settings);
     let updates = vec![
         add_messages_delta(vec![message]),
         related_state_update(token_record_id, record),

--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -167,6 +167,12 @@ pub struct IdentityAftPrefs {
     /// `Hour1`, `Hour3`, `Hour6`, `Hour12`, `Day1`, `Day7`, `Day15`,
     /// `Day30`, `Day90`, `Day180`, `Day365`).
     pub required_tier: String,
+    /// `max_age` half of the recipient anti-flood policy, in days
+    /// (#85). The AFT delegate uses it sender-side when computing
+    /// free slots; capped at 730 to stay under the 2-year ceiling
+    /// `AllocationCriteria::new` enforces.
+    #[serde(default = "default_max_age_days")]
+    pub max_age_days: u64,
     /// Accept messages from contacts in the address book regardless of tier.
     pub allow_known: bool,
     /// Accept messages from senders not in the address book.
@@ -175,10 +181,15 @@ pub struct IdentityAftPrefs {
     pub bounce_message: String,
 }
 
+fn default_max_age_days() -> u64 {
+    365
+}
+
 impl Default for IdentityAftPrefs {
     fn default() -> Self {
         Self {
             required_tier: "Day1".to_string(),
+            max_age_days: default_max_age_days(),
             allow_known: true,
             allow_anon: false,
             bounce_message: String::new(),
@@ -919,6 +930,7 @@ mod boundary_tests {
             auto_sign: false,
             aft: IdentityAftPrefs {
                 required_tier: "Mid2".into(),
+                max_age_days: 90,
                 allow_known: true,
                 allow_anon: true,
                 bounce_message: "rate-limited".into(),

--- a/scripts/run-isolated-nodes.sh
+++ b/scripts/run-isolated-nodes.sh
@@ -162,13 +162,21 @@ up() {
     sleep 2
     if [ -f "$PEER_DATA/secrets/transport_keypair" ]; then
         echo "peer transport_keypair head: $(head -c 32 "$PEER_DATA/secrets/transport_keypair")"
+    else
+        echo "peer transport_keypair: NOT WRITTEN (peer likely crashed during init — see $PEER_LOGS)"
     fi
-    local n
-    # `grep -c` over multiple files emits `<file>:<count>` lines; sum
-    # the counts via cut+awk so the bare integer comparison below
-    # doesn't trip on a `:0:`-suffixed string.
-    n=$(grep -c "Attempting connection to gateway" "$PEER_LOGS"/freenet.*.log 2>/dev/null \
-        | awk -F: '{ sum += $NF } END { print sum + 0 }')
+    # Use shopt nullglob so the freenet.*.log glob doesn't pass a
+    # literal pattern to grep when the peer crashed before producing
+    # any rolled log file. `set -e + pipefail` would abort the whole
+    # `up()` call on grep's exit-2 in that case.
+    local n=0
+    shopt -s nullglob
+    local peer_logs=( "$PEER_LOGS"/freenet.*.log )
+    shopt -u nullglob
+    if (( ${#peer_logs[@]} > 0 )); then
+        n=$(grep -c "Attempting connection to gateway" "${peer_logs[@]}" 2>/dev/null \
+            | awk -F: '{ sum += $NF } END { print sum + 0 }')
+    fi
     if [ "${n:-0}" -gt 1 ]; then
         echo "WARNING: peer is dialing $n gateways — isolation broken (check HOME override)"
     fi

--- a/scripts/run-isolated-nodes.sh
+++ b/scripts/run-isolated-nodes.sh
@@ -61,14 +61,27 @@ spawn_setsid() {
 }
 
 setup_dirs() {
+    # macOS layout: dirs::config_dir() / dirs::data_local_dir() both
+    # resolve under "Library/Application Support/<APPLICATION>".
     mkdir -p "$GW_HOME/Library/Application Support/The-Freenet-Project-Inc.Freenet"
     mkdir -p "$PEER_HOME/Library/Application Support/The-Freenet-Project-Inc.Freenet"
+    # Linux layout: dirs::config_dir() = $XDG_CONFIG_HOME or $HOME/.config;
+    # dirs::data_local_dir() = $XDG_DATA_HOME or $HOME/.local/share.
+    # Pre-create both so freenet never falls back to a host-default path
+    # outside our HOME override (which would let gw + peer share state).
+    mkdir -p "$GW_HOME/.config/freenet" "$GW_HOME/.local/share/freenet"
+    mkdir -p "$PEER_HOME/.config/freenet" "$PEER_HOME/.local/share/freenet"
     mkdir -p "$GW_DATA" "$GW_LOGS" "$PEER_DATA" "$PEER_LOGS"
     # Empty `gateways = []` so freenet doesn't load real public bootstraps
     # from the global config dir. Empty file ('') errors out with
     # "missing field `gateways`" — must be the explicit array form.
-    printf 'gateways = []\n' > "$GW_HOME/Library/Application Support/The-Freenet-Project-Inc.Freenet/gateways.toml"
-    printf 'gateways = []\n' > "$PEER_HOME/Library/Application Support/The-Freenet-Project-Inc.Freenet/gateways.toml"
+    for cfg in \
+        "$GW_HOME/Library/Application Support/The-Freenet-Project-Inc.Freenet/gateways.toml" \
+        "$PEER_HOME/Library/Application Support/The-Freenet-Project-Inc.Freenet/gateways.toml" \
+        "$GW_HOME/.config/freenet/gateways.toml" \
+        "$PEER_HOME/.config/freenet/gateways.toml"; do
+        printf 'gateways = []\n' > "$cfg"
+    done
 }
 
 derive_pubkey() {
@@ -114,6 +127,14 @@ up() {
     GW_PUBKEY=$(derive_pubkey)
     echo "$GW_PUBKEY" > "$GW_PUBKEY_FILE"
     echo "gateway pubkey: $GW_PUBKEY"
+    # Diagnostic for the CI flake where peer bails with
+    # "Skipping gateway with same public key as self" — print the first
+    # 16 bytes of gw's transport_keypair so a follow-up CI run can
+    # compare against peer's keypair head and confirm whether they
+    # actually collide on Linux.
+    if [ -f "$GW_DATA/secrets/transport_keypair" ]; then
+        echo "gw transport_keypair head: $(head -c 32 "$GW_DATA/secrets/transport_keypair")"
+    fi
 
     if lsof -i :$PEER_PORT_WS -P -sTCP:LISTEN > /dev/null 2>&1; then
         echo "peer already listening on :$PEER_PORT_WS"
@@ -139,8 +160,15 @@ up() {
 
     # Confirm only the local gateway shows up in the peer's bootstrap list.
     sleep 2
+    if [ -f "$PEER_DATA/secrets/transport_keypair" ]; then
+        echo "peer transport_keypair head: $(head -c 32 "$PEER_DATA/secrets/transport_keypair")"
+    fi
     local n
-    n=$(grep -c "Attempting connection to gateway" "$PEER_LOGS"/freenet.*.log 2>/dev/null | tail -1 || echo 0)
+    # `grep -c` over multiple files emits `<file>:<count>` lines; sum
+    # the counts via cut+awk so the bare integer comparison below
+    # doesn't trip on a `:0:`-suffixed string.
+    n=$(grep -c "Attempting connection to gateway" "$PEER_LOGS"/freenet.*.log 2>/dev/null \
+        | awk -F: '{ sum += $NF } END { print sum + 0 }')
     if [ "${n:-0}" -gt 1 ]; then
         echo "WARNING: peer is dialing $n gateways — isolation broken (check HOME override)"
     fi

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -350,8 +350,6 @@ impl AftRecords {
 
         let inbox_params: Parameters = InboxParams {
             pub_key: recipient_inbox_pub_key,
-            required_tier: recipient_required_tier,
-            max_age_secs: recipient_max_age_secs,
         }
         .try_into()?;
         let inbox_key =

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -260,14 +260,19 @@ mod inbox_management {
         let identity_key = vk.encode().to_vec();
         let params: Parameters = InboxParams {
             pub_key: crate::inbox::inbox_params_pub_key_bytes(&vk),
-            required_tier,
-            max_age_secs,
         }
         .try_into()?;
+        // Seed the initial InboxSettings with the owner's anti-flood
+        // policy so senders mint at the right tier from day one. The
+        // owner can later mutate this via ModifySettings (#85).
         let state = {
             let inbox = freenet_email_inbox::Inbox::new(
                 ml_dsa_key.as_ref(),
-                InboxSettings::default(),
+                InboxSettings {
+                    minimum_tier: required_tier,
+                    max_age_secs,
+                    private: Default::default(),
+                },
                 Vec::new(),
             );
             inbox.serialize()?
@@ -772,6 +777,7 @@ pub(crate) async fn node_comms(
         token_rec_to_id: &mut HashMap<ContractKey, Identity>,
         user: Signal<crate::app::User>,
         mut login_controller: Signal<crate::app::LoginController>,
+        inboxes: &InboxesData,
     ) {
         let mut client = api.sender_half();
         match req {
@@ -875,6 +881,60 @@ pub(crate) async fn node_comms(
                     }
                     Err(e) => {
                         crate::log::error(format!("{e}"), Some(TryNodeAction::CreateDelegate))
+                    }
+                }
+            }
+            NodeAction::UpdateInboxPolicy {
+                identity,
+                required_tier,
+                max_age_secs,
+            } => {
+                // Match the loaded InboxModel by identity vk-bytes;
+                // skip silently if the inbox isn't loaded yet (caller
+                // shouldn't be able to surface the form pre-load, but
+                // avoid panicking either way).
+                let target_vk = identity.ml_dsa_vk_bytes();
+                let mut found = None;
+                for cell in inboxes.snapshot() {
+                    let key_owner = {
+                        let m = cell.borrow();
+                        crate::inbox::InboxModel::contract_identity(&m.key)
+                    };
+                    if let Some(owner) = key_owner
+                        && owner.ml_dsa_vk_bytes() == target_vk
+                    {
+                        found = Some(cell);
+                        break;
+                    }
+                }
+                let Some(cell) = found else {
+                    crate::log::error(
+                        format!(
+                            "UpdateInboxPolicy: no loaded inbox for alias `{}`",
+                            identity.alias()
+                        ),
+                        None,
+                    );
+                    return;
+                };
+                let prepared = {
+                    let mut model = cell.borrow_mut();
+                    model.update_policy_prepare(required_tier, max_age_secs)
+                };
+                match prepared {
+                    Ok(request) => {
+                        if let Err(e) = client.send(request.into()).await {
+                            crate::log::error(
+                                format!("UpdateInboxPolicy send failed: {e}"),
+                                Some(TryNodeAction::SendMessage),
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        crate::log::error(
+                            format!("UpdateInboxPolicy prepare failed: {e}"),
+                            Some(TryNodeAction::SendMessage),
+                        );
                     }
                 }
             }
@@ -1579,7 +1639,15 @@ pub(crate) async fn node_comms(
             }
             req = rx.next() => {
                 let Some(req) = req else { panic!("async action ch closed") };
-                handle_action(req, &api, &mut token_contract_to_id, user, login_controller).await;
+                handle_action(
+                    req,
+                    &api,
+                    &mut token_contract_to_id,
+                    user,
+                    login_controller,
+                    &inboxes,
+                )
+                .await;
             }
             req = api.requests.next() => {
                 let Some(req) = req else { panic!("request ch closed") };

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -53,9 +53,21 @@ pub(crate) enum NodeAction {
         /// ML-DSA-65 signing key used for both inbox ownership and AFT
         /// token signing (same key serves both subsystems post-Stage-4).
         ml_dsa_key: Arc<MlDsaSigningKey<MlDsa65>>,
-        /// Recipient anti-flood policy hashed into `InboxParams`. Only
-        /// consulted for `ContractType::InboxContract`; the AFT record
-        /// contract id is derived from the sender's key alone (#85).
+        /// Initial recipient anti-flood policy seeded into the inbox's
+        /// `InboxSettings` at creation. Only consulted for
+        /// `ContractType::InboxContract`; the AFT record contract id is
+        /// derived from the sender's key alone. Owner can mutate later
+        /// via `UpdateInboxPolicy` (#85).
+        required_tier: freenet_aft_interface::Tier,
+        max_age_secs: u64,
+    },
+    /// Push a signed `ModifySettings` delta updating the recipient
+    /// anti-flood policy on the inbox contract owned by `identity`
+    /// (#85). Owner-only; the contract verifies the signature against
+    /// `params.pub_key` before accepting.
+    #[allow(dead_code)] // emitted from the wip-settings AFT screen only
+    UpdateInboxPolicy {
+        identity: Box<Identity>,
         required_tier: freenet_aft_interface::Tier,
         max_age_secs: u64,
     },
@@ -2333,11 +2345,7 @@ fn ComposeSheet() -> Element {
         // `send_message` so we can pair the eventual UpdateResponse back to
         // the Sent row's `SentId`.
         #[cfg(feature = "use-node")]
-        let inbox_key_for_ack = crate::inbox::inbox_key_for(
-            &recipient_vk,
-            recipient.required_tier,
-            recipient.max_age_secs,
-        );
+        let inbox_key_for_ack = crate::inbox::inbox_key_for(&recipient_vk);
 
         // Allocate the SentId up-front so the sync enqueue and the async
         // failure-flip both name the same row.

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -639,6 +639,33 @@ fn ScrPrivacy() -> Element {
     }
 }
 
+/// Map an `IdentityAftPrefs.required_tier` string back to the typed
+/// enum. Mirrors the names the `TIER_ROWS` picker writes to local
+/// state (#85). Returns `None` for unrecognized values so the
+/// caller can surface the error rather than silently defaulting.
+#[cfg(feature = "wip-settings")]
+fn parse_tier(s: &str) -> Option<freenet_aft_interface::Tier> {
+    use freenet_aft_interface::Tier::*;
+    Some(match s {
+        "Min1" => Min1,
+        "Min5" => Min5,
+        "Min10" => Min10,
+        "Min30" => Min30,
+        "Hour1" => Hour1,
+        "Hour3" => Hour3,
+        "Hour6" => Hour6,
+        "Hour12" => Hour12,
+        "Day1" => Day1,
+        "Day7" => Day7,
+        "Day15" => Day15,
+        "Day30" => Day30,
+        "Day90" => Day90,
+        "Day180" => Day180,
+        "Day365" => Day365,
+        _ => return None,
+    })
+}
+
 /// One row per real `freenet_aft_interface::Tier`. The "rate" column is
 /// derived from the tier name (1 token per N time-unit) — there is no
 /// `tokens_per_period` getter on the enum, so the period text is encoded
@@ -669,16 +696,64 @@ fn ScrAft() -> Element {
     let (alias_key, ident) = use_identity_settings();
     let aft_now = ident.aft.clone();
     let selected_tier = aft_now.required_tier.clone();
+    let max_age_days = aft_now.max_age_days;
     let allow_known = aft_now.allow_known;
     let allow_anon = aft_now.allow_anon;
     let bounce = aft_now.bounce_message.clone();
+    let actions = use_coroutine_handle::<crate::app::NodeAction>();
+
+    // #85: dispatch a `ModifySettings` delta to the inbox contract so
+    // the new policy actually gates incoming sends — without this the
+    // change is local-state-only and senders keep minting at the old
+    // tier.
+    let push_policy = move |alias: &str, tier_str: &str, max_age_days: u64| {
+        let identity = crate::app::address_book::lookup(alias)
+            .filter(|r| r.is_own)
+            .and_then(|_| {
+                crate::app::login::Identity::get_aliases()
+                    .borrow()
+                    .iter()
+                    .find(|i| i.alias.as_ref() == alias)
+                    .cloned()
+            });
+        let Some(identity) = identity else {
+            crate::log::error(
+                format!("AFT settings: no own identity for alias `{alias}`"),
+                None,
+            );
+            return;
+        };
+        let Some(tier) = parse_tier(tier_str) else {
+            crate::log::error(format!("AFT settings: invalid tier `{tier_str}`"), None);
+            return;
+        };
+        let max_age_secs = max_age_days.saturating_mul(86_400);
+        actions.send(crate::app::NodeAction::UpdateInboxPolicy {
+            identity: Box::new(identity),
+            required_tier: tier,
+            max_age_secs,
+        });
+    };
 
     let alias_key_t = alias_key.clone();
     let ident_t = ident.clone();
+    let push_policy_t = push_policy.clone();
     let on_tier = move |new_tier: String| {
         let mut next = ident_t.clone();
-        next.aft.required_tier = new_tier;
-        local_state::persist_identity_settings(alias_key_t.clone(), next);
+        next.aft.required_tier = new_tier.clone();
+        local_state::persist_identity_settings(alias_key_t.clone(), next.clone());
+        push_policy_t(&alias_key_t, &new_tier, next.aft.max_age_days);
+    };
+    let alias_key_m = alias_key.clone();
+    let ident_m = ident.clone();
+    let push_policy_m = push_policy.clone();
+    let on_max_age = move |ev: Event<FormData>| {
+        let raw = ev.value();
+        let parsed: u64 = raw.parse().unwrap_or(365).clamp(1, 730);
+        let mut next = ident_m.clone();
+        next.aft.max_age_days = parsed;
+        local_state::persist_identity_settings(alias_key_m.clone(), next.clone());
+        push_policy_m(&alias_key_m, &next.aft.required_tier, parsed);
     };
     let alias_key_k = alias_key.clone();
     let ident_k = ident.clone();
@@ -729,6 +804,20 @@ fn ScrAft() -> Element {
                                 }
                             }
                         }
+                    }
+                }
+            }
+            Card {
+                title: "Token max age (days)",
+                sub: "Sender's AFT delegate uses this when picking a free slot. Capped at 730 days by the AFT crate; lower values rotate the cap faster.",
+                div { class: "field",
+                    input {
+                        class: "input",
+                        r#type: "number",
+                        min: "1",
+                        max: "730",
+                        value: "{max_age_days}",
+                        onchange: on_max_age,
                     }
                 }
             }

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -69,20 +69,11 @@ pub(crate) fn inbox_params_pub_key_bytes(ml_dsa_vk: &MlDsaVerifyingKey<MlDsa65>)
 /// so the compose-Send path can enqueue a pending Sent ack against the
 /// recipient's inbox key without re-implementing the params encoding.
 ///
-/// `required_tier` and `max_age_secs` are the recipient's anti-flood
-/// policy from their `ContactCard` (#85). They are part of `InboxParams`
-/// and therefore part of the contract id, so getting them wrong here
-/// produces a different `ContractKey` than the one the recipient
-/// actually owns.
 pub(crate) fn inbox_key_for(
     ml_dsa_vk: &MlDsaVerifyingKey<MlDsa65>,
-    required_tier: freenet_aft_interface::Tier,
-    max_age_secs: u64,
 ) -> Result<ContractKey, DynError> {
     let params = InboxParams {
         pub_key: inbox_params_pub_key_bytes(ml_dsa_vk),
-        required_tier,
-        max_age_secs,
     }
     .try_into()
     .map_err(|e| format!("{e}"))?;
@@ -234,8 +225,14 @@ struct InternalSettings {
     /// This id is used for internal handling of the inbox and is not persistent
     /// or unique across sessions.
     next_msg_id: u64,
-    #[allow(dead_code)] // TODO: surfaced via settings UI (not yet wired)
+    /// AFT tier the recipient demands from incoming senders. Mutable
+    /// via the Settings UI (#85): `update_settings_at_store` signs a
+    /// `ModifySettings` delta with `ml_dsa_signing_key` and pushes it
+    /// to the inbox contract.
     minimum_tier: Tier,
+    /// `max_age_secs` half of the recipient anti-flood policy. Sent
+    /// alongside `minimum_tier` in `ModifySettings` deltas.
+    max_age_secs: u64,
     /// ML-DSA-65 signing key used to authorise modifications to the inbox
     /// contract state (add/remove messages, settings updates). The corresponding
     /// verifying key is embedded in `InboxParams` and becomes part of the
@@ -269,13 +266,14 @@ impl InternalSettings {
             next_msg_id: next_id,
             ml_dsa_signing_key,
             minimum_tier: stored_settings.minimum_tier,
+            max_age_secs: stored_settings.max_age_secs,
         })
     }
 
-    #[allow(dead_code)] // TODO: invoked from update_settings_at_store
     fn to_stored(&self) -> Result<StoredSettings, DynError> {
         Ok(StoredSettings {
             minimum_tier: self.minimum_tier,
+            max_age_secs: self.max_age_secs,
             private: vec![],
         })
     }
@@ -440,8 +438,6 @@ impl DecryptedMessage {
         .await?;
         let params = InboxParams {
             pub_key: inbox_pub_key_bytes,
-            required_tier: recipient_required_tier,
-            max_age_secs: recipient_max_age_secs,
         }
         .try_into()
         .map_err(|e| format!("{e}"))?;
@@ -642,13 +638,9 @@ impl InboxModel {
         fn get_key(identity: &Identity) -> Result<ContractKey, DynError> {
             let vk = MlDsaKeypair::verifying_key(identity.ml_dsa_signing_key.as_ref());
             let pub_key = inbox_params_pub_key_bytes(&vk);
-            let params = freenet_email_inbox::InboxParams {
-                pub_key,
-                required_tier: identity.required_tier,
-                max_age_secs: identity.max_age_secs,
-            }
-            .try_into()
-            .map_err(|e| format!("{e}"))?;
+            let params = freenet_email_inbox::InboxParams { pub_key }
+                .try_into()
+                .map_err(|e| format!("{e}"))?;
             ContractKey::from_params(crate::inbox::INBOX_CODE_HASH, params)
                 .map_err(|e| format!("{e}").into())
         }
@@ -691,8 +683,6 @@ impl InboxModel {
         let vk = MlDsaKeypair::verifying_key(id.ml_dsa_signing_key.as_ref());
         let params = InboxParams {
             pub_key: inbox_params_pub_key_bytes(&vk),
-            required_tier: id.required_tier,
-            max_age_secs: id.max_age_secs,
         }
         .try_into()
         .map_err(|e| format!("{e}"))?;
@@ -897,11 +887,18 @@ impl InboxModel {
         }
     }
 
-    #[allow(dead_code)] // TODO: wire into settings UI
-    async fn update_settings_at_store(
+    /// Apply a new anti-flood policy locally and return a serialized
+    /// `ModifySettings` delta the caller must push to the inbox
+    /// contract via `client.send` outside any RefCell borrow (#85).
+    /// Only the inbox owner can mutate policy — `can_update_settings`
+    /// on the contract verifies the signature against `params.pub_key`.
+    pub fn update_policy_prepare(
         &mut self,
-        client: &mut WebApiRequestClient,
-    ) -> Result<(), DynError> {
+        minimum_tier: Tier,
+        max_age_secs: u64,
+    ) -> Result<ContractRequest<'static>, DynError> {
+        self.settings.minimum_tier = minimum_tier;
+        self.settings.max_age_secs = max_age_secs;
         let settings = self.settings.to_stored()?;
         let serialized = serde_json::to_vec(&settings)?;
         let signing_key = self.settings.ml_dsa_signing_key.as_ref();
@@ -911,12 +908,10 @@ impl InboxModel {
             signature,
             settings,
         };
-        let request = ContractRequest::Update {
+        Ok(ContractRequest::Update {
             key: self.key,
             data: UpdateData::Delta(serde_json::to_vec(&delta)?.into()),
-        };
-        client.send(request.into()).await?;
-        Ok(())
+        })
     }
 
     pub async fn get_state(
@@ -968,6 +963,7 @@ mod tests {
                 settings: InternalSettings {
                     next_msg_id: 0,
                     minimum_tier: Tier::Hour1,
+                    max_age_secs: freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
                     ml_dsa_signing_key,
                 },
                 key: ContractKey::from_params_and_code(


### PR DESCRIPTION
## Summary
- Move AFT `required_tier` + `max_age_secs` from `InboxParams` (immutable, contract-id-bound) to `InboxSettings` (mutable via `ModifySettings`). Contract id stays stable when the recipient retunes their cap.
- Inbox contract `verify_token_policy` now reads from `state.settings`. `can_update_settings` (already in place) gates settings updates on the inbox-owner ML-DSA signature, so only the owner can change policy.
- Settings > AFT screen (wip-settings) gains a max_age input and dispatches a new \`NodeAction::UpdateInboxPolicy\` that signs + pushes a `ModifySettings` delta via `update_policy_prepare` (sync prep + async send to dodge the await-holding-refcell-ref clippy lint).
- ContactCard fields (`required_tier`, `max_age_secs`) keep their meaning — that's still where the *sender* reads the recipient's policy.

## Iso-node CI debug drive-bys
- Pre-create Linux XDG config + data dirs under each node's HOME override so freenet can't fall back to a shared default path on Linux.
- Fix `grep -c` integer-compare bug in the isolation warning (was failing with \`integer expected\`).
- Echo `head -c 32` of each node's transport_keypair post-spawn so the next CI run tells us whether gw and peer truly share a key (current best guess for the e2e flake).

## Test plan
- [x] cargo test --workspace
- [x] cargo test -p freenet-email-inbox --features contract
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] iso-nodes up/down round-trip locally (key heads differ as expected on macOS)
- [ ] Manual: in `wip-settings` build, change tier in Settings > AFT, observe inbox `ModifySettings` round-trip, send under new policy