### PR TITLE
fix(api): prime contact inboxes on rehydrate (#191 follow-up)

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1831,6 +1831,62 @@ pub(crate) async fn node_comms(
                                                 }
                                             }
                                         }
+                                        // #191: rehydrate path also needs to prime
+                                        // every restored contact's inbox contract.
+                                        // CreateContact primes on first import, but
+                                        // contacts persisted in the identity-management
+                                        // delegate come back via `set_aliases` →
+                                        // `insert_contact` without round-tripping the
+                                        // CreateContact handler. After a page reload
+                                        // the local node's contract store is empty,
+                                        // so the first send to a known contact would
+                                        // fail with "missing contract parameters".
+                                        for contact in crate::app::address_book::all_contacts() {
+                                            match crate::app::address_book::vk_from_bytes(
+                                                &contact.ml_dsa_vk_bytes,
+                                            ) {
+                                                Ok(vk) => match crate::inbox::inbox_key_for(&vk) {
+                                                    Ok(inbox_key) => {
+                                                        let req = freenet_stdlib::client_api::ContractRequest::Get {
+                                                            key: inbox_key.into(),
+                                                            return_contract_code: true,
+                                                            subscribe: true,
+                                                            blocking_subscribe: false,
+                                                        };
+                                                        if let Err(e) =
+                                                            client.send(req.into()).await
+                                                        {
+                                                            crate::log::error(
+                                                                format!(
+                                                                    "rehydrate prime contact inbox {inbox_key} for {} failed: {e}",
+                                                                    contact.local_alias
+                                                                ),
+                                                                None,
+                                                            );
+                                                        } else {
+                                                            crate::log::info(format!(
+                                                                "rehydrate primed contact inbox {inbox_key} for {} (#191)",
+                                                                contact.local_alias
+                                                            ));
+                                                        }
+                                                    }
+                                                    Err(e) => crate::log::error(
+                                                        format!(
+                                                            "rehydrate derive inbox_key for contact {}: {e}",
+                                                            contact.local_alias
+                                                        ),
+                                                        None,
+                                                    ),
+                                                },
+                                                Err(e) => crate::log::error(
+                                                    format!(
+                                                        "rehydrate decode ml_dsa_vk for contact {}: {e}",
+                                                        contact.local_alias
+                                                    ),
+                                                    None,
+                                                ),
+                                            }
+                                        }
                                     }
                                     Err(e) => {
                                         crate::log::error(


### PR DESCRIPTION
## Summary

- PR #192 primed contact inboxes only on first import via `CreateContact`.
- Contacts persisted in the identity-management delegate come back through `set_aliases` → `insert_contact` after a page reload without round-tripping `CreateContact`, so the local node's contract store never picks up the inbox code+params.
- First send to a known contact after reload then fails with "missing contract parameters" (`update.rs:619`) before the UPDATE can forward.
- This PR adds a second prime pass after `set_aliases` in the rehydrate path: iterate `address_book::all_contacts()` and emit the same Get-with-subscribe + `return_contract_code` request that `CreateContact` does. Cost is bounded by contact count, runs once per reload.

## Test plan

- [x] Confirmed broken: live 2-node test (peer1 7509 fixtest → peer2 7510 peer2alice) on `main` (post-#192) — first send after reload returned "missing contract parameters" in node logs.
- [x] Console log on rehydrate now shows `rehydrate primed contact inbox <key> for <alias> (#191)`.
- [ ] End-to-end delivery: peer1 prime Get sometimes times out across the public network despite peer2 hosting the contract — see follow-up note below.

## Follow-up — orthogonal core issue

In testing, the rehydrate prime Get + subscribe completes (peer2 logs show `subscribe ... outcome="subscribed"`) but the contract code/params still doesn't materialize on peer1, and the second send still fails the same way. Root cause appears to be that subscribe alone doesn't pull contract bytes, and the parallel Get that would carries the bytes can return "Contract not found" even when a peer in the network is hosting it. Filed as a freenet-core routing concern separate from this fix.