### PR TITLE
fix(test): #179 cap test must switch alice to Sent folder

### DIFF
--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -714,6 +714,10 @@ test.describe("Live node E2E", () => {
         .click();
       await composeAndSend(aliceApp, ALIAS_T4_BOB, "cap test r1", "round one body");
 
+      // Sent rows only render when the Sent folder is selected (app.rs:1545).
+      // Switch alice to Sent so subsequent `fm-sent-card` locators resolve.
+      await aliceApp.locator('[data-testid="fm-folder-sent"]').click();
+
       // Round 1 must NOT flip to Failed within reasonable time.
       // We don't poll for Delivered specifically (transit can take
       // time on iso); we poll for "no Failed row yet" after 30s.
@@ -739,6 +743,7 @@ test.describe("Live node E2E", () => {
 
       // ── Round 2: same minute slot → must Fail ───────────────────
       await composeAndSend(aliceApp, ALIAS_T4_BOB, "cap test r2", "round two body");
+      await aliceApp.locator('[data-testid="fm-folder-sent"]').click();
       const sentR2 = aliceApp
         .locator('[data-testid="fm-sent-card"]')
         .filter({ hasText: "cap test r2" });
@@ -778,6 +783,7 @@ test.describe("Live node E2E", () => {
 
       // ── Round 3: new slot → must succeed ────────────────────────
       await composeAndSend(aliceApp, ALIAS_T4_BOB, "cap test r3", "round three body");
+      await aliceApp.locator('[data-testid="fm-folder-sent"]').click();
       const sentR3 = aliceApp
         .locator('[data-testid="fm-sent-card"]')
         .filter({ hasText: "cap test r3" });


### PR DESCRIPTION
Followup to #181. The cap-enforcement test asserts on alice's `[data-testid=\"fm-sent-card\"]` rows, but Sent rows only render when the Sent folder is selected (default is Inbox). Workflow_dispatch run 25580470671 caught this: round 1 timed out at the surface check despite AFT logs showing the Min1 mint fired correctly.

Switch to Sent (`[data-testid=\"fm-folder-sent\"]`) after each compose.

## Test plan
Trigger workflow_dispatch with `run_aft_cap_test=true` after merge.