### PR TITLE
fix: address skeptical review regressions from #135/#139/#141

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -662,8 +662,16 @@ impl Message {
 // re-render (issue #137).  Use these at every sort site AND in unit tests so
 // the two cannot drift apart.
 
-/// Inbox: newest `Message` first; tie-break by `id` descending (monotonic u64
-/// — higher id = later arrival).
+/// Inbox: newest `Message` first; tie-break by `id` descending for stability.
+///
+/// **Important:** `Message.id` is the *enumerate index* from
+/// `InboxModel::from_state` (i.e. the position of the row in the contract's
+/// `StoredInbox.messages` vec at the time the model was built).  It is NOT a
+/// monotonic arrival id — a higher value does NOT mean the message arrived
+/// later.  The tie-break is purely for render-stability: it guarantees a
+/// consistent ordering across re-renders when two messages share the same
+/// sender-stamped timestamp, preventing the HashMap iteration-order flicker
+/// described in issue #137.
 fn sort_cmp_inbox(a: &Message, b: &Message) -> std::cmp::Ordering {
     b.time.cmp(&a.time).then(b.id.cmp(&a.id))
 }
@@ -686,8 +694,10 @@ fn sort_cmp_sent(
     b.1.sent_at.cmp(&a.1.sent_at).then(b.0.cmp(&a.0))
 }
 
-/// Archive: newest first by `archived_at`; tie-break by `id` descending
-/// (monotonic u64 — higher id = later arrival).
+/// Archive: newest first by `archived_at`; tie-break by `id` descending for
+/// stability.  The `id` key is the stringified `MessageId` used in the
+/// archived map — its ordering is for render-stability only, not chronological
+/// arrival.
 fn sort_cmp_archive(
     a: &(u64, mail_local_state::ArchivedMessage),
     b: &(u64, mail_local_state::ArchivedMessage),
@@ -2710,8 +2720,10 @@ mod inbox_sort_tests {
         assert_eq!(ids, vec![2, 3, 1]);
     }
 
-    /// When timestamps tie, higher id should come first (deterministic
-    /// tie-break — fixes the HashMap reorder on click, issue #137).
+    /// When timestamps tie, higher id should come first for render-stability
+    /// (issue #137).  Note: `id` is the enumerate index from `from_state`,
+    /// not a monotonic arrival counter — this tie-break is for stability
+    /// only, not chronological ordering.
     #[test]
     fn tie_break_by_id_desc() {
         let ts = 5_000;

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -74,7 +74,9 @@ pub struct ContactCard {
     /// Encoded into the recipient's `InboxParams`, so the contract id
     /// hashes over this value — sending under a different tier is
     /// rejected by `verify_token_policy` in the inbox contract.
-    /// Defaults to `Tier::Day1` when missing so v1 cards keep working.
+    /// Defaults to `Tier::Min10` when missing so v1 cards (which omit
+    /// this field) use the same tier as freshly-created inboxes, avoiding
+    /// a silent rejection when the sender mints at an outdated default.
     #[serde(default = "default_tier")]
     pub required_tier: Tier,
     /// Recipient's anti-flood policy: max age (seconds) the AFT delegate
@@ -84,8 +86,12 @@ pub struct ContactCard {
     pub max_age_secs: u64,
 }
 
+/// Default AFT tier for v1 contact cards that pre-date the `required_tier`
+/// field. Must match `IdentityAftPrefs::default().required_tier` so that a
+/// v1 card for a freshly-created inbox does not mint at an outdated tier and
+/// get silently rejected by `verify_token_policy` in the inbox contract.
 fn default_tier() -> Tier {
-    Tier::Day1
+    Tier::Min10
 }
 
 fn default_max_age_secs() -> u64 {
@@ -529,6 +535,8 @@ mod tests {
 
     /// Pre-#85 v1 cards lacked `required_tier` and `max_age_secs`. Decode
     /// must default-fill those fields so existing imports still work.
+    /// The default tier is now `Min10` (matching freshly-created inboxes)
+    /// so v1 card holders don't mint at `Day1` and get rejected.
     #[test]
     fn contact_card_v1_decodes_with_default_policy() {
         let vk: Vec<u8> = vec![1u8; 10];
@@ -543,8 +551,43 @@ mod tests {
         let bytes = serde_json::to_vec(&v1_json).unwrap();
         let encoded = format!("contact://{}", B64.encode(&bytes));
         let decoded = ContactCard::decode(&encoded).expect("v1 card decodes");
-        assert_eq!(decoded.required_tier, Tier::Day1);
+        assert_eq!(decoded.required_tier, Tier::Min10);
         assert_eq!(decoded.max_age_secs, DEFAULT_MAX_AGE_SECS);
+    }
+
+    /// `default_tier()` must match `IdentityAftPrefs::default().required_tier` so
+    /// that a freshly-created inbox and a v1 contact card for that inbox agree on
+    /// the required AFT tier. A mismatch would cause the sender to mint at the
+    /// wrong tier and get rejected by `verify_token_policy` in the inbox contract.
+    #[test]
+    fn default_tier_matches_aft_prefs_default() {
+        use mail_local_state::IdentityAftPrefs;
+        // IdentityAftPrefs uses String; parse the tier name for comparison.
+        let prefs_tier_str = IdentityAftPrefs::default().required_tier;
+        let prefs_tier: Tier = match prefs_tier_str.as_str() {
+            "Min1" => Tier::Min1,
+            "Min5" => Tier::Min5,
+            "Min10" => Tier::Min10,
+            "Min30" => Tier::Min30,
+            "Hour1" => Tier::Hour1,
+            "Hour3" => Tier::Hour3,
+            "Hour6" => Tier::Hour6,
+            "Hour12" => Tier::Hour12,
+            "Day1" => Tier::Day1,
+            "Day7" => Tier::Day7,
+            "Day15" => Tier::Day15,
+            "Day30" => Tier::Day30,
+            "Day90" => Tier::Day90,
+            "Day180" => Tier::Day180,
+            "Day365" => Tier::Day365,
+            other => panic!("unrecognised tier from IdentityAftPrefs::default(): {other}"),
+        };
+        assert_eq!(
+            default_tier(),
+            prefs_tier,
+            "ContactCard v1 back-compat default tier must match the AFT prefs default \
+             so freshly-created inboxes accept tokens minted from v1 cards",
+        );
     }
 
     fn make_contact(alias: &str, vk: u8, ek: u8) -> Contact {

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -724,7 +724,13 @@ fn ScrAft() -> Element {
                             max: "730",
                             value: "{max_age_days}",
                             style: "width: 100px",
-                            oninput: on_max_age,
+                            // Use onchange (not oninput) so persist_identity_settings and
+                            // push_policy (which dispatches a signed ML-DSA inbox-state UPDATE
+                            // over WebSocket) fire only when the user commits the value —
+                            // e.g. pressing Enter or blurring the field — not on every
+                            // keystroke. Typing "365" must not send three signed contract
+                            // updates for 3, 36, 365.
+                            onchange: on_max_age,
                         }
                     },
                 }

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -789,4 +789,80 @@ mod tests {
             "deleted message must not be re-merged as kept on stale echo",
         );
     }
+
+    /// Regression for #137 / #141: `kept` is a `HashMap`, so iteration order
+    /// is non-deterministic. After sorting the `kept_for` output with the same
+    /// `(kept_at, id)` comparator used in the inbox rebuild, the result must
+    /// be identical regardless of HashMap insertion order.
+    ///
+    /// This test builds a synthetic AliasState with 6 messages all sharing
+    /// the same `kept_at` timestamp (forcing the tie-break to decide the final
+    /// order), then re-inserts them in 10 different permutations and asserts
+    /// that `sorted(kept_for(...))` is the same every time.
+    #[test]
+    fn kept_for_sort_is_stable_across_hashmap_insertion_orders() {
+        const SHARED_KEPT_AT: i64 = 1_000_000;
+
+        // Build a batch of (id, KeptMessage) with identical kept_at so the
+        // tie-break by id is what determines order.
+        let make_batch = |order: &[MessageId]| {
+            let mut state = LocalState::default();
+            let entry = state.aliases_mut().entry("alice".to_string()).or_default();
+            for &id in order {
+                entry.kept.insert(
+                    id.to_string(),
+                    KeptMessage {
+                        from: "bob".into(),
+                        title: format!("msg-{id}"),
+                        content: "body".into(),
+                        kept_at: SHARED_KEPT_AT,
+                    },
+                );
+            }
+            state
+        };
+
+        // Sort helper: mirrors the sort_cmp_inbox tie-break logic of (time desc, id desc).
+        let sort_entries = |mut v: Vec<(MessageId, KeptMessage)>| -> Vec<MessageId> {
+            v.sort_by(|(a_id, a_k), (b_id, b_k)| {
+                b_k.kept_at.cmp(&a_k.kept_at).then(b_id.cmp(a_id))
+            });
+            v.into_iter().map(|(id, _)| id).collect()
+        };
+
+        // 10 insertion orders (hand-enumerated permutations of the 6-element vec).
+        let permutations: &[&[MessageId]] = &[
+            &[3, 1, 5, 2, 4, 6],
+            &[6, 4, 2, 5, 1, 3],
+            &[1, 2, 3, 4, 5, 6],
+            &[6, 5, 4, 3, 2, 1],
+            &[2, 4, 6, 1, 3, 5],
+            &[5, 3, 1, 6, 4, 2],
+            &[1, 6, 2, 5, 3, 4],
+            &[4, 2, 6, 3, 5, 1],
+            &[3, 5, 1, 4, 2, 6],
+            &[6, 1, 4, 2, 5, 3],
+        ];
+
+        let mut results: Vec<Vec<MessageId>> = Vec::with_capacity(permutations.len());
+        for &perm in permutations {
+            let snapshot = make_batch(perm);
+            replace_snapshot(snapshot);
+            let entries = kept_for("alice");
+            results.push(sort_entries(entries));
+        }
+
+        // Every permutation must produce the same sorted order.
+        let expected = results[0].clone();
+        for (i, result) in results.iter().enumerate() {
+            assert_eq!(
+                *result, expected,
+                "permutation {i} produced a different sort order: {result:?} vs {expected:?}",
+            );
+        }
+
+        // Sanity: expected order is ids descending (6,5,4,3,2,1) because
+        // kept_at is identical for all and we tie-break by id descending.
+        assert_eq!(expected, vec![6, 5, 4, 3, 2, 1]);
+    }
 }


### PR DESCRIPTION
## Summary

Three high-severity regressions found during skeptical review of recently merged PRs.

### Fix 1 — `ui/src/app/settings.rs` (regression from #139)

The AFT "Token max age" input was using `oninput` which fired `persist_identity_settings` AND `push_policy` (a signed ML-DSA inbox-state UPDATE over WebSocket) on every keystroke. Typing "365" dispatched 3 signed contract updates for 3, 36, 365.

**Fix:** reverted `oninput` → `onchange` on the max_age number input. Added an inline comment explaining why `onchange` is required here vs. text inputs like `display_name`.

### Fix 2 — `ui/src/app/address_book.rs` (high-sev from #135)

`default_tier()` in the v1 ContactCard back-compat path was returning `Tier::Day1`. Since #126 changed new inboxes to default to `Tier::Min10`, anyone holding a v1 card for a freshly-created recipient was minting a Day1 token that the inbox contract silently rejects via `verify_token_policy`.

**Fix:** changed `default_tier()` to return `Tier::Min10`. Updated the v1 decode test to assert `Min10`. Added a new unit test `default_tier_matches_aft_prefs_default` that asserts `ContactCard::default_tier()` equals `IdentityAftPrefs::default().required_tier` so the two cannot drift again.

### Fix 3 — `ui/src/app.rs` sort comparators (regression from #141)

The doc-comments on `sort_cmp_inbox` and `sort_cmp_archive` incorrectly described the `id` tie-break as "monotonic u64 — higher id = later arrival". `Message.id` is the enumerate index from `InboxModel::from_state`, not a monotonic arrival counter. The tie-break is for render-stability only, not chronological ordering.

**Fix:** updated doc-comments on `sort_cmp_inbox`, `sort_cmp_archive`, and the `tie_break_by_id_desc` test to accurately describe the semantics. Added a new unit test `kept_for_sort_is_stable_across_hashmap_insertion_orders` in `local_state::tests` that inserts 6 messages with identical timestamps in 10 different HashMap insertion orders and asserts the sorted output is identical each time — pinning the fix for the HashMap iteration-order flicker described in #137.

## Test plan

- [x] `cargo test -p freenet-email-ui --lib --no-default-features --features example-data,no-sync` — all 54 tests pass (up from 52; +`default_tier_matches_aft_prefs_default`, +`kept_for_sort_is_stable_across_hashmap_insertion_orders`)
- [x] `cargo test -p freenet-email-inbox` — passes
- [x] `cargo clippy --target wasm32-unknown-unknown -p freenet-email-ui --no-default-features --features example-data,no-sync --tests -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (after `cargo make build-contracts`)
- [x] `cargo fmt --all` — no diffs