### PR TITLE
fix(ui): lift contact modal signals to app() root — fixes #158

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -68,5 +68,8 @@
 
   "fmContactVerify": "fm-contact-verify",
   "fmVerifyContactModal": "fm-verify-contact-modal",
-  "fmVerifyContactSubmit": "fm-verify-contact-submit"
+  "fmVerifyContactSubmit": "fm-verify-contact-submit",
+
+  "fmContactsImportBtn": "fm-contacts-import-btn",
+  "fmContactsShareBtn": "fm-contacts-share-btn"
 }

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -131,6 +131,15 @@ pub(crate) fn app() -> Element {
     // it without an extra Signal thread-local.
     use_context_provider(|| Signal::new(Option::<String>::None));
     let toast = use_context::<Signal<Option<String>>>();
+    // Modal signals lifted to the root so that both the login pane
+    // (IdentifiersList) and the inbox (UserInbox → Settings → Contacts)
+    // can open these modals. Fixes #158.
+    use_context_provider(|| Signal::new(login::ImportBackup(false)));
+    use_context_provider(|| Signal::new(login::ImportContact(false)));
+    use_context_provider(|| Signal::new(login::ShareContact(false)));
+    use_context_provider(|| Signal::new(login::SharePending::default()));
+    let import_contact = use_context::<Signal<login::ImportContact>>();
+    let share_contact = use_context::<Signal<login::ShareContact>>();
 
     #[cfg(all(feature = "use-node", not(feature = "no-sync")))]
     {
@@ -224,6 +233,15 @@ pub(crate) fn app() -> Element {
     rsx! {
         document::Title { "{app_name}" }
         {body}
+        // Modals are rendered at the root so they are reachable from both
+        // the login pane (IdentifiersList) and the inbox (UserInbox). Their
+        // signals are provided above. (#158)
+        if share_contact.read().0 {
+            login::ShareContactModal {}
+        }
+        if import_contact.read().0 {
+            login::ImportContactForm {}
+        }
     }
 }
 
@@ -1050,20 +1068,10 @@ fn matches_search(m: &Message, q: &str) -> bool {
 #[allow(non_snake_case)]
 fn UserInbox() -> Element {
     use_context_provider(|| Signal::new(menu::MenuSelection::default()));
-    // Toast signal is provided by app() at the root; UserInbox uses it via
-    // use_context. No re-provide here.
-    // SettingsShell.AccountIdentity reads `Signal<ImportBackup>` to drive
-    // its Restore action through the same modal as the login pane. The
-    // login flow also provides this; we re-provide here so Settings can
-    // be opened from inside the inbox without the login pane in scope.
-    use_context_provider(|| Signal::new(crate::app::login::ImportBackup(false)));
-    // ScrContacts (Settings → Contacts) reads these three signals to drive
-    // its Import / Share buttons. Login pane also provides them; re-provide
-    // here so opening Settings → Contacts from the sidebar (#131) doesn't
-    // panic with "Could not find context".
-    use_context_provider(|| Signal::new(crate::app::login::ImportContact(false)));
-    use_context_provider(|| Signal::new(crate::app::login::ShareContact(false)));
-    use_context_provider(|| Signal::new(crate::app::login::SharePending::default()));
+    // ImportBackup / ImportContact / ShareContact / SharePending are all
+    // provided by app() at the root (lifted in #158 fix) so that the modals
+    // are reachable from both the login pane and the inbox view.
+    // No re-provides needed here.
 
     let menu_selection = use_context::<Signal<menu::MenuSelection>>();
     let settings_open = menu_selection.read().settings().is_some();

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -660,10 +660,10 @@ impl LoginController {
 #[allow(non_snake_case)]
 pub(super) fn IdentifiersList() -> Element {
     use_context_provider(|| Signal::new(CreateAlias(false)));
-    use_context_provider(|| Signal::new(ImportBackup(false)));
-    use_context_provider(|| Signal::new(ShareContact(false)));
-    use_context_provider(|| Signal::new(SharePending::default()));
-    use_context_provider(|| Signal::new(ImportContact(false)));
+    // ImportBackup / ShareContact / SharePending / ImportContact are provided
+    // by app() so that the modals are also reachable from UserInbox
+    // (Settings → Contacts / Account). VerifyContactPending is
+    // login-pane-only; provide it here.
     use_context_provider(|| Signal::new(VerifyContactPending::default()));
     // ImportForm is shared between the hub flow (toggled by ImportBackup
     // here) and the first-run flow (toggled by ImportId in
@@ -672,8 +672,6 @@ pub(super) fn IdentifiersList() -> Element {
     use_context_provider(|| Signal::new(ImportId(false)));
     let create_alias_form = use_context::<Signal<CreateAlias>>();
     let import_backup_form = use_context::<Signal<ImportBackup>>();
-    let share_contact_form = use_context::<Signal<ShareContact>>();
-    let import_contact_form = use_context::<Signal<ImportContact>>();
     let verify_contact_pending = use_context::<Signal<VerifyContactPending>>();
 
     rsx! {
@@ -690,12 +688,6 @@ pub(super) fn IdentifiersList() -> Element {
                         ContactsSection {}
                     }
                 }
-            }
-            if share_contact_form.read().0 {
-                ShareContactModal {}
-            }
-            if import_contact_form.read().0 {
-                ImportContactForm {}
             }
             if verify_contact_pending.read().0.is_some() {
                 VerifyContactModal {}
@@ -1453,7 +1445,7 @@ fn copy_to_clipboard(_text: String) {}
 
 /// Modal that displays the shareable ContactCard text and offers a copy button.
 #[allow(non_snake_case)]
-fn ShareContactModal() -> Element {
+pub(super) fn ShareContactModal() -> Element {
     let mut share_contact_form = use_context::<Signal<ShareContact>>();
     let share_pending = use_context::<Signal<SharePending>>();
     let (alias, share_text) = share_pending
@@ -1548,7 +1540,7 @@ fn ShareContactModal() -> Element {
 
 /// Form to import a contact from a pasted ContactCard.
 #[allow(non_snake_case)]
-fn ImportContactForm() -> Element {
+pub(super) fn ImportContactForm() -> Element {
     let mut import_contact_form = use_context::<Signal<ImportContact>>();
     let actions = use_coroutine_handle::<NodeAction>();
 

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -958,11 +958,13 @@ fn ScrContacts() -> Element {
                     }
                     button {
                         class: "fm-btn-secondary",
+                        "data-testid": crate::testid::FM_CONTACTS_IMPORT_BTN,
                         onclick: on_import,
                         "Import…"
                     }
                     button {
                         class: "fm-btn-primary",
+                        "data-testid": crate::testid::FM_CONTACTS_SHARE_BTN,
                         onclick: on_share,
                         "Share my card"
                     }

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -103,6 +103,10 @@ pub(crate) const FM_CONTACT_VERIFY: &str = "fm-contact-verify";
 pub(crate) const FM_VERIFY_CONTACT_MODAL: &str = "fm-verify-contact-modal";
 pub(crate) const FM_VERIFY_CONTACT_SUBMIT: &str = "fm-verify-contact-submit";
 
+// Contacts settings screen — Import… / Share my card buttons (inbox-side triggers for #158)
+pub(crate) const FM_CONTACTS_IMPORT_BTN: &str = "fm-contacts-import-btn";
+pub(crate) const FM_CONTACTS_SHARE_BTN: &str = "fm-contacts-share-btn";
+
 // Settings
 pub(crate) const FM_SETTINGS_BTN: &str = "fm-settings-btn";
 pub(crate) const FM_SETTINGS_SHELL: &str = "fm-settings-shell";
@@ -191,6 +195,8 @@ mod tests {
             ("fmContactVerify", super::FM_CONTACT_VERIFY),
             ("fmVerifyContactModal", super::FM_VERIFY_CONTACT_MODAL),
             ("fmVerifyContactSubmit", super::FM_VERIFY_CONTACT_SUBMIT),
+            ("fmContactsImportBtn", super::FM_CONTACTS_IMPORT_BTN),
+            ("fmContactsShareBtn", super::FM_CONTACTS_SHARE_BTN),
         ];
         assert_eq!(
             json.len(),

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -1443,3 +1443,105 @@ test.describe("ContactCard #85 — recipient anti-flood policy", () => {
     await expect(page.locator('[data-testid="fm-import-fp"]')).toHaveCount(0);
   });
 });
+
+// ── Regression: #158 — contact modals dead inside inbox ──────────────────────
+//
+// Before the fix the ImportContact / ShareContact / SharePending signals were
+// provided only by the login pane (IdentifiersList). Once the user logged in
+// the login pane unmounted, taking the signal providers with it.  Any attempt
+// to open a modal from Settings → Contacts inside the inbox would silently
+// no-op because `use_context` found no provider.
+//
+// The fix lifts the three signals to the app() root so they survive the
+// login → inbox transition.  These tests guard the regression path:
+//   1. enter the inbox (signals survive the mount transition)
+//   2. open Settings → Contacts via the sidebar button
+//   3. click Import… → ImportContactForm modal must appear
+//   4. close modal, click Share my card → ShareContactModal must appear
+//
+// A separate pair of tests confirms the same modals still open from the
+// pre-login screen (IdentifiersList) so we don't regress the original flow.
+test.describe("Regression #158: contact modals mount inside inbox", () => {
+  test("Import… button inside inbox opens ImportContactForm modal", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    // Open Settings → Contacts via the sidebar button.
+    await page.locator('[data-testid="fm-sidebar-contacts"]').click();
+    await page.locator('[data-testid="fm-settings-shell"]').waitFor({ timeout: 5_000 });
+
+    // Click the Import… button that lives inside the Contacts settings screen.
+    await page.locator('[data-testid="fm-contacts-import-btn"]').click();
+
+    // The modal must appear — before the fix this was a silent no-op.
+    const importModal = page.locator('[data-testid="fm-import-contact-modal"]');
+    await expect(importModal).toBeVisible({ timeout: 5_000 });
+
+    // Dismiss via the modal's close button.
+    await importModal.locator(".modal-x").click();
+    await expect(importModal).toHaveCount(0, { timeout: 3_000 });
+  });
+
+  test("Share my card button inside inbox opens ShareContactModal", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    // Open Settings → Contacts via the sidebar button.
+    await page.locator('[data-testid="fm-sidebar-contacts"]').click();
+    await page.locator('[data-testid="fm-settings-shell"]').waitFor({ timeout: 5_000 });
+
+    // Click the Share my card button inside the Contacts settings screen.
+    await page.locator('[data-testid="fm-contacts-share-btn"]').click();
+
+    // The modal must appear — before the fix this was a silent no-op.
+    const shareModal = page.locator('[data-testid="fm-share-modal"]');
+    await expect(shareModal).toBeVisible({ timeout: 5_000 });
+
+    // Share modal should contain the contact:// token for the active identity.
+    await expect(shareModal.locator(".token-block")).toContainText("contact://");
+
+    // Dismiss.
+    await shareModal.locator(".modal-x").click();
+    await expect(shareModal).toHaveCount(0, { timeout: 3_000 });
+  });
+
+  // Confirm the pre-login flows that triggered these modals from the
+  // identity list are still intact after the signal lift.
+  test("Import… button on login pane still opens ImportContactForm modal", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    // Pre-login: fm-contact-import is the import trigger on the identity list.
+    await page.locator('[data-testid="fm-contact-import"]').click();
+    const importModal = page.locator('[data-testid="fm-import-contact-modal"]');
+    await expect(importModal).toBeVisible({ timeout: 5_000 });
+
+    await importModal.locator(".modal-x").click();
+    await expect(importModal).toHaveCount(0, { timeout: 3_000 });
+  });
+
+  test("Share button on identity row still opens ShareContactModal", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    // Pre-login: fm-id-share on an identity row triggers the share modal.
+    await page
+      .locator('[data-testid="fm-id-row"][data-alias="address1"] [data-testid="fm-id-share"]')
+      .click();
+    const shareModal = page.locator('[data-testid="fm-share-modal"]');
+    await expect(shareModal).toBeVisible({ timeout: 5_000 });
+
+    await shareModal.locator(".modal-x").click();
+    await expect(shareModal).toHaveCount(0, { timeout: 3_000 });
+  });
+});

--- a/ui/tests/testids.ts
+++ b/ui/tests/testids.ts
@@ -64,6 +64,8 @@ interface TestIds {
   fmContactVerify: string;
   fmVerifyContactModal: string;
   fmVerifyContactSubmit: string;
+  fmContactsImportBtn: string;
+  fmContactsShareBtn: string;
 }
 
 export const TID: TestIds = JSON.parse(


### PR DESCRIPTION
## Root cause

PR #156 fixed the \"Could not find context\" panic from #131 by
re-providing `Signal<ImportContact>` / `Signal<ShareContact>` /
`Signal<SharePending>` inside `UserInbox`. But the two modals they
drive — `ImportContactForm` and `ShareContactModal` — were only
**mounted** in `IdentifiersList` (login pane). Clicking
Settings → Contacts → Import (or Share my card) inside the inbox
toggled the signal to `true`, but nothing was rendered.

## Fix — Option B (lift to common ancestor)

Lifted all four signal providers (`ImportBackup`, `ImportContact`,
`ShareContact`, `SharePending`) from both `IdentifiersList` and
`UserInbox` to `app()`, the common ancestor of both views.

Mounted `ShareContactModal` and `ImportContactForm` at the `app()`
level (conditionally on their signals, same pattern as before).
Made the two modal functions `pub(super)` so `app.rs` can call them.

`VerifyContactPending` / `VerifyContactModal` were intentionally
**not** lifted — they are only triggered from the contacts table in
`IdentifiersList` and have no settings-panel entry point.

## Signals lifted

| Signal | Consumer | Was provided in | Now provided in |
|---|---|---|---|
| `ImportBackup` | `ScrAccountIdentity` (Restore) | `UserInbox` (re-provide) | `app()` |
| `ImportContact` | `ScrContacts` (Import) | `IdentifiersList` + `UserInbox` re-provide | `app()` |
| `ShareContact` | `ScrContacts` (Share my card) | `IdentifiersList` + `UserInbox` re-provide | `app()` |
| `SharePending` | `ScrContacts` (Share my card) | `IdentifiersList` + `UserInbox` re-provide | `app()` |

## Audit: `settings.rs` consumers

`grep use_context::<Signal<crate::app::login::` in `settings.rs` returns
four entries, all now covered by the root-level providers above.

One latent bug found but **deferred** (out of scope): the `on_restore`
handler in `ScrAccountIdentity` sets `ImportBackup = true` after closing
settings, but `ImportForm` only renders in the `IdentifiersList` subtree.
A user clicking Restore from inside the inbox would see nothing. This
requires a separate architectural fix (e.g., a dedicated restore-from-inbox
flow or navigation back to the identity list). Filed as a follow-up.

## Verify

```bash
cargo make dev-example   # opens on :8080 by default
# Open inbox → Settings (⚙) → Contacts → Import… → modal opens ✓
# Open inbox → Settings (⚙) → Contacts → Share my card → modal opens ✓
```

Closes #158, partial fix for #131.