### PR TITLE
test(e2e): drop FREENET_LIVE_E2E_AFT_CAP_RAISED gate (#180, #221)

### DIFF
--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -143,7 +143,7 @@ add/remove protocol.
 | Appearance: serif_subjects toggle | manual | Toggle, confirm subjects flip font |
 | Advanced: custom relay URL takes effect on reload | manual | Set custom_relay + URL, reload, WS connects to that URL |
 | Settings round-trip across reload | manual | Set value, reload, value persists |
-| WIP: AFT tier picker (gated) | blocked | Issue #85 — recipient inbox params not configurable |
+| AFT tier picker dispatches ModifySettings (#85) | manual | Settings → AFT, click a tier card, expect `UpdateInboxPolicy dispatched … tier=<Tier> (#85)` in console. Multi-send with raised cap blocked on #221 (sender uses stale recipient tier from contact card). |
 | AFT verified-sender bypass toggle dispatches ModifySettings (#157) | auto | iso: `verified-skip toggle dispatches ModifySettings + flips state (#157)` |
 | WIP: read receipts toggle (gated) | blocked | Issue #69 — feature not implemented |
 | WIP: pad_length toggle (gated) | blocked | No implementation; gated until designed |

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1029,6 +1029,11 @@ pub(crate) async fn node_comms(
                                 format!("UpdateInboxPolicy send failed: {e}"),
                                 Some(TryNodeAction::SendMessage),
                             );
+                        } else {
+                            crate::log::info(format!(
+                                "UpdateInboxPolicy dispatched for `{}` tier={required_tier:?} max_age_secs={max_age_secs} (#85)",
+                                identity.alias()
+                            ));
                         }
                     }
                     Err(e) => {

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -246,9 +246,7 @@ test.describe("Live node E2E", () => {
   // FREENET_LIVE_E2E_SEND was the kill switch while #114 (duplicate
   // inbox per alias on shared delegate state) caused intermittent
   // failures. With #114 + #115 fixed and the iso harness verified
-  // green in PR #122, the gate is removed. Set
-  // FREENET_LIVE_E2E_AFT_CAP_RAISED=1 if you want the round-3
-  // alice→bob retry assertion in test 3.
+  // green in PR #122, the gate is removed.
   test("alice → bob across nodes: send + receive end-to-end (#81)", async ({
     browser,
   }) => {
@@ -422,8 +420,8 @@ test.describe("Live node E2E", () => {
     // after #114 + #115 fixes plus the spec-side reload-instead-of-
     // goBack correction (the SPA doesn't push history entries on
     // click, so `goBack` was navigating to about:blank rather than
-    // the inbox). Round 3 stays gated on
-    // FREENET_LIVE_E2E_AFT_CAP_RAISED until #85 lands.
+    // the inbox). Round 3 stays uncoverable until #221 — see the
+    // explanation around round 2 below.
     test.skip(
       !PEER_BASE_URL,
       "cross-node test requires FREENET_EMAIL_BASE_URL to include the contract id",
@@ -599,19 +597,12 @@ test.describe("Live node E2E", () => {
         "alice receives bob's reply",
       ).toBeVisible({ timeout: 60_000 });
 
-      // ── Round 3: alice → bob again ──────────────────────────────
-      // Skipped on iso by default: AFT day-1 cap is 1 slot, and alice
-      // already burned it in round one. Until #85 makes tier
-      // configurable, this round cannot pass on a fresh iso net.
-      // Set FREENET_LIVE_E2E_AFT_CAP_RAISED=1 once the cap is lifted
-      // (test contract or alternative tier) to re-enable.
-      if (process.env.FREENET_LIVE_E2E_AFT_CAP_RAISED === "1") {
-        await composeAndSend(aliceApp, ALIAS_T3_BOB, "round three", "third body");
-        await expect(
-          bobApp.getByText(/round three/i),
-          "bob receives round three (AFT slot still free)",
-        ).toBeVisible({ timeout: 60_000 });
-      }
+      // Round 3 (alice → bob a second time) is currently uncoverable
+      // on iso: bob's contact card encodes the recipient's tier at
+      // share time and the sender mints against that frozen value
+      // (#221), so a recipient-side ModifySettings tier change leaves
+      // the sender minting at the old tier and the contract rejecting.
+      // Re-enable once #221 ships sender-side dynamic tier resolution.
 
       // ── Archive: bob archives round one. Should leave the inbox
       // list and surface in the Archive folder.


### PR DESCRIPTION
## Summary

One row from #180's env-gate inventory: \`FREENET_LIVE_E2E_AFT_CAP_RAISED\`. Marked as blocked on #85 / #179 in the inventory; both are now closed.

**However** — turning the gate ON still doesn't make round 3 pass. Investigation found that even with the recipient tier mutable (#85) and cap-enforcement covered (#179), the sender mints against the recipient's tier **as encoded in the contact card at share time**. That value is frozen (\`Identity.required_tier\` doesn't update post-creation). So when the recipient raises their tier to gain more slots, the sender keeps minting at the old tier and the contract rejects with \`PolicyTierMismatch\`.

Filed #221 to track sender-side dynamic tier resolution, which is what would actually unblock the round-3 retry.

## Changes

- \`ui/tests/live-node.spec.ts\`: drop the gated \`if (process.env.FREENET_LIVE_E2E_AFT_CAP_RAISED === \"1\")\` block in test 3 + the two stale comment references at tests 2 + 3. Replace with a pointer to #221.
- \`ui/src/api.rs\`: add \`UpdateInboxPolicy dispatched … tier=<Tier> (#85)\` info log so the (now-manual) AFT-tier-picker QA recipe has an observable signal. Same diagnostic style as the \`UpdateVerifiedBypass dispatched\` log from #220.
- \`docs/qa/manual-test-inventory.md\`: \`WIP: AFT tier picker (gated)\` row updated to manual (no longer \"blocked\"); points at #221 for the missing e2e.

## Test plan

- [x] Local: \`cargo make test-e2e-real-node\` — 5 passed (24.4s)
- [ ] CI: build-and-test + e2e-real-node + ui-playwright pass

## Refs

- Closes the \`FREENET_LIVE_E2E_AFT_CAP_RAISED\` row in #180
- Files #221 (sender-side dynamic tier resolution) as the followup that actually unblocks round 3