### PR TITLE
feat(ui): surface AFT token failures via toast (#151)

### DIFF
--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -3,8 +3,9 @@ use std::{cell::RefCell, collections::HashMap};
 
 use chrono::{DateTime, Utc};
 use freenet_aft_interface::{
-    AllocationCriteria, DelegateParameters, RequestNewToken, Tier, TokenAllocationRecord,
-    TokenAllocationSummary, TokenAssignment, TokenDelegateMessage, TokenDelegateParameters,
+    AllocationCriteria, DelegateParameters, FailureReason, RequestNewToken, Tier,
+    TokenAllocationRecord, TokenAllocationSummary, TokenAssignment, TokenDelegateMessage,
+    TokenDelegateParameters,
 };
 use freenet_stdlib::client_api::{ContractRequest, DelegateRequest};
 use freenet_stdlib::prelude::UpdateData::{Delta, State as StateUpdate};
@@ -485,6 +486,50 @@ impl AftRecords {
     }
 }
 
+/// Build a user-facing toast message for a `FailureReason` returned by
+/// the AFT delegate.  Produces distinct, actionable copy for each variant
+/// so the user knows both why the send failed and what they can do next.
+///
+/// `recipient` is an optional display label for the intended recipient;
+/// when `None` the copy falls back to `"the recipient"`.
+pub(crate) fn format_failure_toast(reason: &FailureReason, recipient: Option<&str>) -> String {
+    let recipient = recipient.unwrap_or("the recipient");
+    match reason {
+        FailureReason::UserPermissionDenied => {
+            "Can't send: the token delegate refused to mint a token. \
+             Check Settings → AFT to approve token allocation."
+                .to_string()
+        }
+        FailureReason::NoFreeSlot { criteria, .. } => {
+            format!(
+                "Can't send: no token available at tier {tier} for {recipient}. \
+                 Check Settings → AFT to mint {tier} tokens, or ask {recipient} \
+                 to relax their policy.",
+                tier = criteria.frequency,
+            )
+        }
+    }
+}
+
+/// Build a user-facing toast message when an in-flight AFT assignment
+/// confirmation timed out (the delegate sent no `confirm_allocation`
+/// within the sweep window).
+pub(crate) fn format_expired_assignment_toast(tier: Tier) -> String {
+    format!(
+        "Can't send: the {tier} token assignment timed out. \
+         Your tokens may have expired — mint new ones in Settings → AFT."
+    )
+}
+
+/// Build a user-facing toast message when no AFT token record has been
+/// loaded for the sender yet (the record contract was not yet fetched
+/// from the node when send was attempted).
+pub(crate) fn format_no_record_toast() -> String {
+    "Can't send: your token record hasn't loaded yet. \
+     Wait a moment and try again, or check Settings → AFT."
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -573,6 +618,57 @@ mod tests {
         let leftover_updates = PENDING_INBOXES_UPDATES.with(|q| q.borrow().len());
         assert_eq!(leftover_pending, 0, "PENDING_TOKEN_ASSIGNMENT not cleared");
         assert_eq!(leftover_updates, 0, "PENDING_INBOXES_UPDATES not cleared");
+    }
+
+    /// `format_failure_toast` produces distinct copy for each variant.
+    #[test]
+    fn format_failure_toast_user_permission_denied() {
+        let msg = format_failure_toast(&FailureReason::UserPermissionDenied, None);
+        assert!(
+            msg.contains("refused to mint"),
+            "expected 'refused to mint' in: {msg}"
+        );
+        assert!(
+            msg.contains("Settings → AFT"),
+            "expected settings hint in: {msg}"
+        );
+    }
+
+    #[test]
+    fn format_failure_toast_no_free_slot_includes_tier_and_recipient() {
+        let token_record = fake_token_record();
+        let criteria = AllocationCriteria::new(
+            Tier::Min10,
+            std::time::Duration::from_secs(3600),
+            token_record,
+        )
+        .expect("valid criteria");
+        let delegate_id = freenet_stdlib::prelude::SecretsId::new(vec![0u8; 32]);
+        let reason = FailureReason::NoFreeSlot {
+            delegate_id,
+            criteria,
+        };
+        let msg = format_failure_toast(&reason, Some("alice"));
+        assert!(msg.contains("min10"), "expected tier name in: {msg}");
+        assert!(msg.contains("alice"), "expected recipient in: {msg}");
+        assert!(
+            msg.contains("Settings → AFT"),
+            "expected settings hint in: {msg}"
+        );
+    }
+
+    #[test]
+    fn format_expired_assignment_toast_includes_tier() {
+        let msg = format_expired_assignment_toast(Tier::Day1);
+        assert!(msg.contains("day1"), "expected tier in: {msg}");
+        assert!(msg.contains("Settings → AFT"), "expected hint in: {msg}");
+    }
+
+    #[test]
+    fn format_no_record_toast_is_nonempty() {
+        let msg = format_no_record_toast();
+        assert!(!msg.is_empty());
+        assert!(msg.contains("token record"), "expected context in: {msg}");
     }
 
     /// Drain on an unknown delegate must be a no-op (returns empty,

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -691,6 +691,7 @@ pub(crate) async fn node_comms(
     user: Signal<crate::app::User>,
     inboxes: crate::app::InboxesData,
     ab_gen: crate::app::AddressBookGen,
+    mut toast: Signal<Option<String>>,
 ) {
     // todo don't unwrap inside this function, propagate errors to the UI somehow
     use freenet_email_inbox::Inbox as StoredInbox;
@@ -1007,6 +1008,7 @@ pub(crate) async fn node_comms(
         mut login_controller: dioxus::prelude::Signal<crate::app::LoginController>,
         user: Signal<crate::app::User>,
         mut ab_gen: crate::app::AddressBookGen,
+        mut toast: Signal<Option<String>>,
     ) {
         let mut client = WEB_API_SENDER.get().unwrap().clone();
         let res = match res {
@@ -1595,6 +1597,8 @@ pub(crate) async fn node_comms(
                                         format!("token assignment failure: {reason}"),
                                         Some(TryNodeAction::SendMessage),
                                     );
+                                    toast
+                                        .set(Some(crate::aft::format_failure_toast(&reason, None)));
                                     let drained = AftRecords::drain_pending_for_delegate(&key);
                                     for (inbox_key, _hash) in drained {
                                         crate::inbox::fail_pending_sent_for_inbox(
@@ -1653,6 +1657,7 @@ pub(crate) async fn node_comms(
                     login_controller,
                     user,
                     ab_gen,
+                    toast,
                 )
                 .await;
             }
@@ -1676,7 +1681,25 @@ pub(crate) async fn node_comms(
             }
             error = api.client_errors.next() => {
                 match error {
-                    Some(Err((msg, action))) => crate::log::error(format!("{msg}"), Some(action)),
+                    Some(Err((msg, action))) => {
+                        crate::log::error(format!("{msg}"), Some(action.clone()));
+                        // Surface send failures to the user. A "no token
+                        // record loaded" error from `assign_token` lands here
+                        // via the `start_sending` async future. We detect the
+                        // pattern by action rather than by parsing the message
+                        // string to keep the check stable across refactors.
+                        if matches!(action, TryNodeAction::SendMessage) {
+                            let msg_str = msg.to_string();
+                            let user_msg = if msg_str.contains("failed to get token record") {
+                                crate::aft::format_no_record_toast()
+                            } else {
+                                format!(
+                                    "Can't send: {msg_str}. Check Settings → AFT or try again."
+                                )
+                            };
+                            toast.set(Some(user_msg));
+                        }
+                    }
                     Some(Ok(_)) => {}
                     None => panic!("error ch closed"),
                 }
@@ -1700,6 +1723,9 @@ pub(crate) async fn node_comms(
                         ),
                         Some(TryNodeAction::SendMessage),
                     );
+                    toast.set(Some(
+                        crate::aft::format_expired_assignment_toast(assignment.tier),
+                    ));
                 }
             }
         }

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -126,13 +126,18 @@ pub(crate) fn app() -> Element {
     // `.read()` re-render and pick up the updated verification state.
     use_context_provider(|| AddressBookGen(Signal::new(0u32)));
     let ab_gen = use_context::<AddressBookGen>();
+    // Toast signal is provided at the root so both the node-comms coroutine
+    // (which surfaces async AFT failures) and all UI components can write/read
+    // it without an extra Signal thread-local.
+    use_context_provider(|| Signal::new(Option::<String>::None));
+    let toast = use_context::<Signal<Option<String>>>();
 
     #[cfg(all(feature = "use-node", not(feature = "no-sync")))]
     {
         let _sync: Coroutine<NodeAction> = use_coroutine(move |rx| {
             let login_controller = login_controller;
             let user = user;
-            let fut = crate::api::node_comms(rx, login_controller, user, inbox_data, ab_gen)
+            let fut = crate::api::node_comms(rx, login_controller, user, inbox_data, ab_gen, toast)
                 .map(|_| Ok(JsValue::NULL));
             let _ = wasm_bindgen_futures::future_to_promise(fut);
             async {}.boxed_local()
@@ -141,6 +146,7 @@ pub(crate) fn app() -> Element {
     #[cfg(any(not(feature = "use-node"), feature = "no-sync"))]
     {
         let _ = inbox_data;
+        let _ = toast;
         let mut login_ctl = login_controller;
         let mut ab_gen = ab_gen;
         let _sync: Coroutine<NodeAction> =
@@ -1044,7 +1050,8 @@ fn matches_search(m: &Message, q: &str) -> bool {
 #[allow(non_snake_case)]
 fn UserInbox() -> Element {
     use_context_provider(|| Signal::new(menu::MenuSelection::default()));
-    use_context_provider(|| Signal::new(Option::<String>::None));
+    // Toast signal is provided by app() at the root; UserInbox uses it via
+    // use_context. No re-provide here.
     // SettingsShell.AccountIdentity reads `Signal<ImportBackup>` to drive
     // its Restore action through the same modal as the login pane. The
     // login flow also provides this; we re-provide here so Settings can
@@ -2518,7 +2525,15 @@ fn ComposeSheet() -> Element {
                 true
             }
             Err(e) => {
-                crate::log::error(format!("{e}"), Some(TryNodeAction::SendMessage));
+                let msg = e.to_string();
+                crate::log::error(msg.clone(), Some(TryNodeAction::SendMessage));
+                let user_msg = if msg.contains("failed to get token record") {
+                    crate::aft::format_no_record_toast()
+                } else {
+                    format!("Can't send: {msg}. Check Settings → AFT or try again.")
+                };
+                toast.set(Some(user_msg));
+                spawn_toast_clear();
                 false
             }
         };


### PR DESCRIPTION
## Summary

Surfaces all AFT token-related send failures as user-actionable toast messages instead of silent console errors.

## Failure modes covered

| Mode | User-facing copy |
|------|-----------------|
| **No tokens / no token record loaded** | "Can't send: your token record hasn't loaded yet. Wait a moment and try again, or check Settings → AFT." |
| **Wrong tier (NoFreeSlot)** | "Can't send: no token available at tier `<T>` for `<recipient>`. Check Settings → AFT to mint `<T>` tokens, or ask `<recipient>` to relax their policy." |
| **Mint failed (UserPermissionDenied)** | "Can't send: the token delegate refused to mint a token. Check Settings → AFT to approve token allocation." |
| **Expired / timed-out assignment** | "Can't send: the `<tier>` token assignment timed out. Your tokens may have expired — mint new ones in Settings → AFT." |

## Implementation

- `ui/src/aft.rs`: Add `format_failure_toast`, `format_expired_assignment_toast`, and `format_no_record_toast` helpers — each with a unit test.
- `ui/src/api.rs`: Thread `toast: Signal<Option<String>>` through `node_comms` → `handle_response`. Set toast in the `Failure(FailureReason)` arm, the `client_errors` arm for `SendMessage` actions, and the `pending_sweep` arm for timed-out assignments.
- `ui/src/app.rs`: Move toast signal provision from `UserInbox` to `app()` root so the node-comms coroutine can write to it. Set toast + call `spawn_toast_clear()` in the synchronous `send_message` error arm. Add `role="status" aria-live="polite"` to `ToastView` for screen-reader accessibility.

## Test plan

- [x] All 56 existing unit tests pass
- [x] 4 new unit tests for the format helpers pass
- [x] `cargo clippy --target wasm32-unknown-unknown -p freenet-email-ui --no-default-features --features example-data,no-sync --tests -- -D warnings` is clean
- [ ] Manual: spin up `cargo make dev-example` and verify compose/send still works with mock data
- [ ] Manual (use-node): trigger a NoFreeSlot failure by setting recipient `minimum_tier` higher than sender's available tokens; confirm toast appears and auto-dismisses

Closes #151