### PR TITLE
debug(aft): info-level send-pipeline diagnostics (for #174)

### DIFF
--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -446,7 +446,10 @@ impl AftRecords {
             )
             .into());
         };
-        let nonempty_tier_count = (&records).into_iter().filter(|(_, v)| !v.is_empty()).count();
+        let nonempty_tier_count = (&records)
+            .into_iter()
+            .filter(|(_, v)| !v.is_empty())
+            .count();
         crate::log::info(format!(
             "AFT.assign_token: RECORDS hit alias=`{alias}` nonempty_tiers={count} required_tier={tier:?} max_age_secs={age} (release-visible diagnostic for #174)",
             alias = generator_id.alias(),

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -326,6 +326,11 @@ impl AftRecords {
         client: &mut WebApiRequestClient,
         record: TokenAssignment,
     ) -> Result<(), DynError> {
+        crate::log::info(format!(
+            "AFT.allocated_assignment: token received tier={tier:?} assignment_hash={hash} (release-visible diagnostic for #174)",
+            tier = record.tier,
+            hash = bs58::encode(record.assignment_hash).into_string()
+        ));
         let Some(inbox) = PENDING_INBOXES_UPDATES.with(|queue| {
             queue.borrow().iter().find_map(|(inbox, hash)| {
                 if &record.assignment_hash == hash {
@@ -336,6 +341,10 @@ impl AftRecords {
             })
         }) else {
             // unexpected token
+            crate::log::info(format!(
+                "AFT.allocated_assignment: NO matching pending inbox for assignment_hash={hash} — token dropped (release-visible diagnostic for #174)",
+                hash = bs58::encode(record.assignment_hash).into_string()
+            ));
             return Ok(());
         };
 
@@ -425,6 +434,11 @@ impl AftRecords {
         // todo: optimize so we don't clone the whole record and instead use a smart pointer
         let Some(records) = RECORDS.with(|recs| recs.borrow().get(generator_id).cloned()) else {
             // todo: somehow propagate this to the UI so the user retries /or we retry automatically/ later
+            crate::log::info(format!(
+                "AFT.assign_token: RECORDS miss for alias=`{alias}` token_record={key} (release-visible diagnostic for #174)",
+                alias = generator_id.alias(),
+                key = token_record
+            ));
             return Err(format!(
                 "failed to get token record for alias `{alias}` ({key})",
                 alias = generator_id.alias(),
@@ -432,6 +446,14 @@ impl AftRecords {
             )
             .into());
         };
+        let nonempty_tier_count = (&records).into_iter().filter(|(_, v)| !v.is_empty()).count();
+        crate::log::info(format!(
+            "AFT.assign_token: RECORDS hit alias=`{alias}` nonempty_tiers={count} required_tier={tier:?} max_age_secs={age} (release-visible diagnostic for #174)",
+            alias = generator_id.alias(),
+            count = nonempty_tier_count,
+            tier = recipient_required_tier,
+            age = recipient_max_age_secs,
+        ));
         // Pick the cheapest tier the sender has available that still satisfies
         // the recipient's minimum (#152). Collect available tiers from the
         // cached record so we prefer a Min10 slot over a Day1 when both exist.
@@ -493,6 +515,11 @@ impl AftRecords {
             alias = identity.alias
         );
         let record = TokenAllocationRecord::try_from(state)?;
+        let nonempty_tiers = (&record).into_iter().filter(|(_, v)| !v.is_empty()).count();
+        crate::log::info(format!(
+            "AFT.set_identity_contract: alias=`{alias}` key={key} nonempty_tiers={nonempty_tiers} (release-visible diagnostic for #174)",
+            alias = identity.alias
+        ));
         RECORDS.with(|recs| {
             let recs = &mut *recs.borrow_mut();
             recs.insert(identity, record);

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -435,10 +435,11 @@ impl DecryptedMessage {
         from: &Identity,
     ) -> Result<(), DynError> {
         let (hash, _) = self.assignment_hash_and_signed_content()?;
-        crate::log::debug!(
-            "requesting token for assignment hash: {}",
+        crate::log::info(format!(
+            "send.start_sending: from=`{}` assignment_hash={} (release-visible diagnostic for #174)",
+            from.alias(),
             bs58::encode(hash).into_string()
-        );
+        ));
         let inbox_pub_key_bytes = inbox_params_pub_key_bytes(&recipient_ml_dsa_vk);
         let delegate_key = AftRecords::assign_token(
             client,
@@ -456,6 +457,10 @@ impl DecryptedMessage {
         .map_err(|e| format!("{e}"))?;
         let inbox_key =
             ContractKey::from_params(INBOX_CODE_HASH, params).map_err(|e| format!("{e}"))?;
+        crate::log::info(format!(
+            "send.start_sending: token requested, awaiting AFT delegate response from=`{}` inbox_key={inbox_key} (release-visible diagnostic for #174)",
+            from.alias()
+        ));
         AftRecords::pending_assignment(delegate_key, inbox_key);
 
         PENDING_INBOXES_UPDATE.with(|map| {


### PR DESCRIPTION
## Purpose

Diagnostic-only PR for #174 (live-node test 3 round-1 alice→bob send doesn't fire UPDATE on iso net).

## Background

Test 3 fails with no observable signal: fm-send is clicked, no error toast in alice's DOM, but bob3's inbox contract receives no UPDATE_PROPAGATION on either gw or peer. Cannot tell from current CI logs which pipeline step stalls because every diagnostic in \`ui/src/aft.rs\` and \`ui/src/inbox.rs\` send-path is \`crate::log::debug!\` — \`cfg(debug_assertions)\`-gated, silent in the release WASM that the iso harness publishes.

## What this changes

Promotes a handful of debug! calls to crate::log::info — only along the send pipeline:

- \`inbox.rs:start_sending\` entry + post-assign_token waypoint
- \`aft.rs:assign_token\` RECORDS hit/miss + tier outcome  
- \`aft.rs:set_identity_contract\` write
- \`aft.rs:allocated_assignment\` token received + dropped-token branch

Each line tagged \"(release-visible diagnostic for #174)\" for grep + easy revert once #174 is root-caused.

## Test plan

- [x] \`cargo check -p freenet-email-ui --target wasm32-unknown-unknown\` passes
- [ ] Merge → e2e-real-node CI run reproduces #174 failure → CI logs surface which step stalls

This is intentionally not gated behind a flag — info! is cheap, the messages are short, and they auto-disappear once the issue is fixed.