### PR TITLE
chore(aft): default recipient tier Day1 -> Min10

### DIFF
--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -127,7 +127,7 @@ fn default_max_age_secs() -> u64 {
 impl Default for InboxSettings {
     fn default() -> Self {
         Self {
-            minimum_tier: Tier::Day1,
+            minimum_tier: Tier::Min10,
             max_age_secs: DEFAULT_MAX_AGE_SECS,
             private: Default::default(),
         }

--- a/contracts/inbox/tests/integration.rs
+++ b/contracts/inbox/tests/integration.rs
@@ -100,7 +100,7 @@ fn update_accepts_add_message_with_valid_token() {
     let assignment = make_token_assignment(
         &gen_sk,
         gen_vk_bytes,
-        Tier::Day1,
+        Tier::Min10,
         fixed_valid_slot(),
         assignment_hash_for(b"msg-1"),
         token_record_id,
@@ -250,7 +250,7 @@ fn update_dedups_replay_of_previously_added_message() {
     let assignment = make_token_assignment(
         &gen_sk,
         gen_vk_bytes,
-        Tier::Day1,
+        Tier::Min10,
         fixed_valid_slot(),
         assignment_hash_for(b"replayed-msg"),
         token_record_id,

--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -188,7 +188,7 @@ fn default_max_age_days() -> u64 {
 impl Default for IdentityAftPrefs {
     fn default() -> Self {
         Self {
-            required_tier: "Day1".to_string(),
+            required_tier: "Min10".to_string(),
             max_age_days: default_max_age_days(),
             allow_known: true,
             allow_anon: false,
@@ -895,13 +895,13 @@ mod boundary_tests {
     }
 
     /// `AliasState` written before the Settings feature deserialises with
-    /// default `settings` (Day1, allow-known on, signature off, etc.).
+    /// default `settings` (Min10, allow-known on, signature off, etc.).
     /// Pre-Settings state must keep loading.
     #[test]
     fn alias_state_missing_settings_defaults_loaded() {
         let json = br#"{"drafts":{},"read":[],"kept":{},"sent":{},"archived":{},"deleted":[]}"#;
         let s: AliasState = serde_json::from_slice(json).expect("should deserialise");
-        assert_eq!(s.settings.aft.required_tier, "Day1");
+        assert_eq!(s.settings.aft.required_tier, "Min10");
         assert!(s.settings.aft.allow_known);
         assert!(!s.settings.aft.allow_anon);
         assert!(s.settings.privacy.verify_on_send);

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -117,7 +117,7 @@ impl Identity {
             description,
             ml_dsa_signing_key,
             ml_kem_dk,
-            freenet_aft_interface::Tier::Day1,
+            freenet_aft_interface::Tier::Min10,
             freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
         )
     }
@@ -335,7 +335,7 @@ impl Identity {
             alias: alias.clone(),
             id: existing_id.unwrap_or_else(UserId::new),
             description: description.clone(),
-            required_tier: freenet_aft_interface::Tier::Day1,
+            required_tier: freenet_aft_interface::Tier::Min10,
             max_age_secs: freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
             ml_dsa_signing_key: Arc::clone(&ml_dsa_signing_key),
             ml_kem_dk: ml_kem_dk.clone(),
@@ -984,7 +984,7 @@ pub(super) fn CreateAliasForm() -> Element {
             alias: alias.clone(),
             ml_dsa_key: ml_dsa.clone(),
             contract_type: ContractType::InboxContract,
-            required_tier: freenet_aft_interface::Tier::Day1,
+            required_tier: freenet_aft_interface::Tier::Min10,
             max_age_secs: freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
         });
         actions.send(NodeAction::CreateDelegate {
@@ -995,7 +995,7 @@ pub(super) fn CreateAliasForm() -> Element {
             alias: alias.clone(),
             ml_dsa_key: ml_dsa.clone(),
             contract_type: ContractType::AFTContract,
-            required_tier: freenet_aft_interface::Tier::Day1,
+            required_tier: freenet_aft_interface::Tier::Min10,
             max_age_secs: freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
         });
         actions.send(NodeAction::CreateIdentity {
@@ -1380,7 +1380,7 @@ fn ImportForm() -> Element {
                                 alias: alias.clone(),
                                 ml_dsa_key: ml_dsa.clone(),
                                 contract_type: ContractType::InboxContract,
-                                required_tier: freenet_aft_interface::Tier::Day1,
+                                required_tier: freenet_aft_interface::Tier::Min10,
                                 max_age_secs: freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
                             });
                             actions.send(NodeAction::CreateDelegate {
@@ -1391,7 +1391,7 @@ fn ImportForm() -> Element {
                                 alias: alias.clone(),
                                 ml_dsa_key: ml_dsa.clone(),
                                 contract_type: ContractType::AFTContract,
-                                required_tier: freenet_aft_interface::Tier::Day1,
+                                required_tier: freenet_aft_interface::Tier::Min10,
                                 max_age_secs: freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
                             });
                             actions.send(NodeAction::CreateIdentity {


### PR DESCRIPTION
## Summary

Lower the default AFT recipient tier from Day1 (1 token / day) to Min10 (1 / 10 minutes). Day1 caps every sender to one message per day per recipient, which is fine in production but punishing during normal testing where users expect to exchange several messages per minute. Min10 is still strict enough to rate-limit bulk spam (~6/hour/sender) while letting back-and-forth conversations work.

The owner can override per-inbox via Settings → Anti-Flood (AFT) at any time (#127). The default just changes what gets stamped onto fresh inboxes / fresh local-state.

## Changes

- \`contracts/inbox/src/lib.rs\` — \`InboxSettings::default()\` now picks Min10
- \`modules/mail-local-state/src/lib.rs\` — \`IdentityAftPrefs::default()\` writes \"Min10\"; the back-compat test that asserts the default fingerprint flips to match
- \`ui/src/app/login.rs\` — every \`Identity::new*\` constructor + every default-policy site flips Day1 → Min10 (6 sites)

## Not changed

\`address_book::default_tier()\` keeps returning Day1 — that's the back-compat default for v1 ContactCards that didn't carry a \`required_tier\` field. Touching it would re-encode existing contacts under a different policy on next read.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo test --workspace\` (all green)