### PR TITLE
fix(test): scope fm-id-share to alias row, not .first() (#174)

### DIFF
--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -446,7 +446,10 @@ impl AftRecords {
             )
             .into());
         };
-        let nonempty_tier_count = (&records).into_iter().filter(|(_, v)| !v.is_empty()).count();
+        let nonempty_tier_count = (&records)
+            .into_iter()
+            .filter(|(_, v)| !v.is_empty())
+            .count();
         crate::log::info(format!(
             "AFT.assign_token: RECORDS hit alias=`{alias}` nonempty_tiers={count} required_tier={tier:?} max_age_secs={age} (release-visible diagnostic for #174)",
             alias = generator_id.alias(),

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -326,6 +326,11 @@ impl AftRecords {
         client: &mut WebApiRequestClient,
         record: TokenAssignment,
     ) -> Result<(), DynError> {
+        crate::log::info(format!(
+            "AFT.allocated_assignment: token received tier={tier:?} assignment_hash={hash} (release-visible diagnostic for #174)",
+            tier = record.tier,
+            hash = bs58::encode(record.assignment_hash).into_string()
+        ));
         let Some(inbox) = PENDING_INBOXES_UPDATES.with(|queue| {
             queue.borrow().iter().find_map(|(inbox, hash)| {
                 if &record.assignment_hash == hash {
@@ -336,6 +341,10 @@ impl AftRecords {
             })
         }) else {
             // unexpected token
+            crate::log::info(format!(
+                "AFT.allocated_assignment: NO matching pending inbox for assignment_hash={hash} — token dropped (release-visible diagnostic for #174)",
+                hash = bs58::encode(record.assignment_hash).into_string()
+            ));
             return Ok(());
         };
 
@@ -425,6 +434,11 @@ impl AftRecords {
         // todo: optimize so we don't clone the whole record and instead use a smart pointer
         let Some(records) = RECORDS.with(|recs| recs.borrow().get(generator_id).cloned()) else {
             // todo: somehow propagate this to the UI so the user retries /or we retry automatically/ later
+            crate::log::info(format!(
+                "AFT.assign_token: RECORDS miss for alias=`{alias}` token_record={key} (release-visible diagnostic for #174)",
+                alias = generator_id.alias(),
+                key = token_record
+            ));
             return Err(format!(
                 "failed to get token record for alias `{alias}` ({key})",
                 alias = generator_id.alias(),
@@ -432,6 +446,14 @@ impl AftRecords {
             )
             .into());
         };
+        let nonempty_tier_count = (&records).into_iter().filter(|(_, v)| !v.is_empty()).count();
+        crate::log::info(format!(
+            "AFT.assign_token: RECORDS hit alias=`{alias}` nonempty_tiers={count} required_tier={tier:?} max_age_secs={age} (release-visible diagnostic for #174)",
+            alias = generator_id.alias(),
+            count = nonempty_tier_count,
+            tier = recipient_required_tier,
+            age = recipient_max_age_secs,
+        ));
         // Pick the cheapest tier the sender has available that still satisfies
         // the recipient's minimum (#152). Collect available tiers from the
         // cached record so we prefer a Min10 slot over a Day1 when both exist.
@@ -493,6 +515,11 @@ impl AftRecords {
             alias = identity.alias
         );
         let record = TokenAllocationRecord::try_from(state)?;
+        let nonempty_tiers = (&record).into_iter().filter(|(_, v)| !v.is_empty()).count();
+        crate::log::info(format!(
+            "AFT.set_identity_contract: alias=`{alias}` key={key} nonempty_tiers={nonempty_tiers} (release-visible diagnostic for #174)",
+            alias = identity.alias
+        ));
         RECORDS.with(|recs| {
             let recs = &mut *recs.borrow_mut();
             recs.insert(identity, record);

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -435,10 +435,11 @@ impl DecryptedMessage {
         from: &Identity,
     ) -> Result<(), DynError> {
         let (hash, _) = self.assignment_hash_and_signed_content()?;
-        crate::log::debug!(
-            "requesting token for assignment hash: {}",
+        crate::log::info(format!(
+            "send.start_sending: from=`{}` assignment_hash={} (release-visible diagnostic for #174)",
+            from.alias(),
             bs58::encode(hash).into_string()
-        );
+        ));
         let inbox_pub_key_bytes = inbox_params_pub_key_bytes(&recipient_ml_dsa_vk);
         let delegate_key = AftRecords::assign_token(
             client,
@@ -456,6 +457,10 @@ impl DecryptedMessage {
         .map_err(|e| format!("{e}"))?;
         let inbox_key =
             ContractKey::from_params(INBOX_CODE_HASH, params).map_err(|e| format!("{e}"))?;
+        crate::log::info(format!(
+            "send.start_sending: token requested, awaiting AFT delegate response from=`{}` inbox_key={inbox_key} (release-visible diagnostic for #174)",
+            from.alias()
+        ));
         AftRecords::pending_assignment(delegate_key, inbox_key);
 
         PENDING_INBOXES_UPDATE.with(|map| {

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -227,8 +227,18 @@ test.describe("Live node E2E", () => {
       ]);
 
       // ── Bob shares his contact card ─────────────────────────────
+      // Scope to bob2's row, NOT `.first()`. Identity rows are sorted
+      // alphabetically (login.rs:380), so .first() returns the
+      // alphabetically-first identity on the node — which on a peer that
+      // already saw bob1/bob2 in earlier tests is NOT the one this test
+      // just created. (#174 root cause: in test 3, .first() returned
+      // bob2's row, alice imported bob2's keys under local alias "bob3",
+      // and her send went to bob2's inbox — orphan UPDATE since no UI
+      // was watching that inbox.)
       const bobApp = bobPage.frameLocator("iframe#app");
-      await bobApp.locator('[data-testid="fm-id-share"]').first().click();
+      await bobApp
+        .locator(`[data-testid="fm-id-row"][data-alias="${ALIAS_T2_BOB}"] [data-testid="fm-id-share"]`)
+        .click();
       const shareModal = bobApp.locator('[data-testid="fm-share-modal"]');
       await shareModal.waitFor({ timeout: 5_000 });
       const bobCard = (await shareModal.getAttribute("data-share-text")) ?? "";
@@ -427,11 +437,12 @@ test.describe("Live node E2E", () => {
 
       // Alice imports bob so round 1 (alice→bob) can resolve. Bob's
       // import of alice is deferred to inside the round-2 conditional
-      // — it's only needed for the reply path, and doing it eagerly
-      // here added an address-book write race that prevented round 1
-      // UPDATE from firing on bob3's inbox (observed in #173 CI run
-      // 25542986416).
-      await bobApp.locator('[data-testid="fm-id-share"]').first().click();
+      // — it's only needed for the reply path. Scope share to the
+      // bob3 row specifically; .first() picks bob2 alphabetically when
+      // the peer delegate already saw bob2 in test 2 (#174 root cause).
+      await bobApp
+        .locator(`[data-testid="fm-id-row"][data-alias="${ALIAS_T3_BOB}"] [data-testid="fm-id-share"]`)
+        .click();
       const bobShare = bobApp.locator('[data-testid="fm-share-modal"]');
       await bobShare.waitFor({ timeout: 5_000 });
       const bobCard = (await bobShare.getAttribute("data-share-text")) ?? "";
@@ -510,7 +521,11 @@ test.describe("Live node E2E", () => {
       // the 60s window). Tracked separately; gated until reproducible.
       if (process.env.FREENET_LIVE_E2E_REPLY === "1") {
         // Bob needs to import alice first so the reply can resolve.
-        await aliceApp.locator('[data-testid="fm-id-share"]').first().click();
+        // Scope to alice3 row specifically (#174 — gw delegate accumulates
+        // alice1/alice2/alice3 across tests; .first() returns alice1).
+        await aliceApp
+          .locator(`[data-testid="fm-id-row"][data-alias="${ALIAS_T3_ALICE}"] [data-testid="fm-id-share"]`)
+          .click();
         const aliceShare = aliceApp.locator('[data-testid="fm-share-modal"]');
         await aliceShare.waitFor({ timeout: 5_000 });
         const aliceCard =


### PR DESCRIPTION
## Summary

- Test 3 alice3→bob3 send was reaching the wire — UPDATE fired, gw broadcast, contract state grew — but on **bob2's** inbox, not bob3's
- Identity rows are sorted alphabetically (login.rs:380); peer delegate accumulates bob2 + bob3 across tests; \`fm-id-share .first()\` returns bob2's share modal
- Test 3 alice imports bob2's keys under local alias \"bob3\", sends to bob2 — orphan delivery (bob2's UI closed at end of test 2)
- Same pattern on alice rows in round-2 reply gate (gw delegate has alice1/alice2/alice3, .first() = alice1)

Scope the share locator to the right row via \`[data-alias=...]\`.

## Validation

PR #175 added info-level diagnostic logs to the send pipeline. CI run 25547970949 (manual dispatch) showed:
- ✅ All AFT pipeline checkpoints fire successfully on alice3
- ✅ UPDATE_PROPAGATION on \`2TbMGJ...\` (= bob2's inbox key from test 2 setup)
- bob3's actual inbox \`8cVxc...\` saw only its initial PUT, no follow-on UPDATE

## Test plan

- [x] \`npx playwright test --list live-node.spec.ts\` parses
- [ ] CI e2e-real-node: tests 1, 2, 3 round 1 all pass

Closes #174. Production app unaffected — users click share on a specific row in the UI.