### PR TITLE
test(e2e): fix backup-download timeout via shell-proxy postMessage assertion (closes #203)

### DIFF
--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -171,16 +171,62 @@ test.describe("Live node E2E", () => {
 
       // ── Step 5: regression for #77 (export download blocked) ──────
       // freenet-core#4008 (`allow-downloads` in iframe sandbox) shipped
-      // in v0.2.54.
-      const downloadPromise = page.waitForEvent("download", { timeout: 5_000 });
+      // in v0.2.54. PR #194 then moved the actual download to a
+      // shell-page proxy: the sandboxed app-frame has an opaque origin
+      // and `<a download>` either silently fails (Firefox) or saves
+      // unreachably (Chrome). Inside the iframe the app posts the
+      // payload to the parent shell via `__freenet_shell__: true,
+      // type: "download"`; the gateway shell page does the actual
+      // download from its own origin (handler in freenet-core
+      // path_handlers.rs).
+      //
+      // Asserting `page.waitForEvent("download")` is brittle here —
+      // depends on which frame fires the event under the shell-proxy
+      // path. The contract that PR #194 ships is the postMessage
+      // payload itself, so assert on that instead. Install the listener
+      // on the shell page BEFORE the click so we don't race the post.
+      // Two-step pattern: install captures the next matching message on
+      // `window.__fm_proxy_download__`; await polls for it.
+      await page.evaluate(() => {
+        const w = window as unknown as { __fm_proxy_download__?: unknown };
+        w.__fm_proxy_download__ = undefined;
+        window.addEventListener("message", function handler(ev: MessageEvent) {
+          const data = ev.data as Record<string, unknown> | null;
+          if (!data || typeof data !== "object") return;
+          if (data.__freenet_shell__ !== true || data.type !== "download") return;
+          window.removeEventListener("message", handler);
+          w.__fm_proxy_download__ = {
+            filename: String(data.filename ?? ""),
+            mimeType: String(data.mimeType ?? ""),
+            base64Len: typeof data.base64 === "string" ? data.base64.length : 0,
+          };
+        });
+      });
       await appAfterReload
         .locator(`[data-testid="fm-id-row"][data-alias="${ALIAS_T1_ALICE}"] [data-testid="fm-id-backup"]`)
         .click();
-      const download = await downloadPromise;
+      const proxyMessage = await page.waitForFunction(
+        () => {
+          const w = window as unknown as { __fm_proxy_download__?: unknown };
+          return w.__fm_proxy_download__;
+        },
+        undefined,
+        { timeout: 10_000 },
+      ).then((handle) =>
+        handle.jsonValue() as Promise<{ filename: string; mimeType: string; base64Len: number }>,
+      );
       expect(
-        download.suggestedFilename(),
+        proxyMessage.filename,
         "backup filename matches freenet-identity-<alias>.json (regression for #77)",
       ).toMatch(/freenet-identity-.+\.json/);
+      expect(
+        proxyMessage.mimeType,
+        "backup proxied as application/json",
+      ).toBe("application/json");
+      expect(
+        proxyMessage.base64Len,
+        "backup payload is non-empty base64",
+      ).toBeGreaterThan(0);
     } finally {
       stopPermissionPump();
     }


### PR DESCRIPTION
## Summary

`ui/tests/live-node.spec.ts` step 5 (#77 regression check) has timed out on every tag-triggered run + nightly cron since v0.1.2. PR #194 moved identity-backup downloads from a direct `<a download>` in the sandboxed app frame to a postMessage proxy through the gateway shell page (the opaque iframe origin makes the direct path silently fail in Firefox / save unreachably in Chrome).

The test was still asserting via `page.waitForEvent('download')` on the shell page. Under the proxy path, the actual download fires from a different frame context, so the 5s wait timed out.

Switch to asserting the postMessage payload directly. PR #194's contract is `__freenet_shell__: true, type: 'download'` carrying `filename` + `mimeType` + base64 bytes — that's the on-the-wire signal the test should bind to. Install the listener on the shell page BEFORE clicking the backup button to avoid racing the post.

## Test plan

- [x] `npx playwright test live-node.spec.ts --list` parses cleanly.
- [ ] e2e-real-node CI on this PR: chromium project's "create identity → reload persists → drives permission flow" passes step 5 instead of timing out.
- [ ] Other two tests in the spec (cross-node send + multi-round) unaffected.

## Notes

- Asserting on the postMessage payload is more robust than chasing the actual download event across frame contexts, and matches the contract PR #194 explicitly shipped.
- 10s timeout on the postMessage poll (vs old 5s `waitForEvent`) buys headroom for slow chromium starts on ubicloud without being so high that real failures hide behind it.