### PR TITLE
fix(api): prime contact's inbox contract on import (#191)

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1093,6 +1093,60 @@ pub(crate) async fn node_comms(
                     let prev = *ab_gen.0.read();
                     *ab_gen.0.write() = prev.wrapping_add(1);
 
+                    // #191: prime the local node with the contact's inbox
+                    // contract so a future Send works. The webapp dispatches
+                    // sends as `UpdateData::Delta`, which the originating
+                    // node tries to apply locally before forwarding to a
+                    // hosting peer. That local apply needs the contract's
+                    // wasm + parameters cached, which we don't have until
+                    // we've seen the contract once. A `Get` with
+                    // `return_contract_code=true, subscribe=true` populates
+                    // the local store and registers us as a subscriber so
+                    // future updates also propagate back to the sender's
+                    // node when delivered. Without this, send fails with
+                    // "missing contract parameters" at update.rs:619 and
+                    // the message silently never reaches the recipient.
+                    match crate::app::address_book::vk_from_bytes(&contact.ml_dsa_vk_bytes) {
+                        Ok(vk) => match crate::inbox::inbox_key_for(&vk) {
+                            Ok(inbox_key) => {
+                                let req = freenet_stdlib::client_api::ContractRequest::Get {
+                                    key: inbox_key.into(),
+                                    return_contract_code: true,
+                                    subscribe: true,
+                                    blocking_subscribe: false,
+                                };
+                                if let Err(e) = client.send(req.into()).await {
+                                    crate::log::error(
+                                        format!(
+                                            "prime contact inbox {inbox_key} for {} failed: {e}",
+                                            contact.local_alias
+                                        ),
+                                        None,
+                                    );
+                                } else {
+                                    crate::log::info(format!(
+                                        "primed contact inbox {inbox_key} for {} (#191)",
+                                        contact.local_alias
+                                    ));
+                                }
+                            }
+                            Err(e) => crate::log::error(
+                                format!(
+                                    "derive inbox_key for contact {}: {e}",
+                                    contact.local_alias
+                                ),
+                                None,
+                            ),
+                        },
+                        Err(e) => crate::log::error(
+                            format!(
+                                "decode ml_dsa_vk for contact {}: {e}",
+                                contact.local_alias
+                            ),
+                            None,
+                        ),
+                    }
+
                     // #150: if this contact was just marked verified AND the
                     // active identity has the bypass toggle ON, push an updated
                     // `verified_senders` set to the inbox contract so the new

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1139,10 +1139,7 @@ pub(crate) async fn node_comms(
                             ),
                         },
                         Err(e) => crate::log::error(
-                            format!(
-                                "decode ml_dsa_vk for contact {}: {e}",
-                                contact.local_alias
-                            ),
+                            format!("decode ml_dsa_vk for contact {}: {e}", contact.local_alias),
                             None,
                         ),
                     }


### PR DESCRIPTION
## Summary
Closes #191. Cross-node send was failing silently with \`missing contract parameters\` at the originator's node and the UI showed a misleading \"Sent\" toast.

## Root cause
The webapp dispatches sends as \`UpdateData::Delta\`. freenet-core's task-per-tx update driver tries to apply the delta locally before forwarding to a hosting peer (see \`crates/core/src/operations/update/op_ctx_task.rs:270-313\`). That local apply needs the contract's wasm + parameters cached, which the sender's node has never seen for a brand-new contact's inbox.

## Fix
On contact import (\`NodeAction::CreateContact\`), derive the recipient's inbox \`ContractKey\` from their ml_dsa verifying key and issue a \`Get\` with \`return_contract_code=true, subscribe=true\`. This:
1. Populates the local store with the inbox WASM, parameters, and current state
2. Registers the sender as a subscriber so future updates propagate back

Subsequent send attempts hit the cached params and the local apply succeeds.

## Verification
Live test against two real \`freenet network\` peers (ports 7509 / 7510). On import, the console logs:
\`\`\`
primed contact inbox <key> for <alias> (#191)
\`\`\`
and the corresponding \`ContractRequest::Get\` reaches the local node.

Send-flow validation requires a real Cmd+V paste to import the (~15 KB) contact card — the chrome-devtools MCP \`fill\` truncates strings of that size, which produced a wrong-bytes contact during my MCP-driven test (cosmetic only — confirmed user reports real-paste works).

## Test plan
- [x] \`cargo make clippy\` clean
- [x] \`cargo make test\` green
- [x] Code path verified via console log on real-net
- [ ] Manual end-to-end send between two peers — pending real-paste import
- [ ] CI green

## Related
- freenet/freenet-core#4064 — orthogonal: webapp UPDATE broadcasts don't reliably propagate to subscribed peers (filed during this debug session)
- #185, #186 (PR #188) — earlier identity-creation reliability fixes that unblocked this debug