### PR TITLE
v0.1.8: facade-loader postMessage shell-navigate + delete-identity feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,121 @@ devtools shows which facade a build references. Both are conditional
 on `published-contract/facade-id.txt` being committed (one-time facade
 publish required first; see RELEASING.md §"Facade contract update").
 
+#### Pointer lifecycle — how the facade actually serves a release
+
+Each release rotates the web-container contract id but leaves the
+facade contract id fixed. The full chain on every release:
+
+1. `cargo make build` rebuilds the UI webapp. Workspace `Cargo.lock`
+   churn shifts wasm bytes, producing a new `published-contract/contract-id.txt`.
+2. `scripts/build-loader.sh <new_app_id>` substitutes the new id into
+   `contracts/facade-loader/src/index.html.tmpl` → writes
+   `contracts/facade-loader/dist/index.html`. This loader is the file
+   the facade actually serves; it's a static HTML+JS page that
+   redirects the browser to the new web-container url.
+3. `cargo make pack-facade-loader` tars + xzs the loader into
+   `target/facade/loader.tar.xz`. The gateway's `WebApp::try_from`
+   pipeline (XzDecoder → tar.unpack) requires this exact framing, see
+   memory `facade_state_framing.md`.
+4. `cargo make sign-facade-state` signs a fresh `FacadePointer { version=now, current_app_id=<new>, prev_app_ids=[<old>] }`
+   with the production key from `~/.config/freenet-email/web-container-keys.toml`.
+   Output: `target/facade/facade.state` (signed `[meta_len][meta][web_len][web]`).
+5. `fdev execute update --as-state <facade_id> target/facade/facade.state`
+   pushes the new state to the network. **`--as-state` is required** —
+   default is `UpdateData::Delta` which a facade-style contract rejects
+   silently as `InvalidUpdate` (memory `fdev_update_needs_as_state.md`).
+6. `scripts/release.sh` commits the new web-container snapshot, tags,
+   pushes.
+
+The facade contract id never changes across any of this. Users
+bookmark `/v1/contract/web/<facade_id>/` once and that URL keeps
+working release after release.
+
+#### Loader must postMessage, not location.replace (v0.1.8)
+
+The gateway wraps every contract URL response in a shell page with a
+sandboxed iframe and `X-Frame-Options: DENY` on the shell. Inside the
+sandbox, the loader cannot `window.location.replace(<new_app_url>)` —
+the new app's gateway response would have to render inside our iframe,
+and XFO DENY blocks that (Firefox: "Firefox Can't Open This Page").
+
+The fix: the loader posts `{__freenet_shell__: true, type: 'navigate', href: <new_app_url>}`
+to `window.parent`. The freenet-core shell already implements
+cross-contract navigation for that message — it does a top-level
+`window.location.assign` outside our iframe, which loads a fresh
+shell for the new contract id. See `path_handlers.rs:836` in
+freenet-core for the handler.
+
+Fallback path: if the loader is opened standalone (e.g. `?__sandbox=1`
+or a dev fetch with no parent frame), it uses `window.location.replace`
+so the dev UX still works.
+
+#### Manual pointer flip / recovery
+
+If `scripts/release.sh` aborts after publish-webapp (e.g. fdev's
+300s timeout — see freenet-core#4102 — fires even though the publish
+landed), resume the pointer flip manually:
+
+```bash
+# 1. Confirm the new webapp actually published.
+curl -sI "http://127.0.0.1:7509/v1/contract/web/$(cat published-contract/contract-id.txt)/" \
+  | head -1   # expect HTTP/1.1 200
+
+# 2. Rebuild loader + repack + re-sign state with the production key.
+cargo make sign-facade-state
+# (chains build-facade-loader → pack-facade-loader → sign)
+
+# 3. Push the pointer update.
+fdev execute update --as-state \
+  "$(cat published-contract/facade-id.txt)" \
+  target/facade/facade.state
+# expect "Contract updated successfully" + StateSummary
+
+# 4. Verify the facade now serves the new loader.
+curl -s "http://127.0.0.1:7509/v1/contract/web/$(cat published-contract/facade-id.txt)/?__sandbox=1" \
+  | grep CURRENT_APP_ID
+# expect the new app id baked in
+
+# 5. Open the facade URL in a browser. The loader should postMessage
+# the shell and the shell should navigate to the new web-container url.
+```
+
+If step 4 returns the old app id, the gateway likely served a stale
+extracted webapp from its on-disk cache. The gateway extracts the
+webapp tar.xz on GetResponse and writes the extracted files to its
+webapp_cache directory; UPDATEs that change the `web` slot don't
+invalidate that cache until the next contract get. Bust the cache by
+hand:
+
+```bash
+# macOS:
+CACHE_DIR="$HOME/Library/Caches/The-Freenet-Project-Inc.freenet/webapp_cache"
+# Linux:
+# CACHE_DIR="$HOME/.cache/freenet/webapp_cache"
+FACADE_ID=$(cat published-contract/facade-id.txt)
+rm -rf "${CACHE_DIR}/${FACADE_ID}" "${CACHE_DIR}/${FACADE_ID}.hash"
+
+# Trigger a GetResponse by hitting the MAIN URL (not ?__sandbox=1).
+# The sandbox endpoint short-circuits on cache miss with a 500.
+curl -s -o /dev/null "http://127.0.0.1:7509/v1/contract/web/${FACADE_ID}/"
+```
+
+This is a freenet-core gateway issue. The pointer is correct on-chain
+(verified by `fdev execute get`); the staleness is local to the
+gateway's extracted-webapp cache. Track downstream as a freenet-core
+issue when you next encounter it.
+
+#### What NOT to commit per release
+
+- `target/facade/facade.state` is signed with the production key and
+  carries a per-build timestamp version. **Do not commit it** — every
+  release re-signs. Only the WASM/parameters/id snapshot under
+  `published-contract/facade.*` is checked into git, and that triplet
+  stays byte-stable across releases by design.
+- `contracts/facade-loader/dist/index.html` is regenerated from
+  `src/index.html.tmpl` at every release. Don't hand-edit dist; edit
+  the tmpl and let `build-loader.sh` re-render.
+
 **Inbox + AFT lockfile isolation (issue #199 Phase A)**: same pattern
 extended to every other on-chain contract:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ed25519-dalek",
  "freenet-email-facade-types",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-ui"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "arc-swap",
  "base64",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "web-container-sign"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 license = "LGPL-3.0-or-later"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -215,6 +215,96 @@ must have been published once and its id committed first. Until then,
 the script warns and skips the flip; the rest of the release still goes
 through.
 
+### Verifying the pointer flip worked
+
+After release.sh exits, sanity-check that the facade actually points
+at the new webapp:
+
+```bash
+NEW_APP_ID=$(cat published-contract/contract-id.txt)
+FACADE_ID=$(cat published-contract/facade-id.txt)
+
+# 1. Facade serves the loader, and the loader bakes in the new app id.
+curl -s "http://127.0.0.1:7509/v1/contract/web/${FACADE_ID}/?__sandbox=1" \
+  | grep -F "${NEW_APP_ID}"
+# expect: var CURRENT_APP_ID = "<new app id>";
+
+# 2. The new webapp itself serves.
+curl -sI "http://127.0.0.1:7509/v1/contract/web/${NEW_APP_ID}/" | head -1
+# expect: HTTP/1.1 200 OK
+
+# 3. Browser smoke: open the facade URL in a real browser. The loader
+# postMessages the gateway shell, which navigates to the new app.
+echo "open http://127.0.0.1:7509/v1/contract/web/${FACADE_ID}/"
+```
+
+### Manual pointer flip (if release.sh aborts post-publish)
+
+If the script aborts after step 4 (publish webapp) — most commonly
+because `fdev publish` returns a 300s client timeout despite the
+server-side publish succeeding (freenet-core#4102) — the webapp WAS
+published but the facade pointer was not flipped. Resume manually:
+
+```bash
+# Confirm the webapp landed despite fdev's complaint.
+NEW_APP_ID=$(cat published-contract/contract-id.txt)
+curl -sI "http://127.0.0.1:7509/v1/contract/web/${NEW_APP_ID}/" | head -1
+# expect HTTP/1.1 200 — if you get a 4xx/5xx, the publish actually failed
+# and you need to re-run the publish step.
+
+# Re-sign facade state with the new app id and push the pointer update.
+cargo make sign-facade-state
+fdev execute update --as-state \
+    "$(cat published-contract/facade-id.txt)" \
+    target/facade/facade.state
+# expect: "Contract updated successfully" + StateSummary blob
+
+# Verify (same as §"Verifying the pointer flip worked" above).
+
+# Then complete the commit/tag/push that release.sh would have run:
+git add published-contract/contract-id.txt
+git commit -m "chore(release): v<version> — production publish"
+git tag -a "v<version>" -m "freenet-email v<version>"
+git push origin main && git push origin "v<version>"
+```
+
+**Important**: `--as-state` is required on the `fdev execute update`
+invocation. The facade contract's `update_state` only accepts
+`UpdateData::State`; without the flag fdev sends `UpdateData::Delta`
+and the contract silently rejects the update as `InvalidUpdate`.
+
+### Loader template (`contracts/facade-loader/src/index.html.tmpl`)
+
+The loader is a static HTML+JS shell that the facade serves. It
+embeds the current app id via `__CURRENT_APP_ID__` placeholder and
+hands the user off to the new webapp via a shell postMessage:
+
+```js
+window.parent.postMessage({
+    __freenet_shell__: true,
+    type: 'navigate',
+    href: target
+}, '*');
+```
+
+**Why postMessage instead of `window.location.replace`?** The gateway
+wraps every contract URL in a shell page with `X-Frame-Options: DENY`
+and serves the contract inside a sandboxed iframe. A same-window
+`location.replace` from inside the sandbox would try to load the new
+contract's shell page *inside our iframe*, which the browser blocks
+("Firefox Can't Open This Page"). The freenet-core shell already
+handles cross-contract navigation via the `__freenet_shell__`
+postMessage protocol — see `crates/core/src/server/path_handlers.rs`
+line ~836 in freenet-core.
+
+When the loader is opened standalone (`?__sandbox=1` or no parent
+frame), it falls back to `window.location.replace` so dev fetches
+still work.
+
+If you ever need to hand-edit the loader, edit the `.tmpl` file —
+**not** the rendered `dist/index.html`, which is overwritten on every
+build.
+
 **One-time facade publish (per environment)**: before Phase 3 runs for
 the first time on a network, publish the facade contract once and
 commit its id. Manual steps:

--- a/contracts/facade-loader/src/index.html.tmpl
+++ b/contracts/facade-loader/src/index.html.tmpl
@@ -40,9 +40,34 @@
   var fb = document.getElementById("fallback");
   if (fb) fb.href = target;
 
-  // Use replace() so the loader URL doesn't pollute browser history; the
-  // user's bookmarked facade URL stays the canonical entry point.
-  window.location.replace(target);
+  // The gateway serves contract URLs as a shell page with the contract
+  // content in a sandboxed iframe. The shell page sets
+  // `X-Frame-Options: DENY`, so a same-window `location.replace` from
+  // inside the sandbox would try to load the next contract's shell page
+  // *inside our iframe*, which Firefox/Chrome block as a clickjacking
+  // defense.
+  //
+  // The shell exposes a cross-contract navigation primitive via
+  // postMessage (`__freenet_shell__: 'navigate'`), which performs a
+  // top-level navigation in the same tab. We use that when we're framed.
+  //
+  // When the loader is opened standalone (no parent frame, e.g. a
+  // developer fetching the loader directly), fall back to a same-window
+  // location replace so the UX still works.
+  var framed = false;
+  try { framed = window.parent !== window; } catch (e) { framed = true; }
+
+  if (framed) {
+    window.parent.postMessage({
+      __freenet_shell__: true,
+      type: 'navigate',
+      href: target
+    }, '*');
+  } else {
+    // Use replace() so the loader URL doesn't pollute browser history;
+    // the user's bookmarked facade URL stays the canonical entry point.
+    window.location.replace(target);
+  }
 })();
 </script>
 </body>

--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -43,6 +43,9 @@ manual gap by adding a test, flip status to `auto` and link the test.
 | Backup → restore round-trip (export, wipe, import, identity present) | manual | Compose, generate backup, save file, log out, restore from file, confirm alias + sent + drafts present |
 | Rename identity in place | auto | offline: `renames an id-row in place and surfaces the new alias` |
 | Refuses duplicate alias on rename | auto | offline: `refuses to rename to an alias that already exists` |
+| Delete identity (confirm-modal + row removed) | manual | Open IdentifiersList, click 🗑 on an id-row, type alias verbatim, click Delete identity, confirm row disappears and `Identity::get_alias()` no longer returns it. Inbox + AFT contracts remain on-chain (no on-chain delete primitive). |
+| Delete identity refuses without exact alias match | manual | Open delete modal, type wrong alias, expect inline error "Type the alias exactly as shown to confirm." and no row removal. |
+| Delete identity while logged in clears active id | manual | Open inbox, navigate back to IdentifiersList, delete the currently-active identity, confirm app falls back to the identifiers list and active selection is cleared. |
 | 3+ identities switch + sidebar fingerprint flips | auto (2 ids) / manual (3+) | offline: `fingerprint changes when switching identities` covers 2; 3+ via `cargo make dev-example` + create another + cycle |
 | Switcher in Settings (popover open/close + active row) | manual | Open Settings, click ident switcher button, click a non-active row, verify identity context flipped |
 

--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -52,8 +52,12 @@
   "fmIdRestore": "fm-id-restore",
   "fmIdRename": "fm-id-rename",
   "fmIdShare": "fm-id-share",
+  "fmIdDelete": "fm-id-delete",
   "fmRenameInput": "fm-rename-input",
   "fmRenameSubmit": "fm-rename-submit",
+  "fmDeleteConfirmInput": "fm-delete-confirm-input",
+  "fmDeleteConfirmSubmit": "fm-delete-confirm-submit",
+  "fmDeleteConfirmCancel": "fm-delete-confirm-cancel",
 
   "fmShareModal": "fm-share-modal",
   "fmShareCopy": "fm-share-copy",

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1351,10 +1351,7 @@ pub(crate) async fn node_comms(
                         login_controller.write().updated = true;
                     }
                     Err(e) => {
-                        crate::log::error(
-                            format!("failed to delete identity {alias}: {e}"),
-                            None,
-                        );
+                        crate::log::error(format!("failed to delete identity {alias}: {e}"), None);
                     }
                 }
             }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -643,6 +643,23 @@ mod identity_management {
         send_identity_msg(client, &msg).await
     }
 
+    /// Delete an own identity from the delegate. The delegate stores own
+    /// identities and contacts in the same alias-keyed map, so
+    /// `DeleteIdentity` is the right wire message regardless of kind —
+    /// the UI layer is responsible for confirmation. The inbox/AFT
+    /// contracts on-chain are not touched; without the keypair nobody can
+    /// sign deltas against them anyway, so they're effectively orphaned.
+    pub(super) async fn delete_identity_api_call(
+        client: &mut WebApiRequestClient,
+        alias: &str,
+    ) -> Result<(), DynError> {
+        crate::log::debug!("deleting own identity {alias}");
+        let msg = IdentityMsg::DeleteIdentity {
+            alias: alias.to_string(),
+        };
+        send_identity_msg(client, &msg).await
+    }
+
     /// Rename an own identity by replaying its keypair under a new
     /// alias and deleting the old entry. Issue #32 — the delegate has
     /// no atomic Rename op, so we do delete+create at the UI layer.
@@ -794,7 +811,7 @@ pub(crate) async fn node_comms(
         // below; we accept it here so the call sites don't have to thread
         // a smaller param list.
         _token_rec_to_id: &mut HashMap<ContractKey, Identity>,
-        user: Signal<crate::app::User>,
+        mut user: Signal<crate::app::User>,
         mut login_controller: Signal<crate::app::LoginController>,
         inboxes: &InboxesData,
         mut ab_gen: crate::app::AddressBookGen,
@@ -1301,6 +1318,41 @@ pub(crate) async fn node_comms(
                     Err(e) => {
                         crate::log::error(
                             format!("failed to rename identity {old} → {new}: {e}"),
+                            None,
+                        );
+                    }
+                }
+            }
+            NodeAction::DeleteIdentity { identity } => {
+                let alias = identity.alias.clone();
+                match identity_management::delete_identity_api_call(&mut client, &alias).await {
+                    Ok(()) => {
+                        // Drop from in-memory ALIASES + User.identities so
+                        // the IdentifiersList re-renders without the row.
+                        // The on-chain inbox + AFT contracts stay put
+                        // (no delete primitive); without the keypair they
+                        // become unreachable, which is the security boundary
+                        // users actually care about.
+                        crate::app::login::Identity::remove_in_place(&alias);
+                        let mut user_w = user.write();
+                        let was_logged_in = user_w
+                            .logged_id()
+                            .map(|i| i.id == identity.id)
+                            .unwrap_or(false);
+                        user_w.identities.retain(|i| i.id != identity.id);
+                        if was_logged_in {
+                            user_w.logout();
+                        }
+                        drop(user_w);
+                        // Bump address-book generation so any inbox row that
+                        // had this identity wired up as a sender re-renders.
+                        let prev = *ab_gen.0.read();
+                        ab_gen.0.set(prev.wrapping_add(1));
+                        login_controller.write().updated = true;
+                    }
+                    Err(e) => {
+                        crate::log::error(
+                            format!("failed to delete identity {alias}: {e}"),
                             None,
                         );
                     }

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -104,6 +104,16 @@ pub(crate) enum NodeAction {
         new: Rc<str>,
         identity: Box<Identity>,
     },
+    /// Delete an own identity from this device. Removes the entry from the
+    /// identity-management delegate and from local in-memory stores
+    /// (ALIASES, User.identities). The inbox + AFT contracts themselves
+    /// remain on-chain but become unreachable from this device: there is
+    /// no on-chain "delete contract" primitive, and without the keypair
+    /// nobody can sign deltas against them anyway. Irreversible without
+    /// the backup file.
+    DeleteIdentity {
+        identity: Box<Identity>,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -173,6 +183,7 @@ pub(crate) fn app() -> Element {
         let _ = toast;
         let mut login_ctl = login_controller;
         let mut ab_gen = ab_gen;
+        let mut user_sig = user;
         let _sync: Coroutine<NodeAction> =
             use_coroutine(move |mut rx: UnboundedReceiver<NodeAction>| async move {
                 use futures::StreamExt;
@@ -207,6 +218,23 @@ pub(crate) fn app() -> Element {
                             // trip.
                             Identity::rename_in_place(&old, &new);
                             login_ctl.write().updated = true;
+                        }
+                        NodeAction::DeleteIdentity { identity } => {
+                            Identity::remove_in_place(&identity.alias);
+                            let mut user_w = user_sig.write();
+                            let was_logged_in = user_w
+                                .logged_id()
+                                .map(|i| i.id == identity.id)
+                                .unwrap_or(false);
+                            user_w.identities.retain(|i| i.id != identity.id);
+                            if was_logged_in {
+                                user_w.logout();
+                            }
+                            drop(user_w);
+                            login_ctl.write().updated = true;
+                            address_book::remove_contact(&identity.alias);
+                            let prev = *ab_gen.0.read();
+                            ab_gen.0.set(prev.wrapping_add(1));
                         }
                         _ => {}
                     }
@@ -683,6 +711,13 @@ impl User {
     pub(crate) fn set_logged_id(&mut self, id: UserId) {
         assert!(id.0 < self.identities.len());
         self.active_id = Some(id);
+    }
+
+    /// Clear the active-identity selection without logging out the user
+    /// entirely. Used when an identity is deleted while open.
+    pub(crate) fn logout(&mut self) {
+        self.logged = false;
+        self.active_id = None;
     }
 }
 

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -458,6 +458,18 @@ impl Identity {
             }
         })
     }
+
+    /// Drop the entry whose alias matches `alias` from the shared
+    /// `ALIASES` store. Returns `true` if a matching entry was found.
+    /// Used by `NodeAction::DeleteIdentity`.
+    pub(crate) fn remove_in_place(alias: &str) -> bool {
+        ALIASES.with(|aliases| {
+            let aliases = &mut *aliases.borrow_mut();
+            let before = aliases.len();
+            aliases.retain(|a| &*a.alias != alias);
+            aliases.len() != before
+        })
+    }
 }
 
 impl std::hash::Hash for Identity {
@@ -869,10 +881,18 @@ pub(super) fn Identities() -> Element {
         let backup_alias = identity.clone();
         let share_id = identity.clone();
         let rename_id = identity.clone();
+        let delete_id = identity.clone();
         // Per-row rename state. `Some(draft)` means the inline editor is
         // open. Issue #32 — rename is delete+create with the same key.
         let mut rename_draft: Signal<Option<String>> = use_signal(|| None);
         let mut rename_error = use_signal(String::new);
+        // Per-row delete-confirmation state. `true` means the modal is open;
+        // user has to type the alias verbatim before the Delete button
+        // arms. The keypair is destroyed locally so unconfirmed clicks must
+        // not slip through.
+        let mut delete_open = use_signal(|| false);
+        let mut delete_input = use_signal(String::new);
+        let mut delete_error = use_signal(String::new);
 
         let submit_rename = move |_| {
             let next = rename_draft
@@ -906,6 +926,24 @@ pub(super) fn Identities() -> Element {
             });
             rename_draft.set(None);
             rename_error.set(String::new());
+        };
+
+        let submit_delete = {
+            let delete_id = delete_id.clone();
+            move |_| {
+                let typed = delete_input.read().trim().to_string();
+                if typed != *delete_id.alias {
+                    delete_error
+                        .set("Type the alias exactly as shown to confirm.".into());
+                    return;
+                }
+                actions.send(NodeAction::DeleteIdentity {
+                    identity: Box::new(delete_id.clone()),
+                });
+                delete_open.set(false);
+                delete_input.set(String::new());
+                delete_error.set(String::new());
+            }
         };
 
         rsx! {
@@ -1010,6 +1048,17 @@ pub(super) fn Identities() -> Element {
                             "↗"
                         }
                         button {
+                            class: "icon-btn",
+                            title: "Delete this identity from this device",
+                            "data-testid": testid::FM_ID_DELETE,
+                            onclick: move |_| {
+                                delete_open.set(true);
+                                delete_input.set(String::new());
+                                delete_error.set(String::new());
+                            },
+                            "🗑"
+                        }
+                        button {
                             class: "btn btn-primary",
                             "data-testid": testid::FM_ID_OPEN,
                             onclick: move |_| {
@@ -1017,6 +1066,62 @@ pub(super) fn Identities() -> Element {
                                 inbox.write().set_active_id(id);
                             },
                             "Open inbox"
+                        }
+                    }
+                }
+            }
+            if *delete_open.read() {
+                div { class: "veil",
+                    onclick: move |_| {
+                        delete_open.set(false);
+                        delete_input.set(String::new());
+                        delete_error.set(String::new());
+                    },
+                    div { class: "modal",
+                        onclick: move |evt| { evt.stop_propagation(); },
+                        h2 { class: "display md", "Delete identity?" }
+                        p {
+                            "This permanently removes “{delete_id.alias}” and its private keys from this device. "
+                            "Messages already in this inbox become unreadable. "
+                            "On-chain contracts stay where they are — there's no way to delete them — "
+                            "but without the keypair they can't be reached again."
+                        }
+                        p { style: "color:#b91c1c; font-weight:600;",
+                            "Restore the backup file to recover. Without it, this is irreversible."
+                        }
+                        p {
+                            "Type "
+                            code { "{delete_id.alias}" }
+                            " below to confirm."
+                        }
+                        input {
+                            class: "input",
+                            "data-testid": testid::FM_DELETE_CONFIRM_INPUT,
+                            value: "{delete_input.read()}",
+                            oninput: move |evt| { delete_input.set(evt.value()); },
+                        }
+                        if !delete_error.read().is_empty() {
+                            div { class: "field-help", style: "color:#b91c1c;",
+                                "{delete_error.read()}"
+                            }
+                        }
+                        div { style: "display:flex; gap:10px; margin-top:14px;",
+                            button {
+                                class: "btn btn-ghost",
+                                "data-testid": testid::FM_DELETE_CONFIRM_CANCEL,
+                                onclick: move |_| {
+                                    delete_open.set(false);
+                                    delete_input.set(String::new());
+                                    delete_error.set(String::new());
+                                },
+                                "Cancel"
+                            }
+                            button {
+                                class: "btn btn-danger",
+                                "data-testid": testid::FM_DELETE_CONFIRM_SUBMIT,
+                                onclick: submit_delete,
+                                "Delete identity"
+                            }
                         }
                     }
                 }

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -933,8 +933,7 @@ pub(super) fn Identities() -> Element {
             move |_| {
                 let typed = delete_input.read().trim().to_string();
                 if typed != *delete_id.alias {
-                    delete_error
-                        .set("Type the alias exactly as shown to confirm.".into());
+                    delete_error.set("Type the alias exactly as shown to confirm.".into());
                     return;
                 }
                 actions.send(NodeAction::DeleteIdentity {

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -90,8 +90,12 @@ pub(crate) const FM_ID_BACKUP: &str = "fm-id-backup";
 pub(crate) const FM_ID_RESTORE: &str = "fm-id-restore";
 pub(crate) const FM_ID_RENAME: &str = "fm-id-rename";
 pub(crate) const FM_ID_SHARE: &str = "fm-id-share";
+pub(crate) const FM_ID_DELETE: &str = "fm-id-delete";
 pub(crate) const FM_RENAME_INPUT: &str = "fm-rename-input";
 pub(crate) const FM_RENAME_SUBMIT: &str = "fm-rename-submit";
+pub(crate) const FM_DELETE_CONFIRM_INPUT: &str = "fm-delete-confirm-input";
+pub(crate) const FM_DELETE_CONFIRM_SUBMIT: &str = "fm-delete-confirm-submit";
+pub(crate) const FM_DELETE_CONFIRM_CANCEL: &str = "fm-delete-confirm-cancel";
 
 // Address book — share / import
 pub(crate) const FM_SHARE_MODAL: &str = "fm-share-modal";
@@ -182,8 +186,12 @@ mod tests {
             ("fmIdRestore", super::FM_ID_RESTORE),
             ("fmIdRename", super::FM_ID_RENAME),
             ("fmIdShare", super::FM_ID_SHARE),
+            ("fmIdDelete", super::FM_ID_DELETE),
             ("fmRenameInput", super::FM_RENAME_INPUT),
             ("fmRenameSubmit", super::FM_RENAME_SUBMIT),
+            ("fmDeleteConfirmInput", super::FM_DELETE_CONFIRM_INPUT),
+            ("fmDeleteConfirmSubmit", super::FM_DELETE_CONFIRM_SUBMIT),
+            ("fmDeleteConfirmCancel", super::FM_DELETE_CONFIRM_CANCEL),
             ("fmShareModal", super::FM_SHARE_MODAL),
             ("fmShareCopy", super::FM_SHARE_COPY),
             ("fmContactImport", super::FM_CONTACT_IMPORT),

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -1081,6 +1081,60 @@ test.describe("Rename identity (#32)", () => {
   });
 });
 
+// Delete own identity (offline branch). Online use-node branch round-trips
+// through the identity-management delegate; covered by live-node.spec.ts
+// when the harness includes a delete step.
+test.describe("Delete identity", () => {
+  test("deletes an id-row after confirming the alias verbatim", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const row = page.locator('[data-testid="fm-id-row"][data-alias="address2"]');
+    await expect(row).toBeVisible();
+    await row.locator('[data-testid="fm-id-delete"]').click();
+
+    const input = page.locator('[data-testid="fm-delete-confirm-input"]');
+    await input.waitFor({ timeout: 5_000 });
+    await input.fill("address2");
+
+    await page.locator('[data-testid="fm-delete-confirm-submit"]').click();
+
+    await expect(
+      page.locator('[data-testid="fm-id-row"][data-alias="address2"]'),
+    ).toHaveCount(0, { timeout: 5_000 });
+    // address1 stays.
+    await expect(
+      page.locator('[data-testid="fm-id-row"][data-alias="address1"]'),
+    ).toBeVisible();
+  });
+
+  test("refuses to delete without the alias typed verbatim", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const row = page.locator('[data-testid="fm-id-row"][data-alias="address1"]');
+    await row.locator('[data-testid="fm-id-delete"]').click();
+
+    const input = page.locator('[data-testid="fm-delete-confirm-input"]');
+    await input.waitFor({ timeout: 5_000 });
+    await input.fill("wrong-alias");
+
+    await page.locator('[data-testid="fm-delete-confirm-submit"]').click();
+
+    await expect(page.getByText(/Type the alias exactly/)).toBeVisible({
+      timeout: 5_000,
+    });
+    // Row still there.
+    await expect(
+      page.locator('[data-testid="fm-id-row"][data-alias="address1"]'),
+    ).toBeVisible();
+  });
+});
+
 // Archive (issue #47/47c). Archive splits from Delete: Archive stashes the
 // message locally and removes it from the inbox contract; Delete only
 // removes (no local trace). Re-PUT-on-unarchive lands in #60.

--- a/ui/tests/testids.ts
+++ b/ui/tests/testids.ts
@@ -53,8 +53,12 @@ interface TestIds {
   fmIdRestore: string;
   fmIdRename: string;
   fmIdShare: string;
+  fmIdDelete: string;
   fmRenameInput: string;
   fmRenameSubmit: string;
+  fmDeleteConfirmInput: string;
+  fmDeleteConfirmSubmit: string;
+  fmDeleteConfirmCancel: string;
   fmShareModal: string;
   fmShareCopy: string;
   fmContactImport: string;


### PR DESCRIPTION
## Summary

- **fix(facade-loader)**: replace `window.location.replace` with `postMessage({__freenet_shell__, type: 'navigate', ...})` so cross-contract navigation works through the gateway's sandbox iframe (Firefox/Chrome blocked the same-window replace as clickjacking — XFO DENY on the new contract's shell). Falls back to `location.replace` when standalone.
- **feat(identity)**: per-row 🗑 Delete button in IdentifiersList with verbatim-alias confirm modal. Sends `IdentityMsg::DeleteIdentity` to the delegate, then drops the alias from `ALIASES` + `User.identities` (and clears active selection if logged in). On-chain inbox/AFT contracts stay but become unreachable without the keypair — modal warns + points at backup file.
- **docs**: full facade-pointer lifecycle, manual flip + cache-bust recovery, "what NOT to commit per release" in AGENTS.md and RELEASING.md.
- **version**: 0.1.7 → 0.1.8.

## Test plan

- [x] `cargo check -p freenet-email-ui --features example-data,no-sync --no-default-features` clean
- [x] `cargo check -p freenet-email-ui --features use-node` clean
- [x] `cargo clippy -p freenet-email-ui` (both feature sets) clean
- [x] `cargo build -p freenet-email-ui --features use-node --release --target wasm32-unknown-unknown` clean
- [x] `cargo test -p freenet-email-ui` — 102/102 pass (testid JSON drift guard included)
- [x] `cargo make test-ui-playwright` — 114/114 pass across chromium/firefox/webkit/Pixel-5/iPhone-13 (10 skipped, intentional)
- [x] New tests: "deletes an id-row after confirming the alias verbatim" + "refuses to delete without the alias typed verbatim"
- [ ] Browser-verify facade URL on local node serves the postMessage loader and shell navigates to the new contract (already verified by hand on dev branch before commit)
- [ ] Post-release: smoke-test on isolated harness, then `scripts/release.sh 0.1.8`