### PR TITLE
fix(aft): filter empty tier buckets, fix unwrap_or fallback, explicit Tier Ord (#160)

### DIFF
--- a/modules/antiflood-tokens/interfaces/src/lib.rs
+++ b/modules/antiflood-tokens/interfaces/src/lib.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Display;
 
@@ -94,9 +95,7 @@ pub trait TokenAllocation: DeserializeOwned {
     fn get_criteria(&self) -> AllocationCriteria;
 }
 
-#[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Display, PartialOrd, Ord,
-)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
 #[strum(serialize_all = "lowercase")]
 #[repr(u8)]
 pub enum Tier {
@@ -115,6 +114,25 @@ pub enum Tier {
     Day90,
     Day180,
     Day365,
+}
+
+/// Ordering is by slot duration: cheaper (shorter-period) tiers sort lower.
+/// `Min1 < Min5 < … < Day365`.
+///
+/// This explicit impl replaces the former `#[derive(Ord)]` so that future
+/// contributors reordering variant declarations don't silently break cost
+/// ranking — the ordering is now semantic-bound to `tier_duration()`, not
+/// to declaration order.
+impl Ord for Tier {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.tier_duration().cmp(&other.tier_duration())
+    }
+}
+
+impl PartialOrd for Tier {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl Tier {
@@ -958,6 +976,68 @@ mod tier_tests {
         assert_eq!(day15_normalized, get_date(2023, 1, 30));
         let day15_normalized = day15_tier.normalize_to_next(get_date(2023, 1, 31));
         assert_eq!(day15_normalized, get_date(2023, 2, 14));
+    }
+
+    /// All 15 `Tier` variants must sort in strict ascending slot-duration
+    /// order, i.e. cheaper (shorter-period) tiers are smaller.
+    ///
+    /// This test is the guard that makes the explicit `Ord` impl meaningful:
+    /// if a future contributor adds a variant or changes `tier_duration()`,
+    /// this test will catch any ordering regression before it ships.
+    #[test]
+    fn tier_ord_follows_slot_duration() {
+        // List every variant in the expected cheapest-first order.
+        let expected_order = [
+            Tier::Min1,
+            Tier::Min5,
+            Tier::Min10,
+            Tier::Min30,
+            Tier::Hour1,
+            Tier::Hour3,
+            Tier::Hour6,
+            Tier::Hour12,
+            Tier::Day1,
+            Tier::Day7,
+            Tier::Day15,
+            Tier::Day30,
+            Tier::Day90,
+            Tier::Day180,
+            Tier::Day365,
+        ];
+
+        // Verify strictly ascending: each tier must be strictly less than the next.
+        for window in expected_order.windows(2) {
+            let (a, b) = (window[0], window[1]);
+            assert!(
+                a < b,
+                "expected {a:?} < {b:?} by slot duration, but ordering was {:?}",
+                a.cmp(&b)
+            );
+        }
+
+        // Verify that sorting a shuffled copy produces the expected order.
+        let mut shuffled = [
+            Tier::Day365,
+            Tier::Min10,
+            Tier::Hour12,
+            Tier::Day1,
+            Tier::Min1,
+            Tier::Day30,
+            Tier::Hour3,
+            Tier::Day7,
+            Tier::Min30,
+            Tier::Day90,
+            Tier::Hour6,
+            Tier::Day15,
+            Tier::Hour1,
+            Tier::Day180,
+            Tier::Min5,
+        ];
+        shuffled.sort();
+        assert_eq!(
+            shuffled, expected_order,
+            "sorted Tier array must match expected cheapest-first order"
+        );
     }
 }
 

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -435,9 +435,28 @@ impl AftRecords {
         // Pick the cheapest tier the sender has available that still satisfies
         // the recipient's minimum (#152). Collect available tiers from the
         // cached record so we prefer a Min10 slot over a Day1 when both exist.
-        let available_tiers: Vec<Tier> = (&records).into_iter().map(|(t, _)| *t).collect();
-        let spend_tier = pick_spend_tier(&available_tiers, recipient_required_tier)
-            .unwrap_or(recipient_required_tier);
+        // Filter out empty Vecs: a key with no assignments is not a usable
+        // tier — including it would mislead pick_spend_tier into thinking
+        // the sender has tokens at that level (fix #160 bug 1).
+        let available_tiers: Vec<Tier> = (&records)
+            .into_iter()
+            .filter(|(_, v)| !v.is_empty())
+            .map(|(t, _)| *t)
+            .collect();
+        // Distinguish two None cases (fix #160 bug 2):
+        // - Empty pool (no tiers at all, fresh install): the delegate still
+        //   gets to decide — fall through with the recipient's required tier
+        //   so the delegate can attempt a fresh mint.
+        // - Non-empty pool but no tier qualifies (e.g. sender only has Min1,
+        //   recipient requires Min10): reject early with a user-visible error
+        //   rather than asking the delegate for a tier we don't hold.
+        let spend_tier = match pick_spend_tier(&available_tiers, recipient_required_tier) {
+            Some(t) => t,
+            None if available_tiers.is_empty() => recipient_required_tier,
+            None => {
+                return Err(format_insufficient_tier_toast(recipient_required_tier).into());
+            }
+        };
         let criteria = build_recipient_criteria(spend_tier, recipient_max_age_secs, token_record)?;
         let token_request = TokenDelegateMessage::RequestNewToken(RequestNewToken {
             request_id: REQUEST_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst),
@@ -577,6 +596,22 @@ pub(crate) fn format_no_record_toast() -> String {
     "Can't send: your token record hasn't loaded yet. \
      Wait a moment and try again, or check Settings → AFT."
         .to_string()
+}
+
+/// Build a user-facing toast message when the sender's token pool is
+/// non-empty but contains no tier that satisfies the recipient's
+/// `minimum_tier` requirement.
+///
+/// Distinct from `format_no_record_toast` (record missing entirely) and
+/// from `format_failure_toast(NoFreeSlot)` (delegate rejected the request
+/// after we asked). This error fires *before* the delegate request because
+/// asking for a tier we don't hold would always fail — surfacing it here
+/// gives the user an actionable message immediately (#160).
+pub(crate) fn format_insufficient_tier_toast(required: Tier) -> String {
+    format!(
+        "Insufficient tier — your tokens are too low to send to this recipient \
+         (requires {required}). Mint higher-tier tokens in Settings → AFT.",
+    )
 }
 
 #[cfg(test)]
@@ -807,6 +842,99 @@ mod tests {
             pick_spend_tier(&available, Tier::Day1),
             Some(Tier::Day1),
             "Day1 exact match must be preferred over Day7"
+        );
+    }
+
+    // --- available_tiers filtering (#160 bug 1) --------------------------
+
+    /// An empty Vec under a Tier key must NOT contribute that tier to the
+    /// available list. The filter `!v.is_empty()` must strip it so that
+    /// `pick_spend_tier` doesn't see a "phantom" tier.
+    #[test]
+    fn available_tiers_filters_empty_buckets() {
+        use std::collections::HashMap;
+        // Build a record with one non-empty bucket and one empty bucket.
+        let mut tokens: HashMap<Tier, Vec<TokenAssignment>> = HashMap::new();
+        tokens.insert(Tier::Day1, vec![]); // empty — must be filtered
+        tokens.insert(Tier::Hour1, vec![]); // also empty
+        let record = TokenAllocationRecord::new(tokens);
+
+        // Reproduce the fix: filter empty vecs before passing to pick_spend_tier.
+        let available: Vec<Tier> = (&record)
+            .into_iter()
+            .filter(|(_, v)| !v.is_empty())
+            .map(|(t, _)| *t)
+            .collect();
+
+        assert!(
+            available.is_empty(),
+            "empty buckets must not appear in the available tier list; got {available:?}"
+        );
+
+        // If we had NOT filtered, Day1 and Hour1 would appear and pick_spend_tier
+        // would return Some(Hour1) for a Min10 requirement — which would be wrong
+        // because the sender has zero tokens at that tier.
+        let unfiltered: Vec<Tier> = (&record).into_iter().map(|(t, _)| *t).collect();
+        // Depending on HashMap iteration order, one or two phantom tiers surface.
+        assert!(
+            !unfiltered.is_empty(),
+            "without filtering the phantom tiers would be visible (pre-fix behaviour)"
+        );
+    }
+
+    // --- format_insufficient_tier_toast (#160 bug 2) ---------------------
+
+    /// When the sender's pool is non-empty but has no tier at or above
+    /// the required level, the error must mention the required tier and
+    /// the Settings → AFT hint so the user knows what to mint.
+    #[test]
+    fn format_insufficient_tier_toast_mentions_required_tier_and_hint() {
+        let msg = format_insufficient_tier_toast(Tier::Min10);
+        assert!(
+            msg.contains("min10"),
+            "expected required tier name in: {msg}"
+        );
+        assert!(
+            msg.contains("Settings → AFT"),
+            "expected settings hint in: {msg}"
+        );
+    }
+
+    /// Verify the two-case None split: empty pool falls through (returns
+    /// the required tier so the delegate gets a chance to mint fresh
+    /// tokens), whereas non-empty pool with no qualifying tier returns
+    /// an error string that starts with "Insufficient tier".
+    #[test]
+    fn insufficient_tier_error_is_distinct_from_empty_pool() {
+        // Non-empty pool case — only Min1, recipient requires Min10.
+        let non_empty = vec![Tier::Min1];
+        let result_non_empty = pick_spend_tier(&non_empty, Tier::Min10);
+        assert!(
+            result_non_empty.is_none(),
+            "non-empty pool with no qualifying tier must return None"
+        );
+
+        // Empty pool case — returns None too, but the calling site treats
+        // it differently (falls back to recipient_required_tier).
+        let empty: Vec<Tier> = vec![];
+        let result_empty = pick_spend_tier(&empty, Tier::Min10);
+        assert!(
+            result_empty.is_none(),
+            "empty pool must also return None from pick_spend_tier"
+        );
+
+        // The difference is detected at the call site:
+        // available_tiers.is_empty() distinguishes the two paths.
+        // In the empty case the error is NOT produced; in the non-empty case it IS.
+        let empty_case_produces_error = !empty.is_empty() && result_empty.is_none();
+        let nonempty_case_produces_error = !non_empty.is_empty() && result_non_empty.is_none();
+        assert!(
+            !empty_case_produces_error,
+            "empty pool must NOT produce an insufficient-tier error"
+        );
+        assert!(
+            nonempty_case_produces_error,
+            "non-empty pool with no qualifying tier MUST produce an insufficient-tier error"
         );
     }
 }


### PR DESCRIPTION
## Summary

Three bugs in the AFT tier-picker pipeline discovered in #160:

- **Empty bucket filtering** (`available_tiers`): `TokenAllocationRecord` can hold `Tier -> []` entries when buckets exist but have no assignments. The old iterator included those phantom keys, causing `pick_spend_tier` to return a tier the sender had zero tokens at. Fixed by `.filter(|(_, v)| !v.is_empty())` before collecting available tiers.

- **Wrong `unwrap_or` fallback in `assign_token`**: when `pick_spend_tier` returned `None`, the code fell back to `recipient_required_tier` unconditionally. This is correct for a fresh-install sender with an empty pool (delegate still gets a chance to mint), but silently wrong for a sender with tokens all cheaper than the recipient's minimum (e.g. only Min1 tokens when recipient requires Min10). The fix distinguishes the two `None` cases:
  - Empty pool → fall through to delegate (delegate decides / mints fresh).
  - Non-empty pool but no qualifying tier → return a user-visible "Insufficient tier" error immediately, rather than asking the delegate for a tier we don't hold. The error message follows the #151 toast pattern: *"Insufficient tier — your tokens are too low to send to this recipient (requires `<tier>`). Mint higher-tier tokens in Settings → AFT."*

- **Fragile `#[derive(Ord)]` on `Tier`**: ordering was tied to variant declaration order, so a future contributor reordering variants would silently break cost ranking throughout the codebase. Replaced with explicit `Ord`/`PartialOrd` impls that delegate to `tier_duration()` — ordering is now semantic-bound to slot length and independent of declaration order.

## Test plan

- [ ] `cargo test -p freenet-aft-interface` — new `tier_ord_follows_slot_duration` test passes; all existing boundary/tier tests pass
- [ ] `cargo test -p freenet-email-ui --no-default-features --features "example-data,no-sync"` — new `available_tiers_filters_empty_buckets`, `format_insufficient_tier_toast_mentions_required_tier_and_hint`, `insufficient_tier_error_is_distinct_from_empty_pool` tests pass; all 77 UI unit tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` (excluding UI which needs WASM artifacts, or built with `example-data,no-sync`) — clean
- [ ] Manual: verify a send where sender only has low-tier tokens shows the "Insufficient tier" toast rather than silently failing or hanging

Closes #160.