### PR TITLE
fix(ui): provide contact-form contexts at inbox root (#131)

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1057,6 +1057,13 @@ fn UserInbox() -> Element {
     // login flow also provides this; we re-provide here so Settings can
     // be opened from inside the inbox without the login pane in scope.
     use_context_provider(|| Signal::new(crate::app::login::ImportBackup(false)));
+    // ScrContacts (Settings → Contacts) reads these three signals to drive
+    // its Import / Share buttons. Login pane also provides them; re-provide
+    // here so opening Settings → Contacts from the sidebar (#131) doesn't
+    // panic with "Could not find context".
+    use_context_provider(|| Signal::new(crate::app::login::ImportContact(false)));
+    use_context_provider(|| Signal::new(crate::app::login::ShareContact(false)));
+    use_context_provider(|| Signal::new(crate::app::login::SharePending::default()));
 
     let menu_selection = use_context::<Signal<menu::MenuSelection>>();
     let settings_open = menu_selection.read().settings().is_some();


### PR DESCRIPTION
## Summary

Sidebar **Contacts** button (and Settings gear → Contacts) panicked with:

> Could not find context `dioxus_signals::signal::Signal<ImportContact>`

The panic tore down the whole tree, manifesting as an apparent UI freeze (no further events processed). Reproduced via Playwright + dx serve in dev-example mode.

## Root cause

`ScrContacts` consumes `Signal<ImportContact>`, `Signal<ShareContact>`, `Signal<SharePending>` for its Import / Share buttons. These three signals are provided in `ui/src/app/login.rs:664-666`, scoped to the login pane.

When Settings is opened from inside the inbox (no login pane mounted), only `ImportBackup` was re-provided at `UserInbox` root. The three contact-form contexts were missing, so `use_context::<…>()` inside `ScrContacts` panicked.

## Fix

Re-provide all three signals at `UserInbox` next to the existing `ImportBackup` provider. Three lines.

## Test plan

- [x] Reproduce in dev-example: open inbox → click sidebar Contacts → panics
- [x] Apply fix → Contacts drawer renders cleanly with the address book
- [x] No regression in login pane (its own providers still in scope)
- [x] cargo clippy clean

Closes #131.