### PR TITLE
fix(api): swallow UpdateNotification for contact inbox keys (#198)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ed25519-dalek",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-ui"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arc-swap",
  "base64",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "web-container-sign"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "LGPL-3.0-or-later"
 

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1573,7 +1573,29 @@ pub(crate) async fn node_comms(
                                 token_rec_to_id.insert(key, identity);
                             }
                             _ => {
-                                unreachable!("tried to get wrong contract key: {key}")
+                                // UpdateNotification for a contact's inbox:
+                                // arrives because the rehydrate-prime path
+                                // (#191) subscribed us to every contact's
+                                // inbox to populate the local node's store.
+                                // The state is opaque (encrypted to the
+                                // contact's ml_kem key, not ours), so we
+                                // can't decrypt or display it — just drop
+                                // the notification. Without this guard the
+                                // arm panicked with `unreachable!` and took
+                                // the whole webapp down (#198).
+                                if crate::app::address_book::is_contact_inbox_key(&key) {
+                                    crate::log::debug!(
+                                        "UpdateNotification: contact inbox \
+                                        {key} (#198) — drop"
+                                    );
+                                } else {
+                                    crate::log::error(
+                                        format!(
+                                            "UpdateNotification for unknown contract key: {key}"
+                                        ),
+                                        None,
+                                    );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

- UpdateNotification arm at `api.rs:1576` panicked with `unreachable!` when the host pushed a notification for a contact's inbox key. Same family as #195's GetResponse fix.
- Rehydrate-prime (#191) subscribes us to every contact's inbox to populate the local store; the resulting state is opaque (encrypted to contact's ml_kem key) so we drop the notification.
- Bumps workspace + UI to **0.1.3** so prod release ships the fix.

## Symptom

Hsantos's webapp panicked while sending — browser console showed:

```
WASM PANIC: tried to get wrong contract key: 3znD1t4PQ8FNbDrCx9L7bXkVnrd2Zc6mMz8zybZyb7on
RefCell already borrowed   ← cascaded panic
```

`3znD1t4P...` is debugtest's inbox key (his contact, not his own). The `unreachable!` arm at 1576 had no guard for that case.

## Test plan

- [x] `cargo check -p freenet-email-ui`
- [x] `cargo fmt --all` + `cargo clippy -p freenet-email-ui -- -D warnings`
- [x] `cargo test -p freenet-email-ui --lib` (102 passed)
- [ ] Cut v0.1.3 release after merge; verify hsantos can send without WASM panic