### PR TITLE
debug(inbox): surface ContractError on update_state rejection (#4077 diagnosis)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "ed25519-dalek",
  "serde",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-ui"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "arc-swap",
  "base64",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "web-container-sign"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "LGPL-3.0-or-later"
 

--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -674,6 +674,69 @@ impl ContractInterface for Inbox {
         state: State<'static>,
         updates: Vec<UpdateData<'static>>,
     ) -> Result<UpdateModification<'static>, ContractError> {
+        // Surface every rejection path with the underlying error message
+        // so receiver-side diagnosis isn't blind. The host-side runtime
+        // log only shows "execution error: invalid contract update" with
+        // no detail; this is the only signal that distinguishes (e.g.)
+        // a stale-token rebroadcast from a sigverify failure or a
+        // `requires(missing)` request. See freenet/freenet-core#4077.
+        let result = Self::update_state_impl(parameters, state, updates);
+        if let Err(ref e) = result {
+            freenet_stdlib::log::info(&format!("inbox.update_state REJECTED: {e}"));
+        }
+        result
+    }
+
+    fn summarize_state(
+        _parameters: Parameters<'static>,
+        state: State<'static>,
+    ) -> Result<StateSummary<'static>, ContractError> {
+        let inbox = Inbox::try_from(&state)?;
+        inbox.summarize()
+    }
+
+    fn get_state_delta(
+        _parameters: Parameters<'static>,
+        state: State<'static>,
+        summary: StateSummary<'static>,
+    ) -> Result<StateDelta<'static>, ContractError> {
+        let inbox = Inbox::try_from(&state)?;
+        let summary = InboxSummary::try_from(summary)?;
+        let new_messages: Vec<Message> = inbox
+            .messages
+            .into_iter()
+            .filter(|m| !summary.0.contains(&m.token_assignment.assignment_hash))
+            .collect();
+        // The delta must match the wire shape that `update_state`'s
+        // `UpdateData::Delta` arm expects: a `UpdateInbox::AddMessages`
+        // enum, not a bare `Inbox` struct. Serializing the inbox struct
+        // produces `{"messages":[...]}` which the receiver fails to
+        // decode as `UpdateInbox` ("unknown variant `messages`, expected
+        // one of AddMessages, RemoveMessages, ModifySettings"). The
+        // delta producer + consumer must agree on the JSON shape.
+        let delta = UpdateInbox::AddMessages {
+            messages: new_messages,
+        };
+        let serialized =
+            serde_json::to_vec(&delta).map_err(|err| ContractError::Deser(format!("{err}")))?;
+        Ok(StateDelta::from(serialized))
+    }
+}
+
+#[cfg(feature = "contract")]
+impl Inbox {
+    /// Real body of `update_state`. Split out from the trait method so
+    /// the trait method can wrap it with diagnostic logging on
+    /// rejection: the host-runtime collapses any `ContractError` to
+    /// `execution error: invalid contract update` in its log, hiding
+    /// which of the dozen rejection paths fired (sigverify,
+    /// token-policy, replay, missing-related, etc.). See
+    /// freenet/freenet-core#4077 for the diagnosis trail this enables.
+    fn update_state_impl(
+        parameters: Parameters<'static>,
+        state: State<'static>,
+        updates: Vec<UpdateData<'static>>,
+    ) -> Result<UpdateModification<'static>, ContractError> {
         freenet_stdlib::log::info(&format!(
             "inbox.update_state called: state_size={} updates={}",
             state.as_ref().len(),
@@ -802,41 +865,6 @@ impl ContractInterface for Inbox {
         } else {
             Ok(UpdateModification::requires(missing_related)?)
         }
-    }
-
-    fn summarize_state(
-        _parameters: Parameters<'static>,
-        state: State<'static>,
-    ) -> Result<StateSummary<'static>, ContractError> {
-        let inbox = Inbox::try_from(&state)?;
-        inbox.summarize()
-    }
-
-    fn get_state_delta(
-        _parameters: Parameters<'static>,
-        state: State<'static>,
-        summary: StateSummary<'static>,
-    ) -> Result<StateDelta<'static>, ContractError> {
-        let inbox = Inbox::try_from(&state)?;
-        let summary = InboxSummary::try_from(summary)?;
-        let new_messages: Vec<Message> = inbox
-            .messages
-            .into_iter()
-            .filter(|m| !summary.0.contains(&m.token_assignment.assignment_hash))
-            .collect();
-        // The delta must match the wire shape that `update_state`'s
-        // `UpdateData::Delta` arm expects: a `UpdateInbox::AddMessages`
-        // enum, not a bare `Inbox` struct. Serializing the inbox struct
-        // produces `{"messages":[...]}` which the receiver fails to
-        // decode as `UpdateInbox` ("unknown variant `messages`, expected
-        // one of AddMessages, RemoveMessages, ModifySettings"). The
-        // delta producer + consumer must agree on the JSON shape.
-        let delta = UpdateInbox::AddMessages {
-            messages: new_messages,
-        };
-        let serialized =
-            serde_json::to_vec(&delta).map_err(|err| ContractError::Deser(format!("{err}")))?;
-        Ok(StateDelta::from(serialized))
     }
 }
 


### PR DESCRIPTION
## Summary

Inbox \`update_state\` has roughly a dozen distinct rejection paths, all of which collapse to \`execution error: invalid contract update\` in the host runtime's log because the runtime only sees the outer \`ContractError\`. Receiver-side diagnosis is therefore blind to which check actually failed (sigverify, token-policy mismatch, token replay, missing-related, malformed delta, …).

This PR wraps the trait method around an inherent \`update_state_impl\` and adds a single log line on the rejection path:

\`\`\`
inbox.update_state REJECTED: {underlying ContractError}
\`\`\`

Sits alongside the existing \`inbox.update_state called: state_size=… updates=…\` entry, so a tail of the contract log shows both the entry parameters and the failure reason.

## Why

Real-network test (mail v0.1.4 against freenet-core 0.2.56-dirty incl. freenet/freenet-core#4080) showed receiver still rejecting incoming broadcasts:

\`\`\`
Merge rejected incoming state but local state is valid - not replacing
local_state_size=11945 incoming_state_size=299035
reason: execution error: invalid contract update
event=\"merge_rejected_valid_local\"
\`\`\`

The fetch-related path is no longer the cause (the parallel fetch in #4080 lands the related contracts), so the contract is rejecting for a different reason — but we can't see which one. This log unblocks the next round of diagnosis.

## Scope

- Diagnostic only. No behavior change.
- Bumps workspace + UI to 0.1.5 because the contract WASM bytes change (new log call linked in).
- Inbox contract id rotates per release as usual (#199); webapp URL is now stable thanks to the facade in #205.

## Test plan

- [x] \`cargo make build\`
- [x] \`cargo test -p freenet-email-inbox --features contract\` (26 passed)
- [x] \`cargo fmt --all\`, \`cargo clippy -p freenet-email-ui -- -D warnings\` clean
- [ ] After merge: cut v0.1.5, re-test cross-peer send, capture rejection log line, follow up with the actual fix

## Refs

- freenet/freenet-core#4077 — the umbrella issue this is diagnostic for
- freenet/freenet-core#4080 — parallel related-fetch (merged, in v0.2.57 once that releases)