### PR TITLE
chore: bump workspace + ui to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-core"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ed25519-dalek",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-ui"
-version = "0.0.1"
+version = "0.1.2"
 dependencies = [
  "arc-swap",
  "base64",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "web-container-sign"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.2"
 edition = "2024"
 license = "LGPL-3.0-or-later"
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet-email-ui"
-version = "0.0.1"
+version.workspace = true
 edition = "2024"
 license.workspace = true
 publish = false


### PR DESCRIPTION
## Summary

Bump \`[workspace.package].version\` from 0.1.0 to 0.1.2 to match the next release tag (last shipped tag is v0.1.1). Switch \`ui/Cargo.toml\` from the stale standalone \`version = "0.0.1"\` to \`version.workspace = true\` so the version chip introduced in #196 reflects releases from a single source of truth.

## Test plan

- [x] \`cargo check --workspace\` passes; ui crate now compiles as \`freenet-email-ui v0.1.2\`.
- [ ] Once merged, run \`scripts/release.sh 0.1.2\` from main against a network-connected freenet node per RELEASING.md.

## Notes

The inbox + web-container contracts keep independent versions because they ship as on-chain artifacts with their own update cadence — only the workspace crates pinned to the workspace version are touched here.