### PR TITLE
fix(ui): live-refresh sender badge after contact import

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -779,6 +779,7 @@ pub(crate) async fn node_comms(
         user: Signal<crate::app::User>,
         mut login_controller: Signal<crate::app::LoginController>,
         inboxes: &InboxesData,
+        mut ab_gen: crate::app::AddressBookGen,
     ) {
         let mut client = api.sender_half();
         match req {
@@ -1327,8 +1328,8 @@ pub(crate) async fn node_comms(
                 let found = inbox_management::CREATED_INBOX.with(|keys| {
                     let pos = keys.borrow().iter().position(|(_, k)| k == &contract_key);
                     if let Some(pos) = pos {
-                        let (alias, key) = keys.borrow_mut().remove(pos);
-                        crate::log::debug!("inbox contract `{key}` for alias `{alias}` put");
+                        let (_alias, _key) = keys.borrow_mut().remove(pos);
+                        crate::log::debug!("inbox contract `{_key}` for alias `{_alias}` put");
                         return true;
                     }
                     false
@@ -1361,8 +1362,8 @@ pub(crate) async fn node_comms(
                 let found = token_record_management::CREATED_AFT_RECORD.with(|keys| {
                     let pos = keys.borrow().iter().position(|(_, k)| k == &contract_key);
                     if let Some(pos) = pos {
-                        let (alias, key) = keys.borrow_mut().remove(pos);
-                        crate::log::debug!("AFT record `{key}` for alias `{alias}` put");
+                        let (_alias, _key) = keys.borrow_mut().remove(pos);
+                        crate::log::debug!("AFT record `{_key}` for alias `{_alias}` put");
                         return true;
                     }
                     false
@@ -1411,8 +1412,8 @@ pub(crate) async fn node_comms(
                     let found = token_generator_management::CREATED_AFT_GEN.with(|keys| {
                         let pos = keys.borrow().iter().position(|(_, k)| k == &key);
                         if let Some(pos) = pos {
-                            let (alias, key) = keys.borrow_mut().remove(pos);
-                            crate::log::debug!("AFT gen delegate `{key}` for `{alias}` put");
+                            let (_alias, _key) = keys.borrow_mut().remove(pos);
+                            crate::log::debug!("AFT gen delegate `{_key}` for `{_alias}` put");
                             return true;
                         }
                         false
@@ -1656,6 +1657,7 @@ pub(crate) async fn node_comms(
                     user,
                     login_controller,
                     &inboxes,
+                    ab_gen,
                 )
                 .await;
             }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -689,6 +689,7 @@ pub(crate) async fn node_comms(
     login_controller: Signal<crate::app::LoginController>,
     user: Signal<crate::app::User>,
     inboxes: crate::app::InboxesData,
+    mut ab_gen: crate::app::AddressBookGen,
 ) {
     // todo don't unwrap inside this function, propagate errors to the UI somehow
     use freenet_email_inbox::Inbox as StoredInbox;
@@ -952,6 +953,10 @@ pub(crate) async fn node_comms(
                     // ContactsSection reads ADDRESS_BOOK directly (not via a
                     // Signal) so bump the controller to force re-render.
                     login_controller.write().updated = true;
+                    // Bump generation so MessageList / OpenMessage re-render
+                    // and pick up the new contact's verification state (#134).
+                    let prev = *ab_gen.0.read();
+                    ab_gen.0.set(prev.wrapping_add(1));
                 }
             }
             NodeAction::DeleteContact { alias } => {
@@ -962,6 +967,11 @@ pub(crate) async fn node_comms(
                 } else {
                     crate::app::address_book::remove_contact(&alias);
                     login_controller.write().updated = true;
+                    // Bump generation so inbox rows that showed the
+                    // removed contact as "verified" revert to
+                    // "unknown sender" (#134).
+                    let prev = *ab_gen.0.read();
+                    ab_gen.0.set(prev.wrapping_add(1));
                 }
             }
             NodeAction::RenameIdentity { old, new, identity } => {

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -780,7 +780,7 @@ pub(crate) async fn node_comms(
         user: Signal<crate::app::User>,
         mut login_controller: Signal<crate::app::LoginController>,
         inboxes: &InboxesData,
-        ab_gen: crate::app::AddressBookGen,
+        mut ab_gen: crate::app::AddressBookGen,
     ) {
         let mut client = api.sender_half();
         match req {

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -684,12 +684,13 @@ mod identity_management {
 }
 
 #[cfg(feature = "use-node")]
+#[allow(unused_mut)]
 pub(crate) async fn node_comms(
     mut rx: UnboundedReceiver<crate::app::NodeAction>,
     login_controller: Signal<crate::app::LoginController>,
     user: Signal<crate::app::User>,
     inboxes: crate::app::InboxesData,
-    #[allow(unused_mut)] mut ab_gen: crate::app::AddressBookGen,
+    mut ab_gen: crate::app::AddressBookGen,
 ) {
     // todo don't unwrap inside this function, propagate errors to the UI somehow
     use freenet_email_inbox::Inbox as StoredInbox;

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -957,7 +957,7 @@ pub(crate) async fn node_comms(
                     // Bump generation so MessageList / OpenMessage re-render
                     // and pick up the new contact's verification state (#134).
                     let prev = *ab_gen.0.read();
-                    ab_gen.0.set(prev.wrapping_add(1));
+                    *ab_gen.0.write() = prev.wrapping_add(1);
                 }
             }
             NodeAction::DeleteContact { alias } => {
@@ -972,7 +972,7 @@ pub(crate) async fn node_comms(
                     // removed contact as "verified" revert to
                     // "unknown sender" (#134).
                     let prev = *ab_gen.0.read();
-                    ab_gen.0.set(prev.wrapping_add(1));
+                    *ab_gen.0.write() = prev.wrapping_add(1);
                 }
             }
             NodeAction::RenameIdentity { old, new, identity } => {

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -689,7 +689,7 @@ pub(crate) async fn node_comms(
     login_controller: Signal<crate::app::LoginController>,
     user: Signal<crate::app::User>,
     inboxes: crate::app::InboxesData,
-    mut ab_gen: crate::app::AddressBookGen,
+    ab_gen: crate::app::AddressBookGen,
 ) {
     // todo don't unwrap inside this function, propagate errors to the UI somehow
     use freenet_email_inbox::Inbox as StoredInbox;
@@ -779,7 +779,7 @@ pub(crate) async fn node_comms(
         user: Signal<crate::app::User>,
         mut login_controller: Signal<crate::app::LoginController>,
         inboxes: &InboxesData,
-        mut ab_gen: crate::app::AddressBookGen,
+        ab_gen: crate::app::AddressBookGen,
     ) {
         let mut client = api.sender_half();
         match req {

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -689,7 +689,7 @@ pub(crate) async fn node_comms(
     login_controller: Signal<crate::app::LoginController>,
     user: Signal<crate::app::User>,
     inboxes: crate::app::InboxesData,
-    ab_gen: crate::app::AddressBookGen,
+    #[allow(unused_mut)] mut ab_gen: crate::app::AddressBookGen,
 ) {
     // todo don't unwrap inside this function, propagate errors to the UI somehow
     use freenet_email_inbox::Inbox as StoredInbox;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -121,13 +121,18 @@ pub(crate) fn app() -> Element {
     let inbox = use_context::<Signal<InboxView>>();
     use_context_provider(InboxesData::new);
     let inbox_data = use_context::<InboxesData>();
+    // Address-book generation counter (#134). Bumped on every
+    // CreateContact / DeleteContact so inbox components subscribed via
+    // `.read()` re-render and pick up the updated verification state.
+    use_context_provider(|| AddressBookGen(Signal::new(0u32)));
+    let ab_gen = use_context::<AddressBookGen>();
 
     #[cfg(all(feature = "use-node", not(feature = "no-sync")))]
     {
         let _sync: Coroutine<NodeAction> = use_coroutine(move |rx| {
             let login_controller = login_controller;
             let user = user;
-            let fut = crate::api::node_comms(rx, login_controller, user, inbox_data)
+            let fut = crate::api::node_comms(rx, login_controller, user, inbox_data, ab_gen)
                 .map(|_| Ok(JsValue::NULL));
             let _ = wasm_bindgen_futures::future_to_promise(fut);
             async {}.boxed_local()
@@ -137,6 +142,7 @@ pub(crate) fn app() -> Element {
     {
         let _ = inbox_data;
         let mut login_ctl = login_controller;
+        let mut ab_gen = ab_gen;
         let _sync: Coroutine<NodeAction> =
             use_coroutine(move |mut rx: UnboundedReceiver<NodeAction>| async move {
                 use futures::StreamExt;
@@ -149,11 +155,20 @@ pub(crate) fn app() -> Element {
                         NodeAction::CreateContact { contact } => {
                             if address_book::insert_contact(contact).is_ok() {
                                 login_ctl.write().updated = true;
+                                // Bump generation so MessageList / OpenMessage
+                                // re-render and reflect the new contact (#134).
+                                let prev = *ab_gen.0.read();
+                                ab_gen.0.set(prev.wrapping_add(1));
                             }
                         }
                         NodeAction::DeleteContact { alias } => {
                             address_book::remove_contact(&alias);
                             login_ctl.write().updated = true;
+                            // Bump generation so inbox rows that showed the
+                            // removed contact as "verified" revert to
+                            // "unknown sender" (#134).
+                            let prev = *ab_gen.0.read();
+                            ab_gen.0.set(prev.wrapping_add(1));
                         }
                         NodeAction::RenameIdentity { old, new, .. } => {
                             // Offline mode: just relabel the in-memory
@@ -212,6 +227,17 @@ pub(crate) fn app() -> Element {
 /// for re-render on writes — no separate bump-signal needed.
 #[derive(Clone, Copy)]
 pub(crate) struct InboxesData(pub(crate) Signal<Vec<Rc<RefCell<InboxModel>>>>);
+
+/// Generation counter for address-book mutations (issue #134).
+///
+/// Provided as Dioxus context in `app()` and bumped on every
+/// `CreateContact` / `DeleteContact` action so that inbox components
+/// that call `verification_state()` (which reads the address book
+/// directly) are subscribed to changes. Any component that calls
+/// `.read()` on this value is re-rendered the next time the counter
+/// increments.
+#[derive(Clone, Copy)]
+pub(crate) struct AddressBookGen(pub(crate) Signal<u32>);
 
 impl InboxesData {
     pub fn new() -> Self {
@@ -1294,6 +1320,10 @@ fn MessageList() -> Element {
     // Touch the local-state generation so this component re-renders when
     // drafts are added/removed.
     let _local_gen = crate::local_state::GENERATION();
+    // Subscribe to address-book mutations so verification badges on
+    // inbox rows update immediately after a contact is imported (#134).
+    let ab_gen_ctx = use_context::<AddressBookGen>();
+    let _ab_gen = ab_gen_ctx.0.read();
 
     let inbox_view = inbox.read();
     let emails = inbox_view.messages.borrow();
@@ -1973,6 +2003,11 @@ fn OpenMessage(msg: Message) -> Element {
     let reply_to = from.clone();
     let reply_subj = format!("Re: {}", title);
     let time_full = format_time_full(msg.time);
+    // Subscribe to address-book mutations so the verification badge
+    // updates immediately when the user imports the sender's contact
+    // without requiring a full page reload (#134).
+    let ab_gen_ctx = use_context::<AddressBookGen>();
+    let _ab_gen = ab_gen_ctx.0.read();
     // Sender trust state (#51) — three-valued: verified-known (sig OK +
     // contact verified), verified-unknown (sig OK, sender VK not in AB),
     // unverified (no sig / forged sig). Fingerprint short-form is shown

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -774,10 +774,9 @@ fn ScrInbox() -> Element {
 
 #[allow(non_snake_case)]
 fn ScrContacts() -> Element {
-    // Subscribe to address-book changes. The address book bumps an internal
-    // generation when contacts are added / removed; treat the trash button
-    // as an explicit re-render trigger.
-    let mut tick = use_signal(|| 0u32);
+    // Subscribe to address-book generation so additions *and* removals
+    // (dispatched via NodeAction::DeleteContact) both trigger a re-render.
+    let ab_gen = use_context::<crate::app::AddressBookGen>();
     let mut search = use_signal(String::new);
 
     let mut menu_selection = use_context::<Signal<menu::MenuSelection>>();
@@ -785,6 +784,7 @@ fn ScrContacts() -> Element {
     let mut share_contact_form = use_context::<Signal<crate::app::login::ShareContact>>();
     let mut share_pending = use_context::<Signal<crate::app::login::SharePending>>();
     let user = use_context::<Signal<User>>();
+    let actions = use_coroutine_handle::<crate::app::NodeAction>();
 
     let on_import = move |_| {
         menu_selection.write().close_settings();
@@ -808,7 +808,7 @@ fn ScrContacts() -> Element {
     };
 
     let needle = search.read().to_lowercase();
-    let _ = tick.read(); // re-run the memo when `tick` bumps.
+    let _ = ab_gen.0.read(); // re-run when a contact is added or removed.
     let contacts: Vec<address_book::Contact> = address_book::all_contacts()
         .into_iter()
         .filter(|c| {
@@ -888,9 +888,9 @@ fn ScrContacts() -> Element {
                                         class: "fm-btn-secondary",
                                         style: "height: 26px; padding: 0 9px; font-size: 11px;",
                                         onclick: move |_| {
-                                            address_book::remove_contact(&alias_for_remove);
-                                            let prev = *tick.read();
-                                            tick.set(prev + 1);
+                                            actions.send(crate::app::NodeAction::DeleteContact {
+                                                alias: alias_for_remove.clone(),
+                                            });
                                         },
                                         "Remove"
                                     }


### PR DESCRIPTION
## Summary

Closes #134

- **Root cause**: `verification_state()` already reads the address book live on each call, but `MessageList` and `OpenMessage` had no Dioxus dependency on address-book mutations. After `CreateContact` / `DeleteContact` landed, no signal was bumped that those components subscribed to, so Dioxus never scheduled a re-render and the badge stayed stale until a full page reload.
- **Fix**: Added `AddressBookGen(Signal<u32>)` as a Dioxus context value, provided in `app()`. Both mutation paths (no-sync coroutine in `app.rs` and the live-node `node_comms` in `api.rs`) bump the counter after a successful `insert_contact` / `remove_contact`. `MessageList` and `OpenMessage` each call `.read()` on the counter, registering a reactive dependency so Dioxus re-renders them immediately when the counter increments.
- The "unknown sender" fallback for truly unknown senders is preserved — the only change is reactivity.

## Test plan

- [ ] `cargo clippy -p freenet-email-ui --features "example-data,no-sync" --no-default-features` — clean
- [ ] `cargo test -p freenet-email-ui --features "example-data,no-sync" --no-default-features --lib` — all 52 tests pass
- [ ] Manual: run `cargo make dev-example`, receive a message, import the sender's contact card, verify the badge flips from "signed · unknown sender" to "verified" without a page reload