### PR TITLE
test(aft): delegate-level cap-enforcement coverage (#179)

### DIFF
--- a/modules/antiflood-tokens/delegates/token-generator/src/tests.rs
+++ b/modules/antiflood-tokens/delegates/token-generator/src/tests.rs
@@ -159,4 +159,109 @@ mod token_assignment {
         );
         assert_eq!(assignment.unwrap(), get_assignment_date(2022, 1, 28));
     }
+
+    // Cap-enforcement coverage (#179). The user-visible "no free slot"
+    // path fires when every slot in the closed window
+    // `[normalized - max_age, normalized]` is already assigned. With
+    // Day1 tier + 3-day max_age that window contains 4 daily slots
+    // (e.g. 01-24, 01-25, 01-26, 01-27 when `now == 01-27`); fill all
+    // four and `next_free_assignment` must return None so the delegate
+    // emits `Failure(NoFreeSlot)`.
+    const MAX_DURATION_3D: std::time::Duration = std::time::Duration::from_secs(3 * 24 * 3600);
+
+    #[test]
+    fn day1_window_exhausted_returns_none() {
+        // Reference "now" — Day1 normalize_to_next of a midnight value is
+        // a no-op, so the window is exactly [now - 3d, now] and the
+        // valid slot dates are 2023-01-24, 2023-01-25, 2023-01-26.
+        let now = get_assignment_date(2023, 1, 27);
+        let mk = |y, m, d| TokenAssignment {
+            tier: TEST_TIER,
+            time_slot: get_assignment_date(y, m, d),
+            generator: dummy_generator(),
+            signature: dummy_signature(),
+            assignment_hash: [0; 32],
+            token_record: *ID,
+        };
+        let records = TokenAllocationRecord::new(HashMap::from_iter([(
+            TEST_TIER,
+            vec![
+                mk(2023, 1, 24),
+                mk(2023, 1, 25),
+                mk(2023, 1, 26),
+                mk(2023, 1, 27),
+            ],
+        )]));
+        let assignment = records.next_free_assignment(
+            &AllocationCriteria::new(TEST_TIER, MAX_DURATION_3D, *ID).unwrap(),
+            now,
+        );
+        assert!(
+            assignment.is_none(),
+            "saturated 3-day Day1 window must return None; got {assignment:?}"
+        );
+    }
+
+    #[test]
+    fn day1_window_not_quite_exhausted_returns_remaining_slot() {
+        // Same 3-day window but with the middle slot free. Confirms the
+        // assertion in the previous test isn't a false positive — the
+        // function actually scans for free slots and only returns None
+        // when there are none.
+        let now = get_assignment_date(2023, 1, 27);
+        let mk = |y, m, d| TokenAssignment {
+            tier: TEST_TIER,
+            time_slot: get_assignment_date(y, m, d),
+            generator: dummy_generator(),
+            signature: dummy_signature(),
+            assignment_hash: [0; 32],
+            token_record: *ID,
+        };
+        let records = TokenAllocationRecord::new(HashMap::from_iter([(
+            TEST_TIER,
+            vec![mk(2023, 1, 24), mk(2023, 1, 26)],
+        )]));
+        let assignment = records.next_free_assignment(
+            &AllocationCriteria::new(TEST_TIER, MAX_DURATION_3D, *ID).unwrap(),
+            now,
+        );
+        assert_eq!(
+            assignment,
+            Some(get_assignment_date(2023, 1, 25)),
+            "middle slot 2023-01-25 must be picked"
+        );
+    }
+
+    #[test]
+    fn day1_freeing_a_slot_after_exhaustion_restores_allocation() {
+        // Saturate the 3-day window, then drop the newest assignment
+        // and confirm the allocator can pick it up again. Mirrors the
+        // user-visible "wait until a slot frees, then send" path.
+        let now = get_assignment_date(2023, 1, 27);
+        let mk = |y, m, d| TokenAssignment {
+            tier: TEST_TIER,
+            time_slot: get_assignment_date(y, m, d),
+            generator: dummy_generator(),
+            signature: dummy_signature(),
+            assignment_hash: [0; 32],
+            token_record: *ID,
+        };
+        let mut records = TokenAllocationRecord::new(HashMap::from_iter([(
+            TEST_TIER,
+            vec![
+                mk(2023, 1, 24),
+                mk(2023, 1, 25),
+                mk(2023, 1, 26),
+                mk(2023, 1, 27),
+            ],
+        )]));
+        let criteria = AllocationCriteria::new(TEST_TIER, MAX_DURATION_3D, *ID).unwrap();
+        assert!(records.next_free_assignment(&criteria, now).is_none());
+
+        records.get_mut_tier(&TEST_TIER).unwrap().pop(); // drop 2023-01-27
+        assert!(
+            records.next_free_assignment(&criteria, now).is_some(),
+            "freeing the newest slot must restore allocation"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Followup to PR #183 (which reverted the e2e cap test on the wrong abstraction). Covers \`TokenAllocationRecord::next_free_assignment\` returning None when the slot-window is saturated.

Three new tests in \`modules/antiflood-tokens/delegates/token-generator/src/tests.rs\`:

1. **\`day1_window_exhausted_returns_none\`** — Day1 + 3-day max_age has 4 slots in the closed window; saturating all 4 forces None.
2. **\`day1_window_not_quite_exhausted_returns_remaining_slot\`** — guards #1 against false-positive (middle slot free → allocator picks it).
3. **\`day1_freeing_a_slot_after_exhaustion_restores_allocation\`** — exhaustion → drop newest → recovery, matches the user-visible \"wait until a slot frees, then send\" loop.

## Why
Contract-level slot-collision is unit-tested (\`append_rejects_distinct_assignment_at_same_slot\`); the delegate's allocator behavior under exhaustion was not. This is the right abstraction for the cap-rejection check — e2e through the UI would need minute-scale \`max_age_secs\` in InboxSettings, which the floor doesn't currently allow (1 day; settings.rs:732).

## Test plan
- [x] \`cargo test -p freenet-token-generator --lib\` — 7 passed (4 existing + 3 new).