### PR TITLE
feat(ui): autocomplete To field from address book (#132)

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -32,6 +32,8 @@
   "fmComposeSheet": "fm-compose-sheet",
   "fmSend": "fm-send",
   "fmComposeRecipientHint": "fm-compose-recipient-hint",
+  "fmComposeAutocomplete": "fm-compose-autocomplete",
+  "fmComposeAutocompleteItem": "fm-compose-autocomplete-item",
   "fmToast": "fm-toast",
   "fmActionCreate": "fm-action-create",
   "fmActionImport": "fm-action-import",

--- a/ui/public/vendor/css/components/compose.css
+++ b/ui/public/vendor/css/components/compose.css
@@ -85,6 +85,63 @@
       margin-top: -1px;
     }
 
+    /* Autocomplete dropdown for the To field */
+    .compose-autocomplete-wrap {
+      position: relative;
+    }
+    .compose-autocomplete {
+      position: absolute;
+      top: calc(100% + 2px);
+      left: 0; right: 0;
+      background: #fff;
+      border: 1px solid var(--line2);
+      border-radius: 8px;
+      box-shadow: var(--sh-lg);
+      z-index: 200;
+      overflow: hidden;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+    .compose-ac-item {
+      display: flex; align-items: center; gap: 8px;
+      padding: 8px 14px;
+      cursor: pointer;
+      font-size: 13px; color: var(--ink1);
+      border-bottom: 1px solid var(--line2);
+    }
+    .compose-ac-item:last-child { border-bottom: 0; }
+    .compose-ac-item:hover,
+    .compose-ac-item.highlighted {
+      background: var(--c1);
+    }
+    .compose-ac-alias {
+      font-weight: 600;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .compose-ac-trust {
+      font-family: "Geist Mono", monospace;
+      font-size: 8px;
+      padding: 2px 6px; border-radius: 4px;
+      text-transform: uppercase; letter-spacing: 0.04em;
+      flex-shrink: 0;
+    }
+    .compose-ac-trust.known {
+      color: var(--trust); background: var(--trust-bg);
+      border: 1px solid rgba(51, 153, 102, 0.25);
+    }
+    .compose-ac-trust.unknown {
+      color: var(--unread); background: rgba(217, 119, 6, 0.10);
+      border: 1px solid rgba(217, 119, 6, 0.25);
+    }
+    .compose-ac-fp {
+      font-family: "Geist Mono", monospace;
+      font-size: 9px; color: var(--ink3);
+      flex-shrink: 0;
+    }
+
     .sheet-body { padding: 14px 18px; }
     .sheet-textarea {
       width: 100%; min-height: 180px; border: 0; background: transparent; resize: none;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -588,6 +588,17 @@ impl User {
         for id in &identities {
             Identity::register_example(id.clone());
         }
+        // Seed a pre-imported contact so the compose-sheet autocomplete
+        // has something to suggest in offline / Playwright test mode.
+        let _ = address_book::insert_contact(address_book::Contact {
+            local_alias: "alice-example".into(),
+            description: "Example contact for offline testing".into(),
+            ml_dsa_vk_bytes: vec![0xAA; 1952],
+            ml_kem_ek_bytes: vec![0xBB; 1184],
+            required_tier: freenet_aft_interface::Tier::Min10,
+            max_age_secs: freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
+            verified: true,
+        });
         User {
             logged: false,
             identified: true,
@@ -2243,6 +2254,10 @@ fn ComposeSheet() -> Element {
     let mut title = use_signal(|| initial_subj.clone());
     let mut content = use_signal(|| initial_body.clone());
     let draft_id = use_signal(|| initial_draft_id.clone());
+    // Autocomplete state: index of the highlighted suggestion (-1 = none).
+    let mut ac_highlighted: Signal<i32> = use_signal(|| -1i32);
+    // Whether the autocomplete dropdown is open. Cleared by Escape or selection.
+    let mut ac_open: Signal<bool> = use_signal(|| true);
     // Monotonic token bumped by every keystroke. The debounced delegate save
     // captures the token at scheduling time and only fires the wire call if
     // it still matches when the timer elapses — older keystrokes are silently
@@ -2299,6 +2314,17 @@ fn ComposeSheet() -> Element {
     });
 
     let recipient_lookup = use_memo(move || address_book::lookup(&to.read()));
+
+    // Autocomplete suggestions: case-insensitive substring over all contacts.
+    // Empty when input is blank or exactly matches a known alias.
+    let ac_suggestions = use_memo(move || {
+        let needle = to.read().clone();
+        // Exact match → no suggestions (user already resolved the contact).
+        if needle.is_empty() || address_book::lookup(&needle).is_some() {
+            return vec![];
+        }
+        address_book::filter_contacts(&needle, 8)
+    });
 
     let alias = user_alias.clone();
     let alias_for_delete = user_alias.clone();
@@ -2533,14 +2559,111 @@ fn ComposeSheet() -> Element {
                         }
                     }
                 }
-                div { class: "sheet-field",
+                div { class: "sheet-field compose-autocomplete-wrap",
                     span { class: "field-lbl", "To" }
                     input {
                         class: "field-input",
                         r#type: "text",
                         placeholder: "alias or address",
                         value: "{to}",
-                        oninput: move |ev| { to.set(ev.value()); autosave(()); },
+                        oninput: move |ev| {
+                            to.set(ev.value());
+                            ac_highlighted.set(-1);
+                            ac_open.set(true);
+                            autosave(());
+                        },
+                        onkeydown: move |ev| {
+                            let suggestions = ac_suggestions.read();
+                            let len = suggestions.len() as i32;
+                            // Always intercept Escape even when no suggestions are visible.
+                            if ev.key() == Key::Escape {
+                                ac_open.set(false);
+                                ac_highlighted.set(-1);
+                                return;
+                            }
+                            if len == 0 || !*ac_open.read() {
+                                return;
+                            }
+                            match ev.key() {
+                                Key::ArrowDown => {
+                                    let next = (*ac_highlighted.read() + 1).min(len - 1);
+                                    ac_highlighted.set(next);
+                                }
+                                Key::ArrowUp => {
+                                    let prev = (*ac_highlighted.read() - 1).max(-1);
+                                    ac_highlighted.set(prev);
+                                }
+                                Key::Enter => {
+                                    let idx = *ac_highlighted.read();
+                                    if idx >= 0 && idx < len {
+                                        let alias = suggestions[idx as usize].local_alias.to_string();
+                                        to.set(alias);
+                                        ac_highlighted.set(-1);
+                                        ac_open.set(false);
+                                        autosave(());
+                                    }
+                                }
+                                _ => {}
+                            }
+                        },
+                        // Dismiss on blur — small delay so mousedown on an item fires first.
+                        onblur: move |_| {
+                            spawn(async move {
+                                gloo_timers::future::TimeoutFuture::new(150).await;
+                                ac_open.set(false);
+                                ac_highlighted.set(-1);
+                            });
+                        },
+                        onfocus: move |_| { ac_open.set(true); },
+                    }
+                    // Dropdown — rendered inside the same relative wrapper.
+                    {
+                        let suggestions = ac_suggestions.read().clone();
+                        let highlighted = *ac_highlighted.read();
+                        let open = *ac_open.read();
+                        if open && !suggestions.is_empty() {
+                            rsx! {
+                                div {
+                                    class: "compose-autocomplete",
+                                    "data-testid": testid::FM_COMPOSE_AUTOCOMPLETE,
+                                    for (idx, contact) in suggestions.iter().enumerate() {
+                                        {
+                                            let alias = contact.local_alias.to_string();
+                                            let alias_fill = alias.clone();
+                                            let fp_short = contact.fingerprint_short();
+                                            let (trust_class, trust_label) = if contact.verified {
+                                                ("known", "✓")
+                                            } else {
+                                                ("unknown", "⚠")
+                                            };
+                                            let item_class = if highlighted == idx as i32 {
+                                                "compose-ac-item highlighted"
+                                            } else {
+                                                "compose-ac-item"
+                                            };
+                                            rsx! {
+                                                div {
+                                                    key: "{alias}",
+                                                    class: "{item_class}",
+                                                    "data-testid": testid::FM_COMPOSE_AUTOCOMPLETE_ITEM,
+                                                    onmousedown: move |_| {
+                                                        to.set(alias_fill.clone());
+                                                        ac_highlighted.set(-1);
+                                                        ac_open.set(false);
+                                                        autosave(());
+                                                    },
+                                                    span { class: "compose-ac-alias", "{alias}" }
+                                                    span { class: "compose-ac-trust {trust_class}", "{trust_label}" }
+                                                    span { class: "compose-ac-fp", "{fp_short}" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            rsx! {}
+                        }
                     }
                 }
                 {

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -157,7 +157,7 @@ impl ContactCard {
 // ── Storage types ─────────────────────────────────────────────────────────────
 
 /// A contact whose public keys were imported via a `ContactCard`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Contact {
     pub local_alias: Rc<str>,
     pub description: String,
@@ -359,6 +359,30 @@ pub fn all_contacts() -> Vec<Contact> {
         contacts.sort_by(|a, b| a.local_alias.cmp(&b.local_alias));
         contacts
     })
+}
+
+/// Filter contacts by a case-insensitive substring needle.
+///
+/// Match priority: `local_alias` first, then `description`, then
+/// `fingerprint_short`. Returns up to `limit` matches, sorted by alias.
+/// Used by the compose-sheet autocomplete dropdown.
+///
+/// Returns an empty `Vec` when `needle` is empty so callers never show
+/// the dropdown on a blank To field.
+pub fn filter_contacts(needle: &str, limit: usize) -> Vec<Contact> {
+    if needle.is_empty() {
+        return vec![];
+    }
+    let needle_lc = needle.to_lowercase();
+    all_contacts()
+        .into_iter()
+        .filter(|c| {
+            c.local_alias.to_lowercase().contains(&needle_lc)
+                || c.description.to_lowercase().contains(&needle_lc)
+                || c.fingerprint_short().to_lowercase().contains(&needle_lc)
+        })
+        .take(limit)
+        .collect()
 }
 
 /// Look up a contact by ML-DSA verifying key (#51 — sender trust). Returns
@@ -625,6 +649,58 @@ mod tests {
         assert!(lookup("eve").is_some());
         remove_contact("eve");
         assert!(lookup("eve").is_none());
+    }
+
+    #[test]
+    fn filter_contacts_empty_needle_returns_nothing() {
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        insert_contact(make_contact("alice", 1, 2)).unwrap();
+        assert!(
+            filter_contacts("", 8).is_empty(),
+            "blank needle must return []"
+        );
+    }
+
+    #[test]
+    fn filter_contacts_case_insensitive_alias_substring() {
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        insert_contact(make_contact("Alice", 1, 2)).unwrap();
+        insert_contact(make_contact("bob", 3, 4)).unwrap();
+        insert_contact(make_contact("alice-work", 5, 6)).unwrap();
+
+        // "ali" should match "Alice" and "alice-work", not "bob".
+        let mut results = filter_contacts("ali", 8);
+        results.sort_by(|a, b| a.local_alias.cmp(&b.local_alias));
+        assert_eq!(results.len(), 2, "expected 2 matches for 'ali'");
+        assert_eq!(&*results[0].local_alias, "Alice");
+        assert_eq!(&*results[1].local_alias, "alice-work");
+
+        // Case-insensitive: "ALI" should also match both.
+        let upper = filter_contacts("ALI", 8);
+        assert_eq!(upper.len(), 2, "case-insensitive match for 'ALI'");
+    }
+
+    #[test]
+    fn filter_contacts_matches_description() {
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        let mut c = make_contact("carol", 7, 8);
+        c.description = "work colleague".into();
+        insert_contact(c).unwrap();
+
+        let results = filter_contacts("colleague", 8);
+        assert_eq!(results.len(), 1);
+        assert_eq!(&*results[0].local_alias, "carol");
+    }
+
+    #[test]
+    fn filter_contacts_respects_limit() {
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        for i in 0..10u8 {
+            insert_contact(make_contact(&format!("user{i}"), i, i.wrapping_add(1))).unwrap();
+        }
+        // "user" matches all 10, but limit=3 caps the result.
+        let results = filter_contacts("user", 3);
+        assert_eq!(results.len(), 3);
     }
 
     #[test]

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -64,6 +64,8 @@ pub(crate) const FM_ARCHIVE_REPLY: &str = "fm-archive-reply";
 pub(crate) const FM_COMPOSE_SHEET: &str = "fm-compose-sheet";
 pub(crate) const FM_SEND: &str = "fm-send";
 pub(crate) const FM_COMPOSE_RECIPIENT_HINT: &str = "fm-compose-recipient-hint";
+pub(crate) const FM_COMPOSE_AUTOCOMPLETE: &str = "fm-compose-autocomplete";
+pub(crate) const FM_COMPOSE_AUTOCOMPLETE_ITEM: &str = "fm-compose-autocomplete-item";
 
 // Toast
 pub(crate) const FM_TOAST: &str = "fm-toast";
@@ -151,6 +153,11 @@ mod tests {
             ("fmComposeSheet", super::FM_COMPOSE_SHEET),
             ("fmSend", super::FM_SEND),
             ("fmComposeRecipientHint", super::FM_COMPOSE_RECIPIENT_HINT),
+            ("fmComposeAutocomplete", super::FM_COMPOSE_AUTOCOMPLETE),
+            (
+                "fmComposeAutocompleteItem",
+                super::FM_COMPOSE_AUTOCOMPLETE_ITEM,
+            ),
             ("fmToast", super::FM_TOAST),
             ("fmActionCreate", super::FM_ACTION_CREATE),
             ("fmActionImport", super::FM_ACTION_IMPORT),

--- a/ui/tests/compose-autocomplete.spec.ts
+++ b/ui/tests/compose-autocomplete.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Playwright tests for compose-sheet To-field autocomplete (#132).
+ *
+ * Requires the dev server running with example-data + no-sync:
+ *   cd ui && dx serve --port 8092 --features example-data,no-sync --no-default-features
+ *
+ * The `alice-example` contact is seeded by the example-data feature flag in
+ * User::new() so these tests work without any manual import steps.
+ */
+
+import { test, expect, Page } from "@playwright/test";
+import { APP_NAME } from "./app-name";
+import { TID } from "./testids";
+
+async function waitForApp(page: Page) {
+  await page
+    .locator('.brand-name, [data-testid="fm-app"]')
+    .first()
+    .waitFor({ timeout: 60_000 });
+  await expect(page.locator(".brand-name").first()).toContainText(APP_NAME);
+}
+
+async function selectIdentity(page: Page, alias: string) {
+  await page
+    .locator(
+      `[data-testid="${TID.fmIdRow}"][data-alias="${alias}"] [data-testid="${TID.fmIdOpen}"]`,
+    )
+    .click();
+  await page.locator(`[data-testid="${TID.fmApp}"]`).waitFor({ timeout: 10_000 });
+}
+
+async function openCompose(page: Page) {
+  await page.locator(`[data-testid="${TID.fmComposeBtn}"]`).click();
+  await page
+    .locator(`[data-testid="${TID.fmComposeSheet}"]`)
+    .waitFor({ timeout: 5_000 });
+}
+
+test.describe("Compose To-field autocomplete (#132)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+    await openCompose(page);
+  });
+
+  test("dropdown appears when typing a matching substring", async ({ page }) => {
+    const sheet = page.locator(`[data-testid="${TID.fmComposeSheet}"]`);
+    const toInput = sheet.locator('input[placeholder="alias or address"]');
+
+    // "alice" should match the seeded "alice-example" contact.
+    await toInput.fill("alice");
+
+    const dropdown = sheet.locator(
+      `[data-testid="${TID.fmComposeAutocomplete}"]`,
+    );
+    await expect(dropdown).toBeVisible({ timeout: 3_000 });
+
+    const items = dropdown.locator(
+      `[data-testid="${TID.fmComposeAutocompleteItem}"]`,
+    );
+    await expect(items).toHaveCount(1);
+    await expect(items.first()).toContainText("alice-example");
+  });
+
+  test("no dropdown on empty To field", async ({ page }) => {
+    const sheet = page.locator(`[data-testid="${TID.fmComposeSheet}"]`);
+    const dropdown = sheet.locator(
+      `[data-testid="${TID.fmComposeAutocomplete}"]`,
+    );
+
+    // Field starts empty — dropdown should not be present.
+    await expect(dropdown).toHaveCount(0);
+  });
+
+  test("no dropdown when input exactly matches an alias", async ({ page }) => {
+    const sheet = page.locator(`[data-testid="${TID.fmComposeSheet}"]`);
+    const toInput = sheet.locator('input[placeholder="alias or address"]');
+
+    // Exact match — no autocomplete needed.
+    await toInput.fill("alice-example");
+
+    const dropdown = sheet.locator(
+      `[data-testid="${TID.fmComposeAutocomplete}"]`,
+    );
+    await expect(dropdown).toHaveCount(0);
+  });
+
+  test("clicking a suggestion fills the To field and hides the dropdown", async ({
+    page,
+  }) => {
+    const sheet = page.locator(`[data-testid="${TID.fmComposeSheet}"]`);
+    const toInput = sheet.locator('input[placeholder="alias or address"]');
+
+    await toInput.fill("alice");
+
+    const dropdown = sheet.locator(
+      `[data-testid="${TID.fmComposeAutocomplete}"]`,
+    );
+    await expect(dropdown).toBeVisible();
+
+    // Click the suggestion.
+    await dropdown
+      .locator(`[data-testid="${TID.fmComposeAutocompleteItem}"]`)
+      .first()
+      .click();
+
+    // The input must now hold the alias.
+    await expect(toInput).toHaveValue("alice-example");
+
+    // Dropdown should be gone.
+    await expect(dropdown).toHaveCount(0);
+  });
+
+  test("keyboard ArrowDown + Enter selects suggestion", async ({ page }) => {
+    const sheet = page.locator(`[data-testid="${TID.fmComposeSheet}"]`);
+    const toInput = sheet.locator('input[placeholder="alias or address"]');
+
+    await toInput.fill("alice");
+
+    const dropdown = sheet.locator(
+      `[data-testid="${TID.fmComposeAutocomplete}"]`,
+    );
+    await expect(dropdown).toBeVisible();
+
+    // Arrow-down to highlight first item, then Enter to pick it.
+    await toInput.press("ArrowDown");
+    await toInput.press("Enter");
+
+    await expect(toInput).toHaveValue("alice-example");
+    await expect(dropdown).toHaveCount(0);
+  });
+
+  test("Escape key dismisses dropdown without changing the input", async ({
+    page,
+  }) => {
+    const sheet = page.locator(`[data-testid="${TID.fmComposeSheet}"]`);
+    const toInput = sheet.locator('input[placeholder="alias or address"]');
+
+    await toInput.fill("alice");
+
+    const dropdown = sheet.locator(
+      `[data-testid="${TID.fmComposeAutocomplete}"]`,
+    );
+    await expect(dropdown).toBeVisible();
+
+    await toInput.press("Escape");
+
+    // Dropdown gone; original text preserved.
+    await expect(dropdown).toHaveCount(0);
+    await expect(toInput).toHaveValue("alice");
+  });
+
+  test("suggestion shows verified badge", async ({ page }) => {
+    const sheet = page.locator(`[data-testid="${TID.fmComposeSheet}"]`);
+    const toInput = sheet.locator('input[placeholder="alias or address"]');
+
+    await toInput.fill("alice");
+
+    const dropdown = sheet.locator(
+      `[data-testid="${TID.fmComposeAutocomplete}"]`,
+    );
+    await expect(dropdown).toBeVisible();
+
+    // alice-example is seeded as verified=true, so the ✓ badge should appear.
+    const item = dropdown
+      .locator(`[data-testid="${TID.fmComposeAutocompleteItem}"]`)
+      .first();
+    await expect(item.locator(".compose-ac-trust.known")).toBeVisible();
+  });
+});

--- a/ui/tests/testids.ts
+++ b/ui/tests/testids.ts
@@ -35,6 +35,8 @@ interface TestIds {
   fmArchiveUnarchive: string;
   fmComposeSheet: string;
   fmSend: string;
+  fmComposeAutocomplete: string;
+  fmComposeAutocompleteItem: string;
   fmToast: string;
   fmActionCreate: string;
   fmActionImport: string;


### PR DESCRIPTION
## Summary

- Adds a dropdown under the compose-sheet **To** field that filters contacts by case-insensitive substring as the user types.
- Uses `address_book::filter_contacts(needle, limit)` (new shared helper); matches `local_alias`, `description`, and `fingerprint_short` in that priority order, up to 8 results.
- Each suggestion row shows: **bold alias** · trust badge (✓ verified / ⚠ unverified) · short fingerprint in grey.
- Dropdown hides when input is blank, exactly matches a known alias, or is explicitly dismissed.

## UX

| Gesture | Effect |
|---------|--------|
| Type 1+ chars | Dropdown appears with matches |
| ↑ / ↓ | Move highlighted row |
| Enter | Fill To field with highlighted alias, close dropdown |
| Escape | Dismiss dropdown, preserve typed text |
| Click item | Fill To field, close dropdown |
| Blur (click outside) | Dropdown dismissed after 150 ms delay (so item clicks land first) |
| Re-focus | Dropdown re-opens if suggestions exist |

The existing `recipient_lookup` badge (`verified` / `unverified` / `you`) continues to render below the To field as before — autocomplete just speeds up entry.

## Changes

- `ui/src/app/address_book.rs` — `filter_contacts()` helper; `Contact` derives `PartialEq`; 4 new unit tests.
- `ui/src/app.rs` — `ComposeSheet`: `ac_highlighted`, `ac_open` signals; `ac_suggestions` memo; keyboard/mouse/blur/focus handlers; dropdown RSX; seeds `alice-example` contact in example-data mode for Playwright.
- `ui/public/vendor/css/components/compose.css` — `.compose-autocomplete`, `.compose-ac-item`, `.compose-ac-alias`, `.compose-ac-trust`, `.compose-ac-fp` inside `@scope (.fm-app)`.
- `ui/src/testid.rs` + `ui/branding/testids.json` + `ui/tests/testids.ts` — two new testids (`fmComposeAutocomplete`, `fmComposeAutocompleteItem`); `json_matches_rust_consts` test passes (56/56).
- `ui/tests/compose-autocomplete.spec.ts` — 6 Playwright tests covering appear/absent/click/keyboard/Escape/badge.

## Test plan

- [x] `cargo test -p freenet-email-ui --no-default-features` — 56/56 pass (includes `testid::json_matches_rust_consts` and 4 new `filter_contacts` unit tests)
- [x] `cargo clippy --target wasm32-unknown-unknown -p freenet-email-ui --no-default-features --features example-data,no-sync --tests -- -D warnings` — clean
- [ ] `cargo make test-ui-playwright` — runs full suite including new `compose-autocomplete.spec.ts`

Closes #132