### PR TITLE
feat(ui): show webapp build version in pre-login header + sidebar

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -17,6 +17,7 @@
   "fmComposeSendingAs": "fm-compose-sending-as",
   "fmSidebarFingerprint": "fm-sidebar-fingerprint",
   "fmSidebarContacts": "fm-sidebar-contacts",
+  "fmSidebarVersion": "fm-sidebar-version",
   "fmReply": "fm-reply",
   "fmDelete": "fm-delete",
   "fmArchive": "fm-archive",

--- a/ui/public/vendor/css/components/login.css
+++ b/ui/public/vendor/css/components/login.css
@@ -77,6 +77,14 @@
       font-family: "Geist Mono", monospace; font-size: 9px; letter-spacing: 0.08em;
       text-transform: uppercase; color: var(--ink4);
     }
+    .topbar-version {
+      margin-left: 6px;
+      padding: 2px 6px;
+      border: 1px solid var(--ink5);
+      border-radius: 3px;
+      font-size: 8.5px; letter-spacing: 0.06em;
+      color: var(--ink3);
+    }
     .pulse-dot {
       width: 5px; height: 5px; border-radius: 50%; background: var(--trust); flex: 0 0 5px;
       animation: fm-keypulse 3s ease infinite;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1303,6 +1303,15 @@ fn Sidebar() -> Element {
                             }
                         }
                     }
+                    div { class: "conn-row",
+                        span { class: "lbl", "version" }
+                        span {
+                            class: "val",
+                            "data-testid": testid::FM_SIDEBAR_VERSION,
+                            title: "Webapp build version",
+                            "{crate::app_version()}"
+                        }
+                    }
                 }
                 button {
                     class: "nav-item",

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -28,6 +28,7 @@ struct CreateAlias(bool);
 #[allow(non_snake_case)]
 fn Topbar() -> Element {
     let app_name = crate::app_name();
+    let app_version = crate::app_version();
     rsx! {
         header { class: "topbar",
             div { class: "brand",
@@ -41,6 +42,7 @@ fn Topbar() -> Element {
             div { class: "topbar-state",
                 span { class: "pulse-dot" }
                 span { "local · ready" }
+                span { class: "topbar-version", title: "Webapp build version", "{app_version}" }
             }
         }
     }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -53,6 +53,18 @@ mod branding {
 
 pub(crate) use branding::app_name;
 
+/// Build version string for the UI, shown in the header chip and the
+/// sidebar connection card. Renders as `vX.Y.Z` from the
+/// `freenet-email-ui` crate version. Useful when two peers run
+/// different builds of the webapp — without a visible version it's
+/// easy to chase ghost bugs from a stale published-contract on one
+/// side. We deliberately keep this short (`v…`) so it fits next to
+/// the existing chips; the `title=` attribute can carry build metadata
+/// if we later want a longer string.
+pub(crate) fn app_version() -> &'static str {
+    concat!("v", env!("CARGO_PKG_VERSION"))
+}
+
 /// The base58-encoded `ContractInstanceId` of the signed webapp contract
 /// produced by `cargo make update-published-contract`.
 ///

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -41,6 +41,7 @@ pub(crate) const FM_COMPOSE_SENDING_AS: &str = "fm-compose-sending-as";
 // Sidebar
 pub(crate) const FM_SIDEBAR_FINGERPRINT: &str = "fm-sidebar-fingerprint";
 pub(crate) const FM_SIDEBAR_CONTACTS: &str = "fm-sidebar-contacts";
+pub(crate) const FM_SIDEBAR_VERSION: &str = "fm-sidebar-version";
 
 // Detail / open message
 pub(crate) const FM_REPLY: &str = "fm-reply";
@@ -143,6 +144,7 @@ mod tests {
             ("fmComposeSendingAs", super::FM_COMPOSE_SENDING_AS),
             ("fmSidebarFingerprint", super::FM_SIDEBAR_FINGERPRINT),
             ("fmSidebarContacts", super::FM_SIDEBAR_CONTACTS),
+            ("fmSidebarVersion", super::FM_SIDEBAR_VERSION),
             ("fmReply", super::FM_REPLY),
             ("fmDelete", super::FM_DELETE),
             ("fmArchive", super::FM_ARCHIVE),


### PR DESCRIPTION
## Summary

Two peers running different builds of the webapp produce subtle bugs that look like routing/state issues but are actually a published-contract mismatch. Without a visible version it's hard to tell at a glance which build a peer is on. This PR adds a \`vX.Y.Z\` chip in two places:

- **Pre-login Topbar**: rendered to the right of the existing "local · ready" chip so it's the first thing visible when the app loads.
- **Sidebar conn-card**: rendered below the existing \`connection · live\` and \`key · <fingerprint>\` rows so the version is part of the same diagnostic block users read when comparing peers.

Source: \`env!("CARGO_PKG_VERSION")\` from the \`freenet-email-ui\` crate exposed via \`crate::app_version()\` in \`ui/src/lib.rs\`.

## Test plan

- [x] \`cargo check\` passes for both \`example-data,no-sync\` and \`use-node\` feature sets.
- [x] \`cargo clippy --all-targets -- -D warnings\` clean.
- [ ] Visual: load both peers in browser, verify version chip renders in the header (pre-login) and in the sidebar (post-login).
- [ ] Playwright: existing tests unchanged. Test id \`fmSidebarVersion\` is registered for future regression coverage.

## Notes

Discovered while debugging cross-node send: peer1 and peer2 had visually identical UIs but different rehydrate-prime behavior (peer1 was on the post-#193 build, peer2 was older). Without a version chip there was no way to tell from the screen.