### PR TITLE
fix(make): run-node uses --ws-api-port + binds 127.0.0.1

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -565,7 +565,7 @@ mkdir -p "$DATA_DIR" "$NODE_HOME/.config/freenet"
 echo "freenet local: port=$PORT data-dir=$DATA_DIR home=$NODE_HOME"
 RUST_BACKTRACE=1 RUST_LOG=freenet=debug,freenet_core=debug,info \
     HOME="$NODE_HOME" \
-    freenet local --data-dir "$DATA_DIR" --port "$PORT"
+    freenet local --data-dir "$DATA_DIR" --ws-api-port "$PORT" --ws-api-address 127.0.0.1
 '''
 
 [tasks.test]


### PR DESCRIPTION
## Summary

- `cargo make run-node` was passing `--port` to `freenet local`, which the bundled freenet binary (0.2.52, and the published 0.2.54) rejects with `error: unexpected argument '--port' found`. Use `--ws-api-port` instead.
- Bind explicitly to `127.0.0.1`. The default `--ws-api-address ::` listens IPv6-only on macOS, so `fdev publish` (which dials `127.0.0.1:7509` via IPv4) gets `ECONNREFUSED`.

Found while running the manual QA flow for #127 against a local sandbox: `cargo make run-node` then `cargo make publish-email-test`. Both now work end-to-end.

## Test plan

- [x] `cargo make run-node` boots a node bound to `127.0.0.1:7509`
- [x] `cargo make publish-email-test` succeeds against that node
- [x] webapp loads at `http://127.0.0.1:7509/v1/contract/web/<id>/`