### PR TITLE
fix(iso): pass --config-dir per node so gw and peer can't share config (#124)

### DIFF
--- a/scripts/run-isolated-nodes.sh
+++ b/scripts/run-isolated-nodes.sh
@@ -6,6 +6,13 @@
 # - HOME override per node so neither reads ~/Library/.../gateways.toml
 #   (which would pull in public Freenet bootstrap gateways and break
 #   the "isolated" guarantee — see freenet/freenet-core#3980).
+# - --config-dir per node so gw and peer never share a config.toml.
+#   freenet-core's ConfigArgs::build persists a config.toml on first run
+#   (containing secrets.transport_keypair = ...). On hosts where
+#   XDG_CONFIG_HOME is set (ubicloud runners), HOME override is bypassed
+#   for config resolution and both nodes resolve to the same dir, so the
+#   second node loads the first's transport keypair and fails its
+#   "same public key as self" check (#124).
 #
 # Usage:
 #   scripts/run-isolated-nodes.sh up      # start both
@@ -23,8 +30,10 @@ GW_HOME="$ROOT/HOME-gw"
 PEER_HOME="$ROOT/HOME-peer"
 GW_DATA="$ROOT/gw/data"
 GW_LOGS="$ROOT/gw/logs"
+GW_CONFIG="$ROOT/gw/config"
 PEER_DATA="$ROOT/peer/data"
 PEER_LOGS="$ROOT/peer/logs"
+PEER_CONFIG="$ROOT/peer/config"
 
 GW_PORT_NET=31338
 GW_PORT_WS=7510
@@ -71,7 +80,7 @@ setup_dirs() {
     # outside our HOME override (which would let gw + peer share state).
     mkdir -p "$GW_HOME/.config/freenet" "$GW_HOME/.local/share/freenet"
     mkdir -p "$PEER_HOME/.config/freenet" "$PEER_HOME/.local/share/freenet"
-    mkdir -p "$GW_DATA" "$GW_LOGS" "$PEER_DATA" "$PEER_LOGS"
+    mkdir -p "$GW_DATA" "$GW_LOGS" "$GW_CONFIG" "$PEER_DATA" "$PEER_LOGS" "$PEER_CONFIG"
     # Empty `gateways = []` so freenet doesn't load real public bootstraps
     # from the global config dir. Empty file ('') errors out with
     # "missing field `gateways`" — must be the explicit array form.
@@ -110,6 +119,7 @@ up() {
             --ws-api-address 0.0.0.0 \
             --is-gateway \
             --skip-load-from-network \
+            --config-dir "$GW_CONFIG" \
             --data-dir "$GW_DATA" \
             --public-network-address 127.0.0.1 \
             --log-dir "$GW_LOGS" \
@@ -147,6 +157,7 @@ up() {
             --ws-api-address 0.0.0.0 \
             --gateway "127.0.0.1:$GW_PORT_NET,$GW_PUBKEY" \
             --skip-load-from-network \
+            --config-dir "$PEER_CONFIG" \
             --data-dir "$PEER_DATA" \
             --log-dir "$PEER_LOGS" \
             --log-level info


### PR DESCRIPTION
Closes #124.

## Root cause

ubicloud runners set \`XDG_CONFIG_HOME=/home/runner/.config\`, which
\`dirs-rs\` prefers over the script's \`HOME\` override. Both gw and peer
resolved their \`config_local_dir\` to the same XDG path. On gw's first
run, \`freenet-core::ConfigArgs::build\` persists a \`config.toml\` to
\`\$XDG_CONFIG_HOME/freenet/config.toml\` containing:

\`\`\`toml
[secrets]
transport_keypair = "/home/runner/freenet-mail-iso/gw/data/secrets/transport_keypair"
\`\`\`

When peer launches, \`Self::read_config()\` picks that file up,
\`SecretArgs::merge\` inherits the keypair path (the field is
\`Option<PathBuf>\`, so \`get_or_insert\` from CLI defaults applies),
and peer loads gw's keypair. \`NodeConfig::new\` then computes
\`own_pub_key = config.transport_keypair().public()\` = gw's pub, and
the equality check at
[\`crates/core/src/node.rs:261\`](https://github.com/freenet/freenet-core/blob/v0.2.54/crates/core/src/node.rs#L261)
skips the only gateway peer was given, leaving zero gateways and
aborting with "At least one remote gateway is required".

Local Mac was deterministic green because \`XDG_CONFIG_HOME\` isn't set
there by default — the \`HOME\` override took effect and each node had
its own ProjectDirs config dir.

## Fix

Pass an explicit \`--config-dir\` per node (\`\$ROOT/gw/config\` and
\`\$ROOT/peer/config\`). Bypasses XDG resolution entirely so each node's
\`config.toml\` is independent.

## Verification

Pre-fix CI artifact (run 25507260161): peer/data/secrets had only
\`cli_gw_*.pub\`, no \`transport_keypair\`. Both nodes' \`config_local_dir\`
resolved to \`\$XDG_CONFIG_HOME/freenet\`.

Post-fix CI artifact (run 25507620310): gw and peer write distinct
\`transport_keypair\` files; peer's pub != gw's pub; iso harness boots
cleanly. \`fdev publish-email-iso\` succeeds against the iso gw. One
of three live-node specs passes; the other two fail at
\`fm-create-confirm\`, which is a pre-existing spec-side issue
(#122 territory) — out of scope for #124.

## Test plan

- [x] e2e-real-node CI shows iso harness boot succeeds
- [x] gw publish via fdev succeeds
- [x] live-node spec runs (1/3 passes; remaining 2 are #122 territory)
- [ ] Local Mac \`cargo make test-e2e-real-node\` still passes