### PR TITLE
fix(ui): stable inbox sort — deterministic tie-break by id

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1300,7 +1300,10 @@ fn MessageList() -> Element {
             .cloned()
             .collect();
         // Newest first (#49). Sender-stamped time is what the design assumes.
-        v.sort_by_key(|m| std::cmp::Reverse(m.time));
+        // Tie-break by id descending so that messages with identical 1-second
+        // timestamps always appear in a deterministic order regardless of the
+        // HashMap iteration order of the underlying kept-message map (#137).
+        v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
         v
     } else {
         Vec::new()
@@ -1309,8 +1312,9 @@ fn MessageList() -> Element {
         || (matches!(folder, menu::Folder::Inbox) && inbox_settings.drafts_in_inbox)
     {
         let mut d = crate::local_state::drafts_for(&active_alias);
-        // Newest first.
-        d.sort_by_key(|b| std::cmp::Reverse(b.1.updated_at));
+        // Newest first; tie-break by id so HashMap iteration order doesn't
+        // cause reordering on re-render (#137).
+        d.sort_by(|a, b| b.1.updated_at.cmp(&a.1.updated_at).then(b.0.cmp(&a.0)));
         d
     } else {
         Vec::new()
@@ -1318,7 +1322,8 @@ fn MessageList() -> Element {
     let sent_msgs: Vec<(String, mail_local_state::SentMessage)> =
         if matches!(folder, menu::Folder::Sent) {
             let mut s = crate::local_state::sent_for(&active_alias);
-            s.sort_by_key(|b| std::cmp::Reverse(b.1.sent_at));
+            // Newest first; tie-break by id for deterministic order (#137).
+            s.sort_by(|a, b| b.1.sent_at.cmp(&a.1.sent_at).then(b.0.cmp(&a.0)));
             s
         } else {
             Vec::new()
@@ -1326,7 +1331,8 @@ fn MessageList() -> Element {
     let archived_msgs: Vec<(u64, mail_local_state::ArchivedMessage)> =
         if matches!(folder, menu::Folder::Archive) {
             let mut a = crate::local_state::archived_for(&active_alias);
-            a.sort_by_key(|b| std::cmp::Reverse(b.1.archived_at));
+            // Newest first; tie-break by message id for deterministic order (#137).
+            a.sort_by(|x, y| y.1.archived_at.cmp(&x.1.archived_at).then(y.0.cmp(&x.0)));
             a
         } else {
             Vec::new()
@@ -2615,5 +2621,75 @@ mod time_format_tests {
         let s = format_time_full(old);
         assert!(s.contains('·'), "got {s:?}");
         assert!(s.contains(':'), "got {s:?}");
+    }
+}
+
+#[cfg(test)]
+mod inbox_sort_tests {
+    use super::Message;
+    use chrono::{TimeZone, Utc};
+    use std::borrow::Cow;
+
+    fn make_msg(id: u64, timestamp_secs: i64) -> Message {
+        Message {
+            id,
+            from: Cow::Borrowed("test@test"),
+            title: Cow::Borrowed("subject"),
+            content: Cow::Borrowed("body"),
+            read: false,
+            time: Utc.timestamp_opt(timestamp_secs, 0).unwrap(),
+            sender_vk: Vec::new(),
+            signature_valid: false,
+        }
+    }
+
+    /// Messages with distinct timestamps should be sorted newest-first.
+    #[test]
+    fn sort_by_time_desc() {
+        let mut v = vec![
+            make_msg(1, 1_000),
+            make_msg(2, 3_000),
+            make_msg(3, 2_000),
+        ];
+        v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
+        let ids: Vec<u64> = v.iter().map(|m| m.id).collect();
+        assert_eq!(ids, vec![2, 3, 1]);
+    }
+
+    /// When timestamps tie, higher id should come first (deterministic
+    /// tie-break — fixes the HashMap reorder on click, issue #137).
+    #[test]
+    fn tie_break_by_id_desc() {
+        let ts = 5_000;
+        let mut v = vec![
+            make_msg(10, ts),
+            make_msg(30, ts),
+            make_msg(20, ts),
+        ];
+        v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
+        let ids: Vec<u64> = v.iter().map(|m| m.id).collect();
+        // Regardless of input order, higher id must come first.
+        assert_eq!(ids, vec![30, 20, 10]);
+    }
+
+    /// Calling sort twice on the same vec must produce the same order —
+    /// i.e. the sort is stable and deterministic across re-renders.
+    #[test]
+    fn sort_is_idempotent() {
+        let ts = 7_000;
+        let mut v = vec![
+            make_msg(5, ts),
+            make_msg(1, ts),
+            make_msg(3, ts),
+            make_msg(4, 8_000),
+        ];
+        let sort = |v: &mut Vec<Message>| {
+            v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
+        };
+        sort(&mut v);
+        let first: Vec<u64> = v.iter().map(|m| m.id).collect();
+        sort(&mut v);
+        let second: Vec<u64> = v.iter().map(|m| m.id).collect();
+        assert_eq!(first, second, "sort must be idempotent");
     }
 }

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -655,6 +655,48 @@ impl Message {
     }
 }
 
+// ── Sort comparators ────────────────────────────────────────────────────────
+//
+// One function per folder shape.  All comparators sort newest-first with a
+// deterministic tie-break so that HashMap-backed collections do not reorder on
+// re-render (issue #137).  Use these at every sort site AND in unit tests so
+// the two cannot drift apart.
+
+/// Inbox: newest `Message` first; tie-break by `id` descending (monotonic u64
+/// — higher id = later arrival).
+fn sort_cmp_inbox(a: &Message, b: &Message) -> std::cmp::Ordering {
+    b.time.cmp(&a.time).then(b.id.cmp(&a.id))
+}
+
+/// Drafts: newest first by `updated_at`; tie-break by UUID string descending
+/// (for stability only — UUID v4 ordering is not chronological).
+fn sort_cmp_drafts(
+    a: &(String, mail_local_state::Draft),
+    b: &(String, mail_local_state::Draft),
+) -> std::cmp::Ordering {
+    b.1.updated_at.cmp(&a.1.updated_at).then(b.0.cmp(&a.0))
+}
+
+/// Sent: newest first by `sent_at`; tie-break by UUID string descending
+/// (for stability only — UUID v4 ordering is not chronological).
+fn sort_cmp_sent(
+    a: &(String, mail_local_state::SentMessage),
+    b: &(String, mail_local_state::SentMessage),
+) -> std::cmp::Ordering {
+    b.1.sent_at.cmp(&a.1.sent_at).then(b.0.cmp(&a.0))
+}
+
+/// Archive: newest first by `archived_at`; tie-break by `id` descending
+/// (monotonic u64 — higher id = later arrival).
+fn sort_cmp_archive(
+    a: &(u64, mail_local_state::ArchivedMessage),
+    b: &(u64, mail_local_state::ArchivedMessage),
+) -> std::cmp::Ordering {
+    b.1.archived_at.cmp(&a.1.archived_at).then(b.0.cmp(&a.0))
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+
 impl From<MessageModel> for Message {
     fn from(value: MessageModel) -> Self {
         Message {
@@ -1303,7 +1345,7 @@ fn MessageList() -> Element {
         // Tie-break by id descending so that messages with identical 1-second
         // timestamps always appear in a deterministic order regardless of the
         // HashMap iteration order of the underlying kept-message map (#137).
-        v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
+        v.sort_by(sort_cmp_inbox);
         v
     } else {
         Vec::new()
@@ -1312,9 +1354,9 @@ fn MessageList() -> Element {
         || (matches!(folder, menu::Folder::Inbox) && inbox_settings.drafts_in_inbox)
     {
         let mut d = crate::local_state::drafts_for(&active_alias);
-        // Newest first; tie-break by id so HashMap iteration order doesn't
-        // cause reordering on re-render (#137).
-        d.sort_by(|a, b| b.1.updated_at.cmp(&a.1.updated_at).then(b.0.cmp(&a.0)));
+        // Newest first; tie-break by UUID string for stability only — UUID v4
+        // order is not chronological (#137).
+        d.sort_by(sort_cmp_drafts);
         d
     } else {
         Vec::new()
@@ -1322,8 +1364,9 @@ fn MessageList() -> Element {
     let sent_msgs: Vec<(String, mail_local_state::SentMessage)> =
         if matches!(folder, menu::Folder::Sent) {
             let mut s = crate::local_state::sent_for(&active_alias);
-            // Newest first; tie-break by id for deterministic order (#137).
-            s.sort_by(|a, b| b.1.sent_at.cmp(&a.1.sent_at).then(b.0.cmp(&a.0)));
+            // Newest first; tie-break by UUID string for stability only — UUID v4
+            // order is not chronological (#137).
+            s.sort_by(sort_cmp_sent);
             s
         } else {
             Vec::new()
@@ -1332,7 +1375,7 @@ fn MessageList() -> Element {
         if matches!(folder, menu::Folder::Archive) {
             let mut a = crate::local_state::archived_for(&active_alias);
             // Newest first; tie-break by message id for deterministic order (#137).
-            a.sort_by(|x, y| y.1.archived_at.cmp(&x.1.archived_at).then(y.0.cmp(&x.0)));
+            a.sort_by(sort_cmp_archive);
             a
         } else {
             Vec::new()
@@ -2626,7 +2669,7 @@ mod time_format_tests {
 
 #[cfg(test)]
 mod inbox_sort_tests {
-    use super::Message;
+    use super::{Message, sort_cmp_inbox};
     use chrono::{TimeZone, Utc};
     use std::borrow::Cow;
 
@@ -2651,7 +2694,7 @@ mod inbox_sort_tests {
             make_msg(2, 3_000),
             make_msg(3, 2_000),
         ];
-        v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
+        v.sort_by(sort_cmp_inbox);
         let ids: Vec<u64> = v.iter().map(|m| m.id).collect();
         assert_eq!(ids, vec![2, 3, 1]);
     }
@@ -2666,7 +2709,7 @@ mod inbox_sort_tests {
             make_msg(30, ts),
             make_msg(20, ts),
         ];
-        v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
+        v.sort_by(sort_cmp_inbox);
         let ids: Vec<u64> = v.iter().map(|m| m.id).collect();
         // Regardless of input order, higher id must come first.
         assert_eq!(ids, vec![30, 20, 10]);
@@ -2683,13 +2726,195 @@ mod inbox_sort_tests {
             make_msg(3, ts),
             make_msg(4, 8_000),
         ];
-        let sort = |v: &mut Vec<Message>| {
-            v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
-        };
-        sort(&mut v);
+        v.sort_by(sort_cmp_inbox);
         let first: Vec<u64> = v.iter().map(|m| m.id).collect();
-        sort(&mut v);
+        v.sort_by(sort_cmp_inbox);
         let second: Vec<u64> = v.iter().map(|m| m.id).collect();
         assert_eq!(first, second, "sort must be idempotent");
+    }
+}
+
+#[cfg(test)]
+mod folder_sort_tests {
+    use super::{sort_cmp_archive, sort_cmp_drafts, sort_cmp_sent};
+    use mail_local_state::{ArchivedMessage, Draft, SentMessage};
+
+    fn make_draft(id: &str, updated_at: i64) -> (String, Draft) {
+        (
+            id.to_string(),
+            Draft {
+                to: "a@b".to_string(),
+                subject: "s".to_string(),
+                body: "b".to_string(),
+                updated_at,
+            },
+        )
+    }
+
+    fn make_sent(id: &str, sent_at: i64) -> (String, SentMessage) {
+        (
+            id.to_string(),
+            SentMessage {
+                to: "a@b".to_string(),
+                recipient_fingerprint: String::new(),
+                recipient_fingerprint_full: String::new(),
+                subject: "s".to_string(),
+                body: "b".to_string(),
+                sent_at,
+                delivery_state: mail_local_state::DeliveryState::Delivered,
+            },
+        )
+    }
+
+    fn make_archived(id: u64, archived_at: i64) -> (u64, ArchivedMessage) {
+        (
+            id,
+            ArchivedMessage {
+                from: "a@b".to_string(),
+                title: "t".to_string(),
+                content: "c".to_string(),
+                archived_at,
+            },
+        )
+    }
+
+    // ── Drafts ───────────────────────────────────────────────────────────────
+
+    /// Drafts should appear newest-first by `updated_at`.
+    #[test]
+    fn drafts_sort_time_desc() {
+        let mut d = vec![
+            make_draft("id-1", 1_000),
+            make_draft("id-2", 3_000),
+            make_draft("id-3", 2_000),
+        ];
+        d.sort_by(sort_cmp_drafts);
+        let ids: Vec<&str> = d.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["id-2", "id-3", "id-1"]);
+    }
+
+    /// Drafts with the same `updated_at` must tie-break deterministically
+    /// (UUID string descending — for stability, not chronological ordering).
+    #[test]
+    fn drafts_tie_break_by_id_desc() {
+        let ts = 5_000;
+        let mut d = vec![
+            make_draft("aaa", ts),
+            make_draft("ccc", ts),
+            make_draft("bbb", ts),
+        ];
+        d.sort_by(sort_cmp_drafts);
+        let ids: Vec<&str> = d.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["ccc", "bbb", "aaa"]);
+    }
+
+    /// Sorting drafts twice must produce the same order.
+    #[test]
+    fn drafts_sort_idempotent() {
+        let ts = 7_000;
+        let mut d = vec![
+            make_draft("x", ts),
+            make_draft("y", ts),
+            make_draft("z", ts),
+            make_draft("w", 8_000),
+        ];
+        d.sort_by(sort_cmp_drafts);
+        let first: Vec<String> = d.iter().map(|(id, _)| id.clone()).collect();
+        d.sort_by(sort_cmp_drafts);
+        let second: Vec<String> = d.iter().map(|(id, _)| id.clone()).collect();
+        assert_eq!(first, second, "drafts sort must be idempotent");
+    }
+
+    // ── Sent ─────────────────────────────────────────────────────────────────
+
+    /// Sent messages should appear newest-first by `sent_at`.
+    #[test]
+    fn sent_sort_time_desc() {
+        let mut s = vec![
+            make_sent("id-1", 1_000),
+            make_sent("id-2", 3_000),
+            make_sent("id-3", 2_000),
+        ];
+        s.sort_by(sort_cmp_sent);
+        let ids: Vec<&str> = s.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["id-2", "id-3", "id-1"]);
+    }
+
+    /// Sent messages with the same `sent_at` must tie-break deterministically.
+    #[test]
+    fn sent_tie_break_by_id_desc() {
+        let ts = 5_000;
+        let mut s = vec![
+            make_sent("aaa", ts),
+            make_sent("ccc", ts),
+            make_sent("bbb", ts),
+        ];
+        s.sort_by(sort_cmp_sent);
+        let ids: Vec<&str> = s.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["ccc", "bbb", "aaa"]);
+    }
+
+    /// Sorting sent twice must produce the same order.
+    #[test]
+    fn sent_sort_idempotent() {
+        let ts = 7_000;
+        let mut s = vec![
+            make_sent("x", ts),
+            make_sent("y", ts),
+            make_sent("z", ts),
+            make_sent("w", 8_000),
+        ];
+        s.sort_by(sort_cmp_sent);
+        let first: Vec<String> = s.iter().map(|(id, _)| id.clone()).collect();
+        s.sort_by(sort_cmp_sent);
+        let second: Vec<String> = s.iter().map(|(id, _)| id.clone()).collect();
+        assert_eq!(first, second, "sent sort must be idempotent");
+    }
+
+    // ── Archive ───────────────────────────────────────────────────────────────
+
+    /// Archived messages should appear newest-first by `archived_at`.
+    #[test]
+    fn archive_sort_time_desc() {
+        let mut a = vec![
+            make_archived(1, 1_000),
+            make_archived(2, 3_000),
+            make_archived(3, 2_000),
+        ];
+        a.sort_by(sort_cmp_archive);
+        let ids: Vec<u64> = a.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![2, 3, 1]);
+    }
+
+    /// Archived messages with the same `archived_at` must tie-break by id
+    /// descending (monotonic u64).
+    #[test]
+    fn archive_tie_break_by_id_desc() {
+        let ts = 5_000;
+        let mut a = vec![
+            make_archived(10, ts),
+            make_archived(30, ts),
+            make_archived(20, ts),
+        ];
+        a.sort_by(sort_cmp_archive);
+        let ids: Vec<u64> = a.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![30, 20, 10]);
+    }
+
+    /// Sorting archived twice must produce the same order.
+    #[test]
+    fn archive_sort_idempotent() {
+        let ts = 7_000;
+        let mut a = vec![
+            make_archived(5, ts),
+            make_archived(1, ts),
+            make_archived(3, ts),
+            make_archived(4, 8_000),
+        ];
+        a.sort_by(sort_cmp_archive);
+        let first: Vec<u64> = a.iter().map(|(id, _)| *id).collect();
+        a.sort_by(sort_cmp_archive);
+        let second: Vec<u64> = a.iter().map(|(id, _)| *id).collect();
+        assert_eq!(first, second, "archive sort must be idempotent");
     }
 }

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -2689,11 +2689,7 @@ mod inbox_sort_tests {
     /// Messages with distinct timestamps should be sorted newest-first.
     #[test]
     fn sort_by_time_desc() {
-        let mut v = vec![
-            make_msg(1, 1_000),
-            make_msg(2, 3_000),
-            make_msg(3, 2_000),
-        ];
+        let mut v = vec![make_msg(1, 1_000), make_msg(2, 3_000), make_msg(3, 2_000)];
         v.sort_by(sort_cmp_inbox);
         let ids: Vec<u64> = v.iter().map(|m| m.id).collect();
         assert_eq!(ids, vec![2, 3, 1]);
@@ -2704,11 +2700,7 @@ mod inbox_sort_tests {
     #[test]
     fn tie_break_by_id_desc() {
         let ts = 5_000;
-        let mut v = vec![
-            make_msg(10, ts),
-            make_msg(30, ts),
-            make_msg(20, ts),
-        ];
+        let mut v = vec![make_msg(10, ts), make_msg(30, ts), make_msg(20, ts)];
         v.sort_by(sort_cmp_inbox);
         let ids: Vec<u64> = v.iter().map(|m| m.id).collect();
         // Regardless of input order, higher id must come first.

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -2689,7 +2689,7 @@ mod inbox_sort_tests {
     /// Messages with distinct timestamps should be sorted newest-first.
     #[test]
     fn sort_by_time_desc() {
-        let mut v = vec![make_msg(1, 1_000), make_msg(2, 3_000), make_msg(3, 2_000)];
+        let mut v = [make_msg(1, 1_000), make_msg(2, 3_000), make_msg(3, 2_000)];
         v.sort_by(sort_cmp_inbox);
         let ids: Vec<u64> = v.iter().map(|m| m.id).collect();
         assert_eq!(ids, vec![2, 3, 1]);
@@ -2700,7 +2700,7 @@ mod inbox_sort_tests {
     #[test]
     fn tie_break_by_id_desc() {
         let ts = 5_000;
-        let mut v = vec![make_msg(10, ts), make_msg(30, ts), make_msg(20, ts)];
+        let mut v = [make_msg(10, ts), make_msg(30, ts), make_msg(20, ts)];
         v.sort_by(sort_cmp_inbox);
         let ids: Vec<u64> = v.iter().map(|m| m.id).collect();
         // Regardless of input order, higher id must come first.
@@ -2712,7 +2712,7 @@ mod inbox_sort_tests {
     #[test]
     fn sort_is_idempotent() {
         let ts = 7_000;
-        let mut v = vec![
+        let mut v = [
             make_msg(5, ts),
             make_msg(1, ts),
             make_msg(3, ts),
@@ -2775,7 +2775,7 @@ mod folder_sort_tests {
     /// Drafts should appear newest-first by `updated_at`.
     #[test]
     fn drafts_sort_time_desc() {
-        let mut d = vec![
+        let mut d = [
             make_draft("id-1", 1_000),
             make_draft("id-2", 3_000),
             make_draft("id-3", 2_000),
@@ -2790,7 +2790,7 @@ mod folder_sort_tests {
     #[test]
     fn drafts_tie_break_by_id_desc() {
         let ts = 5_000;
-        let mut d = vec![
+        let mut d = [
             make_draft("aaa", ts),
             make_draft("ccc", ts),
             make_draft("bbb", ts),
@@ -2804,7 +2804,7 @@ mod folder_sort_tests {
     #[test]
     fn drafts_sort_idempotent() {
         let ts = 7_000;
-        let mut d = vec![
+        let mut d = [
             make_draft("x", ts),
             make_draft("y", ts),
             make_draft("z", ts),
@@ -2822,7 +2822,7 @@ mod folder_sort_tests {
     /// Sent messages should appear newest-first by `sent_at`.
     #[test]
     fn sent_sort_time_desc() {
-        let mut s = vec![
+        let mut s = [
             make_sent("id-1", 1_000),
             make_sent("id-2", 3_000),
             make_sent("id-3", 2_000),
@@ -2836,7 +2836,7 @@ mod folder_sort_tests {
     #[test]
     fn sent_tie_break_by_id_desc() {
         let ts = 5_000;
-        let mut s = vec![
+        let mut s = [
             make_sent("aaa", ts),
             make_sent("ccc", ts),
             make_sent("bbb", ts),
@@ -2850,7 +2850,7 @@ mod folder_sort_tests {
     #[test]
     fn sent_sort_idempotent() {
         let ts = 7_000;
-        let mut s = vec![
+        let mut s = [
             make_sent("x", ts),
             make_sent("y", ts),
             make_sent("z", ts),
@@ -2868,7 +2868,7 @@ mod folder_sort_tests {
     /// Archived messages should appear newest-first by `archived_at`.
     #[test]
     fn archive_sort_time_desc() {
-        let mut a = vec![
+        let mut a = [
             make_archived(1, 1_000),
             make_archived(2, 3_000),
             make_archived(3, 2_000),
@@ -2883,7 +2883,7 @@ mod folder_sort_tests {
     #[test]
     fn archive_tie_break_by_id_desc() {
         let ts = 5_000;
-        let mut a = vec![
+        let mut a = [
             make_archived(10, ts),
             make_archived(30, ts),
             make_archived(20, ts),
@@ -2897,7 +2897,7 @@ mod folder_sort_tests {
     #[test]
     fn archive_sort_idempotent() {
         let ts = 7_000;
-        let mut a = vec![
+        let mut a = [
             make_archived(5, ts),
             make_archived(1, ts),
             make_archived(3, ts),


### PR DESCRIPTION
## Problem

Clicking a message in the inbox list shifts the order of other messages (issue #137).

**Root cause:** The inbox list merges live contract messages with *kept-locally* messages sourced from `AliasState.kept: HashMap<String, KeptMessage>`. Rust's `HashMap` iteration order is randomised. The previous sort:

```rust
v.sort_by_key(|m| std::cmp::Reverse(m.time));
```

is stable in itself, but `sort_by_key` only preserves the *input* order for equal elements — and the input order changes every re-render because `kept_for()` iterates a fresh `HashMap`. Sender-stamped time has 1-second granularity, so messages with the same timestamp tie. Any `mark_read` call (triggered by clicking a message) bumps the local-state generation, forces a re-render, and the freshly-iterated `HashMap` produces a new permutation of tied messages.

## Fix

Replace the four `sort_by_key(Reverse(...))` calls in `MessageList` (Inbox, Drafts, Sent, Archive) with `sort_by` that adds a deterministic tie-break on the map key (message `id` for Inbox/Archive, `String` draft/sent id for Drafts/Sent):

```rust
// Before
v.sort_by_key(|m| std::cmp::Reverse(m.time));

// After
v.sort_by(|a, b| b.time.cmp(&a.time).then(b.id.cmp(&a.id)));
```

`MessageId` (`u64`) is monotonically assigned per inbox, so a higher id means a later-arriving message — the tie-break matches user expectation.

## Tests

Three unit tests added in `inbox_sort_tests`:

- `sort_by_time_desc` — distinct timestamps sort newest-first
- `tie_break_by_id_desc` — tied timestamps always order by id descending, regardless of input order
- `sort_is_idempotent` — running the sort twice produces the same result (simulates re-render stability)

All pass with `cargo test -p freenet-email-ui --features "example-data,no-sync" --no-default-features`.

Closes #137