### PR TITLE
fix(ui): correct misleading identity-storage copy; add inline backup button

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -36,6 +36,7 @@
   "fmActionImport": "fm-action-import",
   "fmCreateAliasInput": "fm-create-alias-input",
   "fmCreateConfirm": "fm-create-confirm",
+  "fmCreateBackupNow": "fm-create-backup-now",
   "fmCreateSubmit": "fm-create-submit",
   "fmVerifyCheck": "fm-verify-check",
   "fmRestoreFile": "fm-restore-file",

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -1044,7 +1044,7 @@ pub(super) fn CreateAliasForm() -> Element {
                     span { class: "nudge-icon", "⚠" }
                     div { class: "nudge-text",
                         strong { "Back up the key before you continue." }
-                        " It lives in this browser only. There is no recovery."
+                        " Keys are stored in your local Freenet node's delegate — losing the node's data dir destroys them. Export a backup file to migrate or recover."
                     }
                 }
                 div { class: "modal-foot", style: "background:transparent; border:0; padding:18px 0 0;",
@@ -1052,6 +1052,30 @@ pub(super) fn CreateAliasForm() -> Element {
                         class: "btn btn-ghost",
                         onclick: cancel,
                         "Discard"
+                    }
+                    button {
+                        class: "btn btn-secondary",
+                        "data-testid": testid::FM_CREATE_BACKUP_NOW,
+                        title: "Download a backup of this identity's private keys",
+                        onclick: move |_| {
+                            if let Some((ml_dsa, ml_kem, _)) = pending.read().as_ref() {
+                                let keys = StoredIdentityKeys::new(ml_dsa, ml_kem);
+                                let backup = IdentityBackup {
+                                    version: IDENTITY_BACKUP_VERSION,
+                                    alias: alias_input.read().trim().to_string(),
+                                    description: description.read().clone(),
+                                    keys,
+                                };
+                                if let Ok(json) = serde_json::to_vec_pretty(&backup) {
+                                    let fname = format!(
+                                        "freenet-identity-{}.json",
+                                        alias_input.read().trim()
+                                    );
+                                    trigger_browser_download(&fname, &json);
+                                }
+                            }
+                        },
+                        "Back up now ↓"
                     }
                     button {
                         class: "btn btn-primary btn-lg",

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -72,6 +72,7 @@ pub(crate) const FM_ACTION_CREATE: &str = "fm-action-create";
 pub(crate) const FM_ACTION_IMPORT: &str = "fm-action-import";
 pub(crate) const FM_CREATE_ALIAS_INPUT: &str = "fm-create-alias-input";
 pub(crate) const FM_CREATE_CONFIRM: &str = "fm-create-confirm";
+pub(crate) const FM_CREATE_BACKUP_NOW: &str = "fm-create-backup-now";
 pub(crate) const FM_CREATE_SUBMIT: &str = "fm-create-submit";
 pub(crate) const FM_VERIFY_CHECK: &str = "fm-verify-check";
 pub(crate) const FM_RESTORE_FILE: &str = "fm-restore-file";
@@ -154,6 +155,7 @@ mod tests {
             ("fmActionImport", super::FM_ACTION_IMPORT),
             ("fmCreateAliasInput", super::FM_CREATE_ALIAS_INPUT),
             ("fmCreateConfirm", super::FM_CREATE_CONFIRM),
+            ("fmCreateBackupNow", super::FM_CREATE_BACKUP_NOW),
             ("fmCreateSubmit", super::FM_CREATE_SUBMIT),
             ("fmVerifyCheck", super::FM_VERIFY_CHECK),
             ("fmRestoreFile", super::FM_RESTORE_FILE),


### PR DESCRIPTION
## Summary

- **Copy fix**: The fingerprint-confirmation nudge previously said _"It lives in this browser only"_ — this is incorrect. Keys are stored in the local Freenet node's identity-management delegate, not browser localStorage. The new copy reads: _"Keys are stored in your local Freenet node's delegate — losing the node's data dir destroys them. Export a backup file to migrate or recover."_

- **Inline backup button**: A **"Back up now ↓"** button is now present on the fingerprint-confirmation step itself (between _Discard_ and _Continue to inbox_). It reuses the existing `IdentityBackup` / `trigger_browser_download` path that the post-creation identity-list "↓" button already uses. The user no longer has to click _Continue_, navigate back to the identity list, and find the download icon.

- **Warning copy used on the button**: The existing `title` attribute reads _"Download a backup of this identity's private keys"_. The identity-list footer already says _"Backup files contain raw private keys — store them securely."_

- **Restore**: Already implemented (prior to this PR) via the _"Restore from backup"_ button on the identity list page. No changes needed there.

- **Testid**: New constant `FM_CREATE_BACKUP_NOW` (`fm-create-backup-now`) added to `testid.rs` and mirrored in `testids.json`; `testid::tests::json_matches_rust_consts` confirms they are in sync.

## Test plan

- [ ] `cargo test --lib -p freenet-email-ui --no-default-features --features example-data,no-sync` → 40 tests pass including `testid::tests::json_matches_rust_consts`
- [ ] `cargo clippy --target wasm32-unknown-unknown -p freenet-email-ui --no-default-features --features example-data,no-sync --tests -- -D warnings` → clean
- [ ] `cargo make dev-example` → create a new identity → confirm fingerprint screen shows updated nudge text and a "Back up now ↓" button → click it → verify a `.json` file downloads with the expected `{ version, alias, description, keys }` shape
- [ ] Clicking _Continue to inbox_ still works normally after (or without) using the backup button

Closes #130