### PR TITLE
fix(ui): missing-alias UX polish — auto-dismiss, trim, a11y

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -2190,7 +2190,11 @@ fn ToastView() -> Element {
     let value = toast.read().clone();
     if let Some(text) = value {
         rsx! {
-            div { class: "toast", "data-testid": testid::FM_TOAST,
+            div {
+                class: "toast",
+                "data-testid": testid::FM_TOAST,
+                role: "status",
+                "aria-live": "assertive",
                 span { class: "pulse-dot" }
                 span { "{text}" }
             }
@@ -2335,6 +2339,7 @@ fn ComposeSheet() -> Element {
                 toast.set(Some(format!(
                     "Recipient `{to_val}` is not in your address book. Import their contact card before sending."
                 )));
+                spawn_toast_clear();
                 return;
             }
         };
@@ -2350,6 +2355,7 @@ fn ComposeSheet() -> Element {
             toast.set(Some(format!(
                 "Recipient `{to_val}` is not verified. Verify the fingerprint in Contacts before sending."
             )));
+            spawn_toast_clear();
             return;
         }
         let recipient_ek = match address_book::ek_from_bytes(&recipient.ml_kem_ek_bytes) {
@@ -2572,11 +2578,13 @@ fn ComposeSheet() -> Element {
                                 }
                             }
                         }
-                    } else if !to_val.is_empty() {
+                    } else if !to_val.trim().is_empty() {
                         rsx! {
                             div {
                                 class: "sheet-recipient-hint",
                                 "data-testid": testid::FM_COMPOSE_RECIPIENT_HINT,
+                                role: "status",
+                                "aria-live": "polite",
                                 "Not in address book — import their contact card first."
                             }
                         }


### PR DESCRIPTION
## Summary

Addresses three UX nits raised in the skeptical review of #142.

- **Toast auto-dismiss** — `send_msg` now calls `spawn_toast_clear()` immediately after setting the two error toasts (missing address-book entry and `verify_on_send` guard). Both previously stayed on-screen forever; they now clear after ~2.2 s (same timer used everywhere else in the app). The `verify_on_send` toast was broken since before #142; fixed here for consistency.

- **Trim whitespace before hint** — The inline hint guard changed from `!to_val.is_empty()` to `!to_val.trim().is_empty()`. Whitespace-only input (e.g. accidental space) no longer shows "Not in address book" prematurely.

- **Accessibility (aria-live)** — Added `role="status"` + `aria-live="polite"` to the inline recipient hint `div` so screen readers announce it when it appears. Added `role="status"` + `aria-live="assertive"` to the toast element so time-sensitive error announcements are read immediately.

## Test plan

- [ ] Type spaces into the To field — hint should not appear
- [ ] Type a non-existent alias — hint appears; toast appears on Send and dismisses after ~2 s
- [ ] Enable `verify_on_send`, type an unverified alias, hit Send — toast appears and dismisses after ~2 s
- [ ] Screen-reader check: hint region announced on alias change; toast announced on send error