### PR TITLE
fix(api): swallow GetResponse for contact inbox keys (#191 follow-up)

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1464,7 +1464,27 @@ pub(crate) async fn node_comms(
                                 token_rec_to_id.insert(key, identity);
                             }
                             _ => {
-                                unreachable!("tried to get wrong contract key: {key}")
+                                // GetResponse for a contact's inbox: arrives
+                                // because the rehydrate-prime path (#191) and
+                                // CreateContact handler send Get-with-subscribe
+                                // for every known contact to populate the local
+                                // node's contract store + register interest.
+                                // We only care about the side-effects (subscribe,
+                                // local store populated); the state itself is
+                                // useless to the webapp because a contact's
+                                // inbox is opaque (encrypted to the contact's
+                                // ml_kem key, not ours).
+                                if crate::app::address_book::is_contact_inbox_key(&key) {
+                                    crate::log::debug!(
+                                        "GetResponse: contact inbox {key} \
+                                        primed (#191) — drop"
+                                    );
+                                } else {
+                                    crate::log::error(
+                                        format!("GetResponse for unknown contract key: {key}"),
+                                        None,
+                                    );
+                                }
                             }
                         }
                     }

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -351,6 +351,28 @@ pub fn lookup(alias: &str) -> Option<Recipient> {
     })
 }
 
+/// True if `key` is the inbox `ContractKey` of any known contact.
+///
+/// Used by the api.rs GetResponse handler to swallow responses produced by
+/// the rehydrate-prime / CreateContact-prime paths (#191). The webapp
+/// can't render a contact's inbox (the messages are encrypted to the
+/// contact's ml_kem key, not ours) — the prime is fire-and-forget.
+pub fn is_contact_inbox_key(key: &freenet_stdlib::prelude::ContractKey) -> bool {
+    use crate::inbox::inbox_key_for;
+    ADDRESS_BOOK.with(|ab| {
+        ab.borrow().values().any(|e| match e {
+            Entry::Contact(c) => match vk_from_bytes(&c.ml_dsa_vk_bytes) {
+                Ok(vk) => match inbox_key_for(&vk) {
+                    Ok(contact_key) => contact_key.id() == key.id(),
+                    Err(_) => false,
+                },
+                Err(_) => false,
+            },
+            Entry::Own(_) => false,
+        })
+    })
+}
+
 /// All contacts (non-own entries), sorted by alias.
 pub fn all_contacts() -> Vec<Contact> {
     ADDRESS_BOOK.with(|ab| {
@@ -870,5 +892,85 @@ mod tests {
         let decoded =
             ContactCard::decode(&share_text).expect("share text with verify line should decode");
         assert_eq!(decoded.ml_dsa_vk_bytes, card.ml_dsa_vk_bytes);
+    }
+
+    /// Regression for the api.rs:1467 panic ("tried to get wrong contract
+    /// key: …"): GetResponse for a contact's inbox key (produced by the
+    /// rehydrate-prime / CreateContact-prime paths from #191) must be
+    /// recognisable so the api.rs handler can swallow it instead of
+    /// panicking.
+    ///
+    /// We exercise the helper end-to-end with a real ML-DSA-65 keypair
+    /// so `vk_from_bytes` and `inbox_key_for` produce the same key the
+    /// node would echo back in a GetResponse.
+    #[test]
+    fn is_contact_inbox_key_recognises_imported_contact() {
+        use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+
+        // Real ML-DSA-65 keypair so vk_from_bytes succeeds.
+        let sk = MlDsa65::from_seed(&[7u8; 32].into());
+        let vk_bytes = MlDsaKeypair::verifying_key(&sk).encode().to_vec();
+
+        let contact = Contact {
+            local_alias: "bob".into(),
+            description: String::new(),
+            ml_dsa_vk_bytes: vk_bytes.clone(),
+            ml_kem_ek_bytes: vec![0u8; 1184],
+            required_tier: Tier::Day1,
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
+            verified: false,
+        };
+        insert_contact(contact).unwrap();
+
+        let vk = vk_from_bytes(&vk_bytes).expect("vk decodes");
+        let key = crate::inbox::inbox_key_for(&vk).expect("inbox_key_for");
+        assert!(
+            is_contact_inbox_key(&key),
+            "is_contact_inbox_key must return true for an imported contact's inbox key",
+        );
+    }
+
+    #[test]
+    fn is_contact_inbox_key_returns_false_for_unrelated_key() {
+        use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+
+        // Insert one contact.
+        let sk_a = MlDsa65::from_seed(&[1u8; 32].into());
+        let vk_a_bytes = MlDsaKeypair::verifying_key(&sk_a).encode().to_vec();
+        insert_contact(Contact {
+            local_alias: "alice".into(),
+            description: String::new(),
+            ml_dsa_vk_bytes: vk_a_bytes,
+            ml_kem_ek_bytes: vec![0u8; 1184],
+            required_tier: Tier::Day1,
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
+            verified: false,
+        })
+        .unwrap();
+
+        // Probe with a *different* keypair's inbox key — must not match.
+        let sk_b = MlDsa65::from_seed(&[2u8; 32].into());
+        let vk_b = MlDsaKeypair::verifying_key(&sk_b);
+        let other_key = crate::inbox::inbox_key_for(&vk_b).expect("inbox_key_for");
+        assert!(
+            !is_contact_inbox_key(&other_key),
+            "is_contact_inbox_key must return false for a key that is not any known contact's inbox",
+        );
+    }
+
+    #[test]
+    fn is_contact_inbox_key_empty_book_returns_false() {
+        use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+
+        let sk = MlDsa65::from_seed(&[3u8; 32].into());
+        let vk = MlDsaKeypair::verifying_key(&sk);
+        let key = crate::inbox::inbox_key_for(&vk).expect("inbox_key_for");
+        assert!(
+            !is_contact_inbox_key(&key),
+            "is_contact_inbox_key on an empty address book must return false",
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix WASM panic at `ui/src/api.rs:1467` ("tried to get wrong contract key: …") that fires whenever a node sends back a `GetResponse` for a contact's inbox key. The Get is produced by the rehydrate-prime / CreateContact-prime paths from #191 — every contact's inbox is fetched on import and on every page reload to populate the local node's contract store + register interest.
- The api.rs handler dispatches `GetResponse` by key: own-identity inbox → render; AFT record key → set_identity_contract; otherwise `unreachable!`. A contact's inbox falls through both arms and panics. Cascade: WASM panic → "RefCell already borrowed" in wasm-bindgen-futures → message client futures stall → app dead until reload.
- Add `address_book::is_contact_inbox_key(&key) -> bool`, check it in the fallback arm, log+drop. The webapp can't render a contact's inbox (messages are encrypted to the contact's ml_kem key, not ours) — the prime is fire-and-forget; only the node-side side-effects matter.

## Test plan

- [x] Unit: 3 regression tests exercising the helper end-to-end with real ML-DSA-65 keypairs (`is_contact_inbox_key_recognises_imported_contact`, `is_contact_inbox_key_returns_false_for_unrelated_key`, `is_contact_inbox_key_empty_book_returns_false`).
- [x] Full UI suite: `cargo test --no-default-features --features example-data,no-sync -p freenet-email-ui` → 102/102 pass.
- [x] Manual: live nodes (peer1@7509 launchd, peer2@7510 manual) on freenet-core 72f88e38 (with #4071, #4069). Browser opens both webapps cleanly post-fix; no WASM panic; send pipeline reaches "awaiting AFT delegate response" without crashing.
- [ ] Playwright: not in scope — the panic only manifests in the live-node build (`use-node`), not in `example-data,no-sync`.

## Notes

- Doesn't unblock the cross-node send end-to-end. After this fix, the send reaches AFT permission prompt, which times out because the prompt is rendered in the gateway shell page (out of view from the iframe) — separate UX issue, #190 territory.
- Discovered while validating freenet-core #4071 + #4069 (auto-fetch contract on non-hosting originator + clear ops.get on retry-loop exit). Those fixes are working: zero `missing contract parameters` errors post-restart on either node.