### PR TITLE
feat(release+ui): wire facade pointer flip into release.sh + log FACADE_ID (#200 Phase 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,9 +272,15 @@ sidestep CBOR map-ordering concerns.
 **Phase 1 scope**: facade lives alongside the web-container, not yet
 replacing it. The UI is still served at the rotating web-container id;
 the facade is published once per environment as the new stable entry
-point. Phase 3 (issue #200 sub-task) flips the UI to embed the facade id
-exclusively. Phase 2 (issue #199) handles per-identity inbox + AFT
-contract migration.
+point.
+
+**Phase 3 scope (#200)**: `scripts/release.sh` automatically renders +
+signs + UPDATEs the facade pointer per release (so users hitting the
+facade URL get the new app). UI's `lib.rs` logs both
+`WEB_CONTAINER_CONTRACT_ID` and `FACADE_CONTRACT_ID` on startup so
+devtools shows which facade a build references. Both are conditional
+on `published-contract/facade-id.txt` being committed (one-time facade
+publish required first; see RELEASING.md §"Facade contract update").
 
 **Inbox + AFT lockfile isolation (issue #199 Phase A)**: same pattern
 extended to every other on-chain contract:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -192,41 +192,63 @@ There are two ways to cover the real round trip:
 Post the liveness result and whichever of (1) or (2) you ran as a
 comment on the release tracking issue.
 
-## Facade contract update (issue #200, Phase 1)
+## Facade contract update (issue #200, Phases 1 + 3)
 
 The web-container contract id rotates per release (issue #198). The
 facade contract gives users a stable bookmarkable URL across releases.
 See AGENTS.md §"Facade contract" for the architecture.
 
-Per release, after `scripts/release.sh` finishes (which leaves the new
-web-container id in `published-contract/contract-id.txt`), flip the
-facade pointer:
+**Phase 3 (#200) — automatic per-release flip**: `scripts/release.sh`
+now does this for you. After the contract publish + before the commit,
+the script:
+
+1. Re-renders the loader with the new `current_app_id` baked in
+   (`cargo make build-facade-loader` with `FACADE_CURRENT_APP_ID` set).
+2. Signs a new facade state with the production key (`cargo make
+   sign-facade-state`).
+3. Prompts to push the facade UPDATE to the network (`fdev execute
+   update <FACADE_ID> target/facade/facade.state network`).
+
+The facade-flip block is **conditional on
+`published-contract/facade-id.txt` being committed** — i.e. the facade
+must have been published once and its id committed first. Until then,
+the script warns and skips the flip; the rest of the release still goes
+through.
+
+**One-time facade publish (per environment)**: before Phase 3 runs for
+the first time on a network, publish the facade contract once and
+commit its id. Manual steps:
 
 ```bash
-# 1. Re-render the loader with the new current_app_id baked in.
-cargo make build-facade-loader
+# Build the facade and produce the snapshot.
+cargo make update-published-facade
+git add published-contract/facade.{wasm,parameters} published-contract/facade-id.txt
+git commit -m "chore(facade): commit production facade snapshot"
 
-# 2. Sign a new facade state pointing at the new app id with bumped version.
-cargo make sign-facade-state          # uses production key
-
-# 3. Push the UPDATE to the network.
-fdev execute update \
-    "$(cat published-contract/facade-id.txt)" \
-    target/facade/facade.state \
+# Publish (PUT) the facade with initial state pointing at the current
+# web-container id. After this, every subsequent release.sh run flips
+# its state via UPDATE.
+cargo make publish-facade-test    # for the local sandbox
+# OR for production:
+fdev publish \
+    --code published-contract/facade.wasm \
+    --parameters published-contract/facade.parameters \
+    contract --state target/facade/facade.state \
     network
 ```
 
-The facade itself is published **once per environment** (test sandbox
-+ production). Subsequent releases only flip its state.
+**Phase 1/3 status**: the committed `published-contract/facade.{wasm,
+parameters,id.txt}` snapshot is not yet present in this repo. The
+byte-equality CI gate is informational until rustc is pinned and the
+snapshot is rebuilt on Linux CI (issue #206). Until then:
 
-**Phase 1 status**: the committed `published-contract/facade.{wasm,
-parameters}` snapshot is not yet present in this repo. The byte-equality
-CI gate is informational until rustc is pinned and the snapshot is
-rebuilt on Linux CI. Until then, regenerate the wasm locally before any
-publish (`cargo make update-published-facade`) and verify the resulting
-contract id matches whatever was last published to the network — there
-is no in-repo source of truth to compare against yet. Once the snapshot
-lands, this paragraph should be replaced with: "If
+- Regenerate the wasm locally before any publish
+  (`cargo make update-published-facade`).
+- The Phase 3 facade-flip in `release.sh` will warn + skip until you
+  commit `published-contract/facade-id.txt`. Run the one-time publish
+  steps above first.
+
+Once the snapshot lands, this paragraph should be replaced with: "If
 `scripts/check-facade-byte-equal.sh` fails, treat as a release blocker."
 
 ## Recovery

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -188,6 +188,54 @@ CONTRACT_ID=$(cat published-contract/contract-id.txt)
 echo ""
 echo "  ✓ published contract id: $CONTRACT_ID"
 echo ""
+
+# ─── Facade pointer flip (issue #200 Phase 3) ──────────────────────────────
+#
+# The web-container contract id rotates per release (#198 root cause).
+# Users hit the facade contract instead — a stable bookmarkable URL whose
+# state points at the current release's webapp. Per release we re-render
+# the facade loader with the new current_app_id baked in, sign a new
+# facade state with bumped version, and UPDATE the facade contract.
+#
+# Conditional: only runs when published-contract/facade-id.txt exists
+# (i.e. the facade has been published once and its id committed). Until
+# then, this step warns + skips so the rest of the release still goes
+# through. See #200 Phase 1 (PR #205) and #206 (Linux-built snapshot).
+
+if [ -f published-contract/facade-id.txt ]; then
+    FACADE_ID=$(cat published-contract/facade-id.txt | tr -d '[:space:]')
+    echo "═══ Flipping facade pointer (issue #200) ════════════════════════════"
+    echo "  facade contract id: $FACADE_ID"
+    echo "  pointing at:        $CONTRACT_ID"
+
+    # Re-render the loader with the new current_app_id and sign the
+    # facade state with the production key (same key that signs the
+    # web-container — facade reuses it).
+    FACADE_CURRENT_APP_ID="$CONTRACT_ID" cargo make build-facade-loader
+    cargo make sign-facade-state
+
+    FACADE_STATE="$REPO_ROOT/target/facade/facade.state"
+    if [ ! -f "$FACADE_STATE" ]; then
+        die "facade state not produced at $FACADE_STATE — sign step failed?"
+    fi
+
+    confirm "Push facade UPDATE to the network now?"
+
+    # `network` mode is the production target; `local` would publish to a
+    # `freenet local` sandbox. fdev execute update takes positional args
+    # KEY DELTA [RELEASE].
+    fdev execute update "$FACADE_ID" "$FACADE_STATE" network
+
+    echo "  ✓ facade UPDATEd; bookmarked URL stays stable across releases"
+    echo ""
+else
+    echo "  ⚠️  published-contract/facade-id.txt not committed yet."
+    echo "      Skipping facade pointer flip (issue #200 Phase 1 prerequisite)."
+    echo "      Once the facade is published once and the id committed, this"
+    echo "      step will run automatically per release."
+    echo ""
+fi
+
 echo "Diff in published-contract/:"
 git status --short -- published-contract/
 echo ""
@@ -242,9 +290,20 @@ echo ""
 echo "✅ released $TAG"
 echo ""
 echo "Next steps:"
-echo "  1. Wait ~30s for the contract to propagate"
-echo "  2. Run: scripts/smoke-test-production.sh <gateway-url>"
-echo "     (the gateway URL will look like"
-echo "      http://<gateway-host>:<port>/contract/web/$CONTRACT_ID/)"
-echo "  3. Post the smoke-test result as a comment on issue #9"
+echo "  1. Wait ~30s for the contract (and facade UPDATE, if applicable)"
+echo "     to propagate"
+echo "  2. Smoke-test against the rotating webapp id:"
+echo "       scripts/smoke-test-production.sh \\"
+echo "         http://<gw>:<port>/contract/web/$CONTRACT_ID/"
+if [ -f published-contract/facade-id.txt ]; then
+    FACADE_ID_FOR_NOTES=$(cat published-contract/facade-id.txt | tr -d '[:space:]')
+    echo "  3. Smoke-test against the STABLE facade URL (issue #200):"
+    echo "       scripts/smoke-test-production.sh \\"
+    echo "         http://<gw>:<port>/contract/web/$FACADE_ID_FOR_NOTES/"
+    echo "     The facade URL is what users bookmark and what stays stable"
+    echo "     across releases."
+    echo "  4. Post the smoke-test result as a comment on issue #9"
+else
+    echo "  3. Post the smoke-test result as a comment on issue #9"
+fi
 echo ""

--- a/ui/build.rs
+++ b/ui/build.rs
@@ -103,6 +103,20 @@ fn main() {
         }
     }
 
+    // Optional artifacts — present once their respective phase landed.
+    // Missing is fine; we emit an empty FACADE_ID env. Listing it here
+    // makes cargo rebuild when the file appears/changes.
+    //
+    // facade-id.txt: issue #200 Phase 3. Once committed, the UI logs it
+    // alongside the rotating web-container id so devtools shows which
+    // facade this build references.
+    let facade_id_path = root.join("published-contract/facade-id.txt");
+    println!("cargo:rerun-if-changed={}", facade_id_path.display());
+    let facade_id = std::fs::read_to_string(&facade_id_path)
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+    println!("cargo:rustc-env=FREENET_EMAIL_FACADE_ID={facade_id}");
+
     if !missing.is_empty() {
         eprintln!();
         eprintln!("error: freenet-email-ui cannot be built because the following");

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -84,6 +84,17 @@ pub(crate) const WEB_CONTAINER_CONTRACT_ID: &str =
 #[cfg(not(feature = "use-node"))]
 pub(crate) const WEB_CONTAINER_CONTRACT_ID: &str = "";
 
+/// Facade contract id — the STABLE bookmarkable URL users hit (#200).
+/// Populated by `ui/build.rs` from `published-contract/facade-id.txt`,
+/// or empty when the snapshot hasn't been committed yet (Phase 1
+/// prereq) OR when the offline UI build skips build.rs entirely.
+/// Phase 3 (this constant) only logs the value; the routing decision
+/// remains in the browser URL.
+pub(crate) const FACADE_CONTRACT_ID: &str = match option_env!("FREENET_EMAIL_FACADE_ID") {
+    Some(s) => s,
+    None => "",
+};
+
 type DynError = Box<dyn std::error::Error + Send + Sync>;
 
 pub fn main() {
@@ -118,6 +129,12 @@ pub fn main() {
     {
         let id = WEB_CONTAINER_CONTRACT_ID.trim();
         log::info(format!("web-container contract id (build-embedded): {id}"));
+        let facade = FACADE_CONTRACT_ID.trim();
+        if facade.is_empty() {
+            log::info("facade contract id: <not committed yet — issue #200 Phase 1 prereq>");
+        } else {
+            log::info(format!("facade contract id (build-embedded): {facade}"));
+        }
     }
 
     // In offline mode (`no-sync` / `!use-node`), the WebSocket bridge never


### PR DESCRIPTION
## Summary

Phase 3 of #200 — makes the facade actually used.

**release.sh**: after contract publish + before commit, builds the loader with the new `current_app_id` baked in, signs a new facade state with the production key, and runs `fdev execute update <FACADE_ID> target/facade/facade.state network` to flip the facade pointer. Asks for confirmation before each network-visible step.

**Conditional**: the block runs only when \`published-contract/facade-id.txt\` is committed (one-time facade publish prereq). Until then it warns + skips so the rest of the release still runs. Once the snapshot lands (#206), Phase 3 becomes automatic per release.

**UI**: new \`FACADE_CONTRACT_ID\` constant populated by \`ui/build.rs\` from the snapshot via \`cargo:rustc-env\`. Uses \`option_env!\` so the offline UI build still compiles when build.rs early-returns. Logged on startup alongside \`WEB_CONTAINER_CONTRACT_ID\` so devtools shows which facade a build references.

## Changes

- \`scripts/release.sh\` — facade-flip block + updated post-release notes.
- \`ui/build.rs\` — emit \`FREENET_EMAIL_FACADE_ID\` env (empty when missing); rerun-if-changed.
- \`ui/src/lib.rs\` — \`FACADE_CONTRACT_ID\` constant + startup log.
- \`RELEASING.md\` — documents new auto-flip behavior + one-time facade publish steps.
- \`AGENTS.md\` — Phase 3 paragraph in §"Facade contract".

## Test plan

- [x] \`cargo test -p freenet-email-ui --no-default-features --features example-data,no-sync\` — 102 pass
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy -p freenet-email-ui --no-default-features --features example-data,no-sync -- -D warnings\` clean
- [x] \`bash -n scripts/release.sh\` syntax ok
- [ ] CI: build-and-test passes
- [ ] Manual (post-merge): publish facade once, commit facade-id.txt, run a real release, verify the facade UPDATE goes through and the bookmarked URL serves the new app

## Related

- #200 Phase 3 (this PR)
- #200 Phase 1 (PR #205) — facade contract + signer + loader
- #198 (PR #208) — facade lockfile isolation
- #206 — pin rustc + Linux-built snapshot (prerequisite for the facade-flip block to actually run)

Refs #200.