### PR TITLE
test(e2e): verified-sender bypass toggle round-trip (#157, closes a #180 row)

### DIFF
--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -144,6 +144,7 @@ add/remove protocol.
 | Advanced: custom relay URL takes effect on reload | manual | Set custom_relay + URL, reload, WS connects to that URL |
 | Settings round-trip across reload | manual | Set value, reload, value persists |
 | WIP: AFT tier picker (gated) | blocked | Issue #85 — recipient inbox params not configurable |
+| AFT verified-sender bypass toggle dispatches ModifySettings (#157) | auto | iso: `verified-skip toggle dispatches ModifySettings + flips state (#157)` |
 | WIP: read receipts toggle (gated) | blocked | Issue #69 — feature not implemented |
 | WIP: pad_length toggle (gated) | blocked | No implementation; gated until designed |
 | WIP: display_name field (gated) | blocked | No consumer of the field; gated until wired into Sent/Inbox surfaces |

--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -76,5 +76,7 @@
   "fmVerifyContactSubmit": "fm-verify-contact-submit",
 
   "fmContactsImportBtn": "fm-contacts-import-btn",
-  "fmContactsShareBtn": "fm-contacts-share-btn"
+  "fmContactsShareBtn": "fm-contacts-share-btn",
+
+  "fmAftVerifiedSkipToggle": "fm-aft-verified-skip-toggle"
 }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1081,6 +1081,11 @@ pub(crate) async fn node_comms(
                                 format!("UpdateVerifiedBypass send failed: {e}"),
                                 Some(TryNodeAction::SendMessage),
                             );
+                        } else {
+                            crate::log::info(format!(
+                                "UpdateVerifiedBypass dispatched for `{}` allow={allow_verified_skip_token} (#157)",
+                                identity.alias()
+                            ));
                         }
                     }
                     Err(e) => {

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -1026,9 +1026,13 @@ fn ScrAft() -> Element {
                     label: "Don't require tokens from verified senders",
                     help: "When on, messages from contacts you've verified (fingerprint confirmed) skip the AFT token check. Verified contacts are managed in Settings → Contacts.",
                     control: rsx! {
-                        Toggle {
-                            on: allow_verified_skip_token,
-                            ontoggle: on_verified_bypass,
+                        div {
+                            "data-testid": crate::testid::FM_AFT_VERIFIED_SKIP_TOGGLE,
+                            "data-state": if allow_verified_skip_token { "on" } else { "off" },
+                            Toggle {
+                                on: allow_verified_skip_token,
+                                ontoggle: on_verified_bypass,
+                            }
                         }
                     },
                 }

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -117,6 +117,9 @@ pub(crate) const FM_SETTINGS_BTN: &str = "fm-settings-btn";
 pub(crate) const FM_SETTINGS_SHELL: &str = "fm-settings-shell";
 pub(crate) const FM_SETTINGS_BACK: &str = "fm-settings-back";
 pub(crate) const FM_SETTINGS_NAV_ITEM: &str = "fm-settings-nav-item";
+// AFT verified-sender bypass toggle (Settings → AFT).
+// `data-state` mirrors the bool: "on" / "off".
+pub(crate) const FM_AFT_VERIFIED_SKIP_TOGGLE: &str = "fm-aft-verified-skip-toggle";
 
 #[cfg(test)]
 mod tests {
@@ -207,6 +210,10 @@ mod tests {
             ("fmVerifyContactSubmit", super::FM_VERIFY_CONTACT_SUBMIT),
             ("fmContactsImportBtn", super::FM_CONTACTS_IMPORT_BTN),
             ("fmContactsShareBtn", super::FM_CONTACTS_SHARE_BTN),
+            (
+                "fmAftVerifiedSkipToggle",
+                super::FM_AFT_VERIFIED_SKIP_TOGGLE,
+            ),
         ];
         assert_eq!(
             json.len(),

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -66,6 +66,8 @@ const ALIAS_T3_ALICE = "alice3";
 const ALIAS_T3_BOB = "bob3";
 const ALIAS_T4_ALICE = "alice4";
 const ALIAS_T4_BOB = "bob4";
+const ALIAS_T5_ALICE = "alice5";
+const ALIAS_T5_BOB = "bob5";
 test.describe("Live node E2E", () => {
   test.skip(
     !process.env.FREENET_EMAIL_BASE_URL?.includes("/v1/contract/web/"),
@@ -849,6 +851,123 @@ test.describe("Live node E2E", () => {
       await bobCtx.close().catch(() => {});
       stopGwPump();
       stopPeerPump();
+    }
+  });
+
+  // #157 / #180 regression: turning on the verified-sender bypass
+  // toggle in Settings → AFT must dispatch a signed `ModifySettings`
+  // delta to the inbox contract — without it the change is local-only
+  // and senders keep paying the AFT cost. The bypass itself is a
+  // recipient-side policy; this test exercises the ON path's wire
+  // dispatch:
+  //   1. Alice creates an identity, imports bob as a verified contact
+  //   2. Alice opens her inbox + Settings → AFT
+  //   3. Alice flicks the verified-skip toggle ON
+  //   4. The webapp emits `UpdateVerifiedBypass dispatched … allow=true`
+  //      (signed ModifySettings → inbox contract) and the toggle's
+  //      `data-state` flips to "on"
+  // Sender-side cost-avoidance (bob sends without minting + alice
+  // receives) is a separate test gated on AFT cap configurability
+  // (#85 / #179) — once those land, an inverted assertion can verify
+  // the bypass actually frees sends through a depleted cap.
+  test("verified-skip toggle dispatches ModifySettings + flips state (#157)", async ({
+    page,
+  }) => {
+    const stopPermissionPump = startPermissionPump();
+    let bypassDispatched = false;
+    page.on("console", (m) => {
+      if (
+        /UpdateVerifiedBypass dispatched for `.+` allow=true \(#157\)/.test(
+          m.text(),
+        )
+      ) {
+        bypassDispatched = true;
+      }
+    });
+
+    try {
+      await page.goto("");
+      const app = page.frameLocator("iframe#app");
+      await expect(app.locator(".brand-name").first()).toContainText(APP_NAME, {
+        timeout: 60_000,
+      });
+
+      // Create alice + import bob (synthetic contact card — we don't
+      // need a real second peer for this test, just an entry whose VK
+      // alice's settings can list as verified).
+      await createIdentity(page, ALIAS_T5_ALICE);
+
+      // Generate bob's share card by spinning a second browser context
+      // long enough to read his contact:// payload. The actual cross-
+      // node send + receive isn't exercised here; we just need bob's
+      // VK in alice's verified-senders set.
+      const bobCtx = await page.context().browser()!.newContext();
+      try {
+        const bobPage = await bobCtx.newPage();
+        await bobPage.goto(PEER_BASE_URL);
+        await createIdentity(bobPage, ALIAS_T5_BOB);
+        const bobApp = bobPage.frameLocator("iframe#app");
+        await bobApp
+          .locator(`[data-testid="fm-id-row"][data-alias="${ALIAS_T5_BOB}"] [data-testid="fm-id-share"]`)
+          .click();
+        const bobShare = bobApp.locator('[data-testid="fm-share-modal"]');
+        await bobShare.waitFor({ timeout: 5_000 });
+        const bobCard = (await bobShare.getAttribute("data-share-text")) ?? "";
+        expect(bobCard).toMatch(/verify: .+\ncontact:\/\//);
+
+        // Alice imports bob (verified).
+        await app.locator('[data-testid="fm-contact-import"]').click();
+        await app
+          .locator('[data-testid="fm-import-contact-modal"] textarea')
+          .fill(bobCard);
+        await app
+          .locator('input[placeholder="e.g. Alice (work)"]')
+          .fill(ALIAS_T5_BOB);
+        const verifyCheck = app.locator('[data-testid="fm-verify-check"]');
+        await verifyCheck.waitFor({ timeout: 15_000 });
+        await verifyCheck.click();
+        await app.locator('[data-testid="fm-import-submit"]').click();
+        await expect(
+          app.locator(`[data-testid="contact-row"][data-alias="${ALIAS_T5_BOB}"]`),
+          "bob5 imported as verified contact",
+        ).toBeVisible({ timeout: 15_000 });
+      } finally {
+        await bobCtx.close().catch(() => {});
+      }
+
+      // Open alice's inbox so the Settings button is reachable.
+      await app
+        .locator(`[data-testid="fm-id-row"][data-alias="${ALIAS_T5_ALICE}"] [data-testid="fm-id-open"]`)
+        .first()
+        .click();
+      await app.locator('[data-testid="fm-settings-btn"]').click();
+      await app
+        .locator('[data-testid="fm-settings-nav-item"][data-screen="aft"]')
+        .click();
+
+      // Flick the verified-skip toggle ON. The toggle's `data-state`
+      // is "off" by default; after click it must flip to "on" AND the
+      // webapp must dispatch a ModifySettings delta (asserted via the
+      // console log marker).
+      const toggle = app.locator('[data-testid="fm-aft-verified-skip-toggle"]');
+      await toggle.waitFor({ timeout: 10_000 });
+      await expect(toggle).toHaveAttribute("data-state", "off");
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("data-state", "on", {
+        timeout: 5_000,
+      });
+
+      await expect
+        .poll(() => bypassDispatched, {
+          message:
+            "expected `UpdateVerifiedBypass dispatched … allow=true (#157)` " +
+            "console log within 10s of toggle click — otherwise the wire " +
+            "dispatch path didn't fire and the bypass is local-only",
+          timeout: 10_000,
+        })
+        .toBe(true);
+    } finally {
+      stopPermissionPump();
     }
   });
 

--- a/ui/tests/testids.ts
+++ b/ui/tests/testids.ts
@@ -70,6 +70,7 @@ interface TestIds {
   fmVerifyContactSubmit: string;
   fmContactsImportBtn: string;
   fmContactsShareBtn: string;
+  fmAftVerifiedSkipToggle: string;
 }
 
 export const TID: TestIds = JSON.parse(


### PR DESCRIPTION
## Summary

Closes the \`allow_verified_skip_token\` row in #180 (\"has at least one e2e covering the ON path\").

New iso test \`verified-skip toggle dispatches ModifySettings + flips state (#157)\`:

1. Alice creates an identity, imports bob as a verified contact (six-word fingerprint ticked in the import modal)
2. Alice opens her inbox + Settings → AFT
3. Alice flicks the new \`fm-aft-verified-skip-toggle\` ON
4. Assert \`data-state\` flips \`off\` → \`on\`
5. Assert the webapp emits \`UpdateVerifiedBypass dispatched for \`<alias>\` allow=true (#157)\` — without that log line the bypass is local-state-only and senders keep paying the AFT cost

Sender-side cost-avoidance (bob actually sends without minting + alice receives) is a separate test path gated on AFT tier configurability (#85 / #179). Once those land, an inverted assertion can exercise sends through a depleted cap.

## Changes

- \`ui/src/app/settings.rs\`: wraps the existing Toggle in a labeled \`div[data-testid][data-state]\` for Playwright targeting
- \`ui/src/api.rs\`: success log on \`UpdateVerifiedBypass\` so the wire dispatch is observable (matches the diagnostic style of \`primed contact inbox\` / \`rehydrate primed contact inbox\`)
- \`ui/src/testid.rs\` + \`ui/branding/testids.json\` + \`ui/tests/testids.ts\`: new \`FM_AFT_VERIFIED_SKIP_TOGGLE\` pinned with the standard drift guard
- \`ui/tests/live-node.spec.ts\`: new test 5
- \`docs/qa/manual-test-inventory.md\`: new auto row

## Test plan

- [x] Local: \`cargo make test-e2e-real-node\` — 5 passed (25.1s)
- [x] Local: \`cargo test -p freenet-email-ui --lib testid::\` — drift guard passes
- [ ] CI: build-and-test + e2e-real-node + ui-playwright pass

## Refs

- Closes the \`allow_verified_skip_token\` row in #180
- Related: #157 (verified-sender bypass feature)
- Blocked-by for sender-side path: #85, #179