### PR TITLE
test(e2e): drop FREENET_LIVE_E2E_REPLY gate (#180)

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -956,6 +956,5 @@ cd "$ROOT/ui/tests" && \
     FREENET_ISO_GW_PORT="$GW_PORT" \
     FREENET_ISO_GW_LOG_DIR="$ISO_ROOT/gw/logs" \
     FREENET_ISO_PEER_LOG_DIR="$ISO_ROOT/peer/logs" \
-    FREENET_LIVE_E2E_REPLY="${FREENET_LIVE_E2E_REPLY:-1}" \
     npx playwright test live-node.spec.ts --project=chromium
 '''

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -521,9 +521,9 @@ test.describe("Live node E2E", () => {
       await aliceVerify.click();
       await aliceApp.locator('[data-testid="fm-import-submit"]').click();
 
-      // Bob imports alice up-front too — needed for round-2 reply
-      // (FREENET_LIVE_E2E_REPLY). fm-contact-import is on the home
-      // view; once bob opens his inbox, it unmounts.
+      // Bob imports alice up-front too — needed for round-2 reply.
+      // fm-contact-import is on the home view; once bob opens his
+      // inbox, it unmounts.
       await bobApp.locator('[data-testid="fm-contact-import"]').click();
       await bobApp
         .locator('[data-testid="fm-import-contact-modal"] textarea')
@@ -590,18 +590,12 @@ test.describe("Live node E2E", () => {
       ).toBeVisible({ timeout: 30_000 });
 
       // ── Round 2: bob → alice (reply path) ────────────────────────
-      // #122: was flaky on iso while #174 was open (round-1 path was
-      // also broken; reply assertion couldn't be exercised).
-      // Re-enabled by default in test-e2e-real-node make task; export
-      // FREENET_LIVE_E2E_REPLY=0 to disable for local debug runs.
-      if (process.env.FREENET_LIVE_E2E_REPLY !== "0") {
-        // Bob already imported alice at setup; just send the reply.
-        await composeAndSend(bobApp, ALIAS_T3_ALICE, "round two reply", "reply body");
-        await expect(
-          aliceApp.getByText(/round two reply/i),
-          "alice receives bob's reply",
-        ).toBeVisible({ timeout: 60_000 });
-      }
+      // Bob already imported alice at setup; just send the reply.
+      await composeAndSend(bobApp, ALIAS_T3_ALICE, "round two reply", "reply body");
+      await expect(
+        aliceApp.getByText(/round two reply/i),
+        "alice receives bob's reply",
+      ).toBeVisible({ timeout: 60_000 });
 
       // ── Round 3: alice → bob again ──────────────────────────────
       // Skipped on iso by default: AFT day-1 cap is 1 slot, and alice


### PR DESCRIPTION
## Summary

One row in #180's env-gate inventory. Removes \`FREENET_LIVE_E2E_REPLY\` (default-on) from \`ui/tests/live-node.spec.ts\` and \`Makefile.toml\`. The flakiness it was hedging against (#122 / #174) has been resolved, the iso harness has been stable for weeks, and no caller sets it to 0.

## Test plan

- [x] Local: \`cargo make test-e2e-real-node\` — 4 passed (29.4s)
- [ ] CI: e2e-real-node passes

## Refs

- Part of #180 (env-gated coverage inventory)