### PR TITLE
fix(ui): show toast + inline hint when To alias not in address book

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -31,6 +31,7 @@
   "fmArchiveReply": "fm-archive-reply",
   "fmComposeSheet": "fm-compose-sheet",
   "fmSend": "fm-send",
+  "fmComposeRecipientHint": "fm-compose-recipient-hint",
   "fmToast": "fm-toast",
   "fmActionCreate": "fm-action-create",
   "fmActionImport": "fm-action-import",

--- a/ui/public/vendor/css/components/compose.css
+++ b/ui/public/vendor/css/components/compose.css
@@ -78,6 +78,13 @@
     }
     .badge-fp { color: var(--ink3); }
 
+    .sheet-recipient-hint {
+      padding: 6px 18px 10px;
+      border-bottom: 1px solid var(--line2);
+      font-size: 11px; color: var(--unread);
+      margin-top: -1px;
+    }
+
     .sheet-body { padding: 14px 18px; }
     .sheet-textarea {
       width: 100%; min-height: 180px; border: 0; background: transparent; resize: none;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -2332,6 +2332,9 @@ fn ComposeSheet() -> Element {
                     format!("couldn't find key for `{to_val}`"),
                     Some(TryNodeAction::GetAlias),
                 );
+                toast.set(Some(format!(
+                    "Recipient `{to_val}` is not in your address book. Import their contact card before sending."
+                )));
                 return;
             }
         };
@@ -2541,7 +2544,9 @@ fn ComposeSheet() -> Element {
                     }
                 }
                 {
-                    recipient_lookup.read().as_ref().map(|r| {
+                    let to_val = to.read().clone();
+                    let lookup = recipient_lookup.read().clone();
+                    if let Some(r) = lookup {
                         let (badge_class, badge_label): (&str, &str) =
                             if r.is_own {
                                 ("badge badge-trust", "you")
@@ -2567,7 +2572,17 @@ fn ComposeSheet() -> Element {
                                 }
                             }
                         }
-                    })
+                    } else if !to_val.is_empty() {
+                        rsx! {
+                            div {
+                                class: "sheet-recipient-hint",
+                                "data-testid": testid::FM_COMPOSE_RECIPIENT_HINT,
+                                "Not in address book — import their contact card first."
+                            }
+                        }
+                    } else {
+                        rsx! {}
+                    }
                 }
                 div { class: "sheet-field",
                     span { class: "field-lbl", "Re" }

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -63,6 +63,7 @@ pub(crate) const FM_ARCHIVE_REPLY: &str = "fm-archive-reply";
 // Compose
 pub(crate) const FM_COMPOSE_SHEET: &str = "fm-compose-sheet";
 pub(crate) const FM_SEND: &str = "fm-send";
+pub(crate) const FM_COMPOSE_RECIPIENT_HINT: &str = "fm-compose-recipient-hint";
 
 // Toast
 pub(crate) const FM_TOAST: &str = "fm-toast";
@@ -149,6 +150,7 @@ mod tests {
             ("fmArchiveReply", super::FM_ARCHIVE_REPLY),
             ("fmComposeSheet", super::FM_COMPOSE_SHEET),
             ("fmSend", super::FM_SEND),
+            ("fmComposeRecipientHint", super::FM_COMPOSE_RECIPIENT_HINT),
             ("fmToast", super::FM_TOAST),
             ("fmActionCreate", super::FM_ACTION_CREATE),
             ("fmActionImport", super::FM_ACTION_IMPORT),


### PR DESCRIPTION
## Summary

- In `send_msg`, when `address_book::lookup` returns `None` (alias not in address book), call `toast.set(Some(...))` with a human-readable message before returning — mirrors the existing `verify_on_send` branch that already uses this pattern.
- Add an inline `sheet-recipient-hint` div below the To field that appears while the user is typing a non-empty alias that isn't in the address book — reuses the existing `recipient_lookup` memo, no new polling needed.
- Add `FM_COMPOSE_RECIPIENT_HINT` testid constant + JSON entry so the hint is selectable in Playwright tests.
- Add `sheet-recipient-hint` CSS class styled consistently with the existing `badge-warn` colour (`--unread`).

## Test plan

- [ ] Build passes: `cargo build -p freenet-email-ui --features example-data,no-sync --no-default-features --target wasm32-unknown-unknown`
- [ ] Clippy clean: `cargo clippy -p freenet-email-ui --features example-data,no-sync --no-default-features`
- [ ] Testid consistency test passes: `cargo test -p freenet-email-ui --features example-data,no-sync --no-default-features -- testid`
- [ ] Manual: open compose, type an unknown alias in To, observe inline amber hint; click Send, observe toast banner with the address-book-import prompt.

Closes #133