### PR TITLE
fix(facade): pack loader as tar.xz so gateway can serve facade URL

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -255,9 +255,58 @@ cd "$ROOT/contracts/facade"
 cargo build --profile "${BUILD_PROFILE}" --target "${CONTRACT_TARGET}"
 '''
 
+[tasks.pack-facade-loader]
+description = "Pack the rendered facade loader (dist/index.html) into a tar.xz blob the freenet-core gateway can serve as a webapp."
+dependencies = ["build-facade-loader"]
+script_runner = "bash"
+script = '''
+set -euo pipefail
+ROOT="${CARGO_MAKE_WORKING_DIRECTORY}"
+APP_ID="${FACADE_CURRENT_APP_ID:-$(cat "$ROOT/published-contract/contract-id.txt")}"
+DIST_DIR="$ROOT/contracts/facade-loader/dist"
+LOADER_HTML="$DIST_DIR/index.html"
+if [ ! -f "$LOADER_HTML" ]; then
+    echo "error: $LOADER_HTML missing (build-facade-loader should have produced it)" >&2
+    exit 1
+fi
+# Sanity: the rendered HTML MUST embed the current_app_id we're about
+# to sign over, otherwise the facade pointer redirects users to a
+# different app than the loader actually fetches.
+if ! grep -q "$APP_ID" "$LOADER_HTML"; then
+    echo "error: $LOADER_HTML does not embed current_app_id '$APP_ID'." >&2
+    echo "       Re-render with: FACADE_CURRENT_APP_ID=$APP_ID cargo make build-facade-loader" >&2
+    exit 1
+fi
+mkdir -p "$ROOT/target/facade"
+# Use GNU tar for reproducibility (matches compress-webapp). The
+# gateway's WebApp::try_from runs XzDecoder → tar.unpack over these
+# bytes, so the archive must be a real tar+xz containing index.html.
+if command -v gtar >/dev/null 2>&1; then
+    TAR=gtar
+elif tar --version 2>/dev/null | grep -qi 'gnu tar'; then
+    TAR=tar
+else
+    echo "warning: GNU tar not found — facade loader archive will not be" >&2
+    echo "         byte-identical across machines (signing is per-build" >&2
+    echo "         anyway so this only affects diff noise)." >&2
+    TAR=""
+fi
+OUT="$ROOT/target/facade/loader.tar.xz"
+if [ -n "$TAR" ]; then
+    "$TAR" --sort=name \
+        --mtime='2024-01-01 00:00:00 UTC' \
+        --owner=0 --group=0 --numeric-owner \
+        -C "$DIST_DIR" \
+        -cJf "$OUT" index.html
+else
+    tar -C "$DIST_DIR" -cJf "$OUT" index.html
+fi
+echo "wrote $OUT ($(wc -c < "$OUT") bytes)"
+'''
+
 [tasks.sign-facade-state-test]
 description = "Sign a facade state blob using the committed test key (current_app_id from published-contract)"
-dependencies = ["build-facade-loader"]
+dependencies = ["pack-facade-loader"]
 script_runner = "bash"
 script = '''
 set -euo pipefail
@@ -268,9 +317,9 @@ if [ ! -f "$KEY_FILE" ]; then
     exit 1
 fi
 APP_ID="${FACADE_CURRENT_APP_ID:-$(cat "$ROOT/published-contract/contract-id.txt")}"
-LOADER="$ROOT/contracts/facade-loader/dist/index.html"
+LOADER="$ROOT/target/facade/loader.tar.xz"
 if [ ! -f "$LOADER" ]; then
-    echo "error: $LOADER missing (build-facade-loader should have produced it)" >&2
+    echo "error: $LOADER missing (pack-facade-loader should have produced it)" >&2
     exit 1
 fi
 mkdir -p "$ROOT/target/facade"
@@ -287,7 +336,7 @@ echo "test facade state signed at version $version pointing at $APP_ID"
 
 [tasks.sign-facade-state]
 description = "Sign a facade state blob using the PRODUCTION key (current_app_id from published-contract)"
-dependencies = ["build-facade-loader"]
+dependencies = ["pack-facade-loader"]
 script_runner = "bash"
 script = '''
 set -euo pipefail
@@ -299,9 +348,9 @@ if [ ! -f "$KEY_FILE" ]; then
     exit 1
 fi
 APP_ID="${FACADE_CURRENT_APP_ID:-$(cat "$ROOT/published-contract/contract-id.txt")}"
-LOADER="$ROOT/contracts/facade-loader/dist/index.html"
+LOADER="$ROOT/target/facade/loader.tar.xz"
 if [ ! -f "$LOADER" ]; then
-    echo "error: $LOADER missing" >&2
+    echo "error: $LOADER missing (pack-facade-loader should have produced it)" >&2
     exit 1
 fi
 mkdir -p "$ROOT/target/facade"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -103,6 +103,16 @@ command -v dx >/dev/null || die "dx (dioxus-cli) not in PATH"
 command -v cargo-make >/dev/null || die "cargo-make not in PATH"
 command -v gh >/dev/null || die "gh (GitHub CLI) not in PATH"
 
+# fdev must support the --as-state flag for facade pointer flips.
+# Older builds silently wrap the file as `UpdateData::Delta` and the
+# facade contract then returns `InvalidUpdate`, so the pointer never
+# moves and users hitting the stable facade URL get a stale app.
+if ! fdev execute update --help 2>&1 | grep -q -- '--as-state'; then
+    die "fdev does not support \`--as-state\` (required for facade UPDATE).
+Build a newer fdev from freenet-core HEAD:
+  cargo install --path /path/to/freenet-core/crates/fdev"
+fi
+
 # GNU tar — required for reproducible archive
 if command -v gtar >/dev/null 2>&1; then
     echo "  ✓ GNU tar available (gtar)"
@@ -226,7 +236,12 @@ if [ -f published-contract/facade-id.txt ]; then
     # if set), so we omit it. The update always targets whichever node
     # the local fdev API points at; since release prerequisites assert
     # a `freenet network` daemon, the update propagates network-wide.
-    fdev execute update "$FACADE_ID" "$FACADE_STATE"
+    #
+    # --as-state: facade `update_state` only matches `UpdateData::State`.
+    # Without this flag fdev wraps the file as `UpdateData::Delta` and
+    # the contract returns `InvalidUpdate`. Requires fdev with the
+    # `--as-state` flag (freenet-core PR; older fdev silently fails).
+    fdev execute update --as-state "$FACADE_ID" "$FACADE_STATE"
 
     echo "  ✓ facade UPDATEd; bookmarked URL stays stable across releases"
     echo ""

--- a/tools/web-container-sign/src/main.rs
+++ b/tools/web-container-sign/src/main.rs
@@ -207,22 +207,13 @@ fn cmd_sign_facade_state(
     let loader_bytes =
         fs::read(loader).with_context(|| format!("reading loader archive {}", loader.display()))?;
 
-    // Best-effort consistency check: the loader is normally rendered by
-    // scripts/build-loader.sh, which embeds `current_app_id` directly into
-    // the HTML. If the loader bytes don't contain the id we're signing,
-    // the operator probably forgot to re-render the loader before re-signing
-    // — the signed pointer would then redirect users to a different app
-    // than the loader does. Catch this silently-broken state here.
-    if !loader_bytes
-        .windows(current_app_id_b58.len())
-        .any(|w| w == current_app_id_b58.as_bytes())
-    {
-        bail!(
-            "loader at {} does not contain current_app_id '{current_app_id_b58}'. \
-             Re-run scripts/build-loader.sh before signing, or pass --skip-loader-check (not implemented).",
-            loader.display()
-        );
-    }
+    // Loader bytes are expected to be a tar.xz archive containing
+    // `index.html` (so the freenet-core gateway's WebApp::try_from →
+    // XzDecoder → tar.unpack pipeline can serve them). We can't do the
+    // old "substring contains current_app_id" sanity check on compressed
+    // bytes — that check is now done upstream in the Makefile before
+    // compression. Caller is responsible for re-rendering the loader
+    // and re-packing it before invoking this command.
 
     let pointer = FacadePointer {
         version,
@@ -547,9 +538,9 @@ mod tests {
         cmd_generate(&key_file, true).unwrap();
         let app_id = [0xABu8; 32];
         let app_id_b58 = bs58::encode(app_id).into_string();
-        // Loader must embed current_app_id (signer enforces this; mirrors
-        // what scripts/build-loader.sh produces).
-        fs::write(&loader, format!("<html>id={app_id_b58}</html>")).unwrap();
+        // Signer treats loader bytes opaquely; in real builds these are
+        // tar.xz bytes produced by Makefile.toml's pack-facade-loader.
+        fs::write(&loader, b"opaque-loader-bytes").unwrap();
         let prev_id = [0xCDu8; 32];
         let prev_b58 = format!("100:{}", bs58::encode(prev_id).into_string());
 
@@ -583,10 +574,7 @@ mod tests {
         assert_eq!(metadata.pointer.version, 200);
         assert_eq!(metadata.pointer.current_app_id, app_id);
         assert_eq!(metadata.pointer.prev_app_ids, vec![(100u64, prev_id)]);
-        assert_eq!(
-            loader_bytes,
-            format!("<html>id={app_id_b58}</html>").into_bytes()
-        );
+        assert_eq!(loader_bytes, b"opaque-loader-bytes".to_vec());
 
         let payload = facade_signed_payload(&metadata.pointer, &loader_bytes);
         vk.verify(&payload, &metadata.signature).unwrap();
@@ -615,30 +603,10 @@ mod tests {
         assert!(err.to_string().contains("strictly less"));
     }
 
-    /// Regression for review-finding B6: signer rejects when the loader
-    /// bytes don't embed the current_app_id. Catches the silent
-    /// inconsistency where operator passes mismatching --loader and
-    /// --current-app-id (e.g. forgot to re-render the loader).
-    #[test]
-    fn sign_facade_state_rejects_loader_without_current_app_id() {
-        let dir = tempdir().unwrap();
-        let key_file = dir.path().join("keys.toml");
-        let loader = dir.path().join("loader");
-        cmd_generate(&key_file, true).unwrap();
-        // Loader does NOT contain the app id we'll sign.
-        fs::write(&loader, b"<html>stale loader</html>").unwrap();
-
-        let app_id_b58 = bs58::encode([0xAAu8; 32]).into_string();
-        let err = cmd_sign_facade_state(
-            &loader,
-            &app_id_b58,
-            &[],
-            42,
-            &key_file,
-            &dir.path().join("s"),
-            &dir.path().join("p"),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("does not contain current_app_id"));
-    }
+    // Note: the former B6 regression test (signer rejects loader without
+    // current_app_id) was removed because the loader is now passed as
+    // tar.xz-compressed bytes whose substring contents are opaque to the
+    // signer. The id-embedding sanity check now lives upstream in
+    // Makefile.toml's pack-facade-loader step, against the raw HTML
+    // before compression.
 }

--- a/tools/web-container-sign/tests/facade_integration.rs
+++ b/tools/web-container-sign/tests/facade_integration.rs
@@ -86,3 +86,4 @@ fn placeholder_id_derivation_documented() {
     // signature verification, which is what really matters.
     let _ = OsRng;
 }
+

--- a/tools/web-container-sign/tests/facade_integration.rs
+++ b/tools/web-container-sign/tests/facade_integration.rs
@@ -86,4 +86,3 @@ fn placeholder_id_derivation_documented() {
     // signature verification, which is what really matters.
     let _ = OsRng;
 }
-


### PR DESCRIPTION
## Summary

- `pack-facade-loader` cargo-make task wraps the facade loader HTML in a reproducible tar.xz blob; sign tasks now feed it through.
- Signer drops the substring sanity check (moved upstream to the cargo-make task, where the HTML is still readable).
- `scripts/release.sh` requires fdev with `--as-state` and passes the flag to the facade UPDATE.

## Why

The gateway at `/v1/contract/web/<id>/` always runs `WebApp::try_from → XzDecoder → tar.unpack` over the `web` slot of state, so the slot MUST be an xz-tar. The facade was previously fed raw HTML there. Symptom: `curl <facade URL>` returns 400 \"failed unpacking contract\" — every release of the issue #200 stable bookmark URL has been broken since Phase 1.

Compounding bug: even when the bytes are valid, `fdev execute update` wraps them as `UpdateData::Delta`. The facade's `update_state` matches only `UpdateData::State` and returns `InvalidUpdate`. Every prior release's facade pointer flip silently failed. Paired freenet-core PR https://github.com/freenet/freenet-core/pull/4100 adds the `--as-state` flag that release.sh now requires.

## Test plan

- [x] `cargo test -p web-container-sign` — 8/8 pass
- [x] Built tar.xz loader + signed with production key
- [x] Pushed UPDATE via patched fdev (`--as-state`) against live `freenet network` daemon
- [x] Verified `curl http://127.0.0.1:7509/v1/contract/web/122f6AR7PyF8d8mhczuNQM4xrLtBf5t8g2iB7PEVT7KC/` returns 200 with the loader HTML, loader redirects to the rotating webapp id
- [ ] CI green
- [ ] Manual: re-run a full release once freenet-core PR lands and the next fdev is in PATH

## Out of scope

- Committing the new facade.{state,parameters} snapshot — that happens automatically on the next `scripts/release.sh` run.
- Updating `RELEASING.md` to mention the new fdev requirement — separate doc PR.