### PR TITLE
fix(send): bundle sender's AFT record inline as RelatedStateAndDelta (freenet-core#4077 workaround)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "ed25519-dalek",
  "serde",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-ui"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arc-swap",
  "base64",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "web-container-sign"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "LGPL-3.0-or-later"
 

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -530,6 +530,26 @@ impl AftRecords {
         Ok(())
     }
 
+    /// Serialize the cached `TokenAllocationRecord` for `identity` as a
+    /// JSON byte vector suitable for inclusion as
+    /// `UpdateData::RelatedStateAndDelta { state, .. }`. Returns `None`
+    /// if the identity has no record cached locally.
+    ///
+    /// Used by `MessageModel::finish_sending` (#198 follow-up) to bundle
+    /// the sender's AFT record inline with the inbox UPDATE so the
+    /// receiver doesn't need to issue a sub-op GET — works around
+    /// freenet-core#4077 where `fetch_related_via_network` times out
+    /// against AFT contracts that aren't close to the receiver in
+    /// keyspace, pinning the receiver's inbox to its initial empty
+    /// state via `merge_rejected_valid_local`.
+    pub fn record_state_for(identity: &Identity) -> Option<Vec<u8>> {
+        RECORDS.with(|recs| {
+            recs.borrow()
+                .get(identity)
+                .and_then(|rec| rec.clone().serialized().ok())
+        })
+    }
+
     pub fn update_record(identity: Identity, update_data: UpdateData) -> Result<(), DynError> {
         let record = match update_data {
             StateUpdate(state) => {

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -365,21 +365,49 @@ impl MessageModel {
         });
 
         if let Some(update) = pending_update {
+            let token_record = assignment.token_record;
             let stored = update.msg.to_stored(assignment, &update.sender)?;
             let delta = UpdateInbox::AddMessages {
                 messages: vec![stored],
             };
             let delta_bytes = serde_json::to_vec(&delta)?;
-            // Send a bare `UpdateData::Delta` and let the runtime resolve
-            // the inbox contract's `update_state` requires(AFT record)
-            // signal via `fetch_related_via_network`. This relies on
-            // freenet-core PR #4006 (validate-side) + PR #4007
-            // (update-side) — without those the receiver's
-            // `update_state` errors with MissingRelated and the broadcast
-            // bounces through ResyncRequest recovery, see #80.
+            // Bundle the sender's AFT record state inline as
+            // `RelatedStateAndDelta`. The inbox contract's
+            // `update_state` reads it from the bundle (see
+            // contracts/inbox/src/lib.rs:738-774, the
+            // `RelatedStateAndDelta` arm) instead of asking the runtime
+            // to fetch it. This works around freenet-core#4077 where
+            // `fetch_related_via_network` times out against AFT
+            // contracts that are far from the receiver in keyspace,
+            // and the receiver's inbox state stays pinned at the
+            // initial empty value via `merge_rejected_valid_local`.
+            //
+            // Falls back to bare `UpdateData::Delta` if the local AFT
+            // record isn't cached (shouldn't happen for the sender at
+            // send time — `assign_token` already required RECORDS hit
+            // — but the fallback keeps us correct against future
+            // refactors of that ordering).
+            let data = match crate::aft::AftRecords::record_state_for(&update.sender) {
+                Some(state_bytes) => UpdateData::RelatedStateAndDelta {
+                    related_to: token_record,
+                    state: state_bytes.into(),
+                    delta: delta_bytes.into(),
+                },
+                None => {
+                    crate::log::error(
+                        format!(
+                            "finish_sending: no AFT record cached for sender `{alias}`; \
+                             falling back to bare Delta — receiver may stall on freenet-core#4077",
+                            alias = update.sender.alias()
+                        ),
+                        None,
+                    );
+                    UpdateData::Delta(delta_bytes.into())
+                }
+            };
             let request = ContractRequest::Update {
                 key: inbox_contract,
-                data: UpdateData::Delta(delta_bytes.into()),
+                data,
             };
             client.send(request.into()).await?;
             // todo: event after sending, we may fail to update, must keep this in mind in case we receive no confirmation


### PR DESCRIPTION
## Summary

- Workaround for freenet-core#4077: receivers' inboxes never apply UPDATEs because the runtime's related-contract fetch times out + `merge_rejected_valid_local` pins stale state forever.
- Switch `MessageModel::finish_sending` from bare `UpdateData::Delta` to `UpdateData::RelatedStateAndDelta`, bundling the sender's cached AFT record state inline. The inbox contract already supports this variant (contracts/inbox/src/lib.rs:738-774).
- Bumps workspace + UI to **0.1.4** for prod release.

## Background

Hsantos's node logs (real-network test, 2026-05-10) showed:

```
WARN runtime: Failed to fetch related contract for update_state requires()
    contract=4EBLuFr... related_id=4jrpVK6...
    error=missing related contract: 4jrpVK6...

WARN runtime: BroadcastToStreaming update skipped: contract not ready locally
    error=put error... reason: timed out fetching related contracts

WARN runtime: Merge rejected incoming state but local state is valid - not replacing
    contract=4EBLuFr... local_state_size=11977 incoming_state_size=241290
    event=\"merge_rejected_valid_local\"
```

Receiver's inbox stays at 11977 bytes (initial empty) while sender's is 241290. Bundling the AFT record inline removes the failure mode.

## Test plan

- [x] `cargo check -p freenet-email-ui`
- [x] `cargo fmt --all` + `cargo clippy -p freenet-email-ui -- -D warnings`
- [x] `cargo test -p freenet-email-ui --lib` (102 passed)
- [ ] Cut v0.1.4 release after merge; re-run cross-peer test with hsantos to verify inbox now populates