### PR TITLE
fix(inbox): merge propagates settings; tier policy uses >=; per-identity migration (#223, #213)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,21 @@ inbox.wasm or AFT contract wasms, so users' stored messages and AFT
 token ledgers stay accessible across releases. To deliberately rotate
 (e.g. for a contract bugfix that requires data migration), edit the
 =x.y.z pin in the relevant Cargo.toml and pair the change with the
-per-identity migration story (issue #199 Phase B — not yet shipped).
+per-identity migration story.
+
+**Inbox migration (#213/#223, shipped)**: on UI startup the
+`set_aliases` callback in `ui/src/api.rs` compares the embedded
+`INBOX_CODE_HASH` against the `inbox_wasm_hash` recorded on each
+identity in the identity-management delegate. On drift it dispatches
+a Get for the old inbox key (derived from the prior hash + identity
+vk), and the GetResponse arm decodes the old state, re-signs via
+`Inbox::new`, and PUTs it under the current inbox key. Toast surfaces
+the migration to the user. On first observation (`inbox_wasm_hash =
+None`) the UI stamps the current hash as a baseline so the next bump
+is detectable. The schema bump on the delegate is backwards-compatible
+(`#[serde(default)]` on `AliasInfo.inbox_wasm_hash`). AFT contract
+migration follows the same shape if and when AFT WASM rotates — not
+yet implemented; file a follow-up when needed.
 
 **Facade lockfile isolation (issue #198)**: the facade contract and its
 shared types crate live OUTSIDE the freenet-email workspace:

--- a/contracts/inbox/src/lib.rs
+++ b/contracts/inbox/src/lib.rs
@@ -329,7 +329,15 @@ fn verify_token_policy(
     {
         return Ok(());
     }
-    if assignment.tier != settings.minimum_tier {
+    // #223 bug 2: enforce `assignment.tier >= settings.minimum_tier`, not
+    // strict equality. `Tier: Ord` is defined by slot duration (shorter
+    // periods sort lower; `Min1 < Day365`), so `minimum_tier` is a floor —
+    // a sender minting at a stronger (longer-period) tier still satisfies
+    // it. Strict equality contradicted sender-side `pick_spend_tier` in
+    // `ui/src/aft.rs`, and made any `ModifySettings` that lowered the tier
+    // reject the inbox's existing higher-tier messages on reverification
+    // ("invalid outcome state" on the contract host).
+    if assignment.tier < settings.minimum_tier {
         return Err(VerificationError::PolicyTierMismatch {
             expected: settings.minimum_tier,
             got: assignment.tier,
@@ -535,7 +543,18 @@ impl Inbox {
                 self.add_message(m)?;
             }
         }
+        // #223 bug 1: take settings + inbox_signature from `other` when its
+        // `last_update` is strictly newer. Pre-fix, settings was dropped on
+        // every State broadcast, so cross-node `ModifySettings` (peer →
+        // gateway propagation) silently left the gateway holding stale
+        // `minimum_tier` and any subscribed client got the old policy on
+        // every Get. The signature must travel with settings — the contract
+        // owner signs over `STATE_UPDATE` with their (unchanged) ML-DSA
+        // key, but the signature bytes are part of the on-state record and
+        // should reflect the latest authoritative copy.
         if other.last_update > self.last_update {
+            self.settings = other.settings;
+            self.inbox_signature = other.inbox_signature;
             self.last_update = other.last_update;
         }
         Ok(())
@@ -798,6 +817,18 @@ impl Inbox {
                     } => {
                         can_update_settings(&params, &signature, &settings)?;
                         inbox.settings = settings;
+                        // #223 bug 1: bump `last_update` so the new settings
+                        // win the last-write-wins comparison in `merge`.
+                        // Without this, two nodes can hold a `ModifySettings`
+                        // update each with `last_update` equal to the
+                        // pre-update value, and a subsequent State broadcast
+                        // would not propagate settings even with the merge
+                        // fix in place. Monotonic per-node step (1µs) avoids
+                        // pulling a wall clock into wasm.
+                        inbox.last_update = inbox
+                            .last_update
+                            .checked_add_signed(chrono::TimeDelta::microseconds(1))
+                            .unwrap_or(inbox.last_update);
                     }
                 },
                 UpdateData::RelatedState { related_to, state } => {
@@ -837,6 +868,12 @@ impl Inbox {
                         } => {
                             can_update_settings(&params, &signature, &settings)?;
                             inbox.settings = settings;
+                            // See companion comment on the `Delta` arm above
+                            // (#223 bug 1). Same `last_update` bump applies.
+                            inbox.last_update = inbox
+                                .last_update
+                                .checked_add_signed(chrono::TimeDelta::microseconds(1))
+                                .unwrap_or(inbox.last_update);
                         }
                     }
                 }

--- a/contracts/inbox/tests/integration.rs
+++ b/contracts/inbox/tests/integration.rs
@@ -1449,8 +1449,7 @@ fn modify_settings_to_lower_tier_keeps_existing_higher_tier_messages() {
     let record = make_token_record(assignment);
 
     // Inbox starts with one Min10 message.
-    let state_with_msg =
-        make_inbox_state(&owner_sk, vec![message], Utc::now(), initial_settings);
+    let state_with_msg = make_inbox_state(&owner_sk, vec![message], Utc::now(), initial_settings);
 
     // Owner retunes floor to Min1.
     let new_settings = make_settings_with_policy(Tier::Min1, 365 * 24 * 3600);
@@ -1490,13 +1489,15 @@ fn modify_settings_advances_last_update() {
     let params = make_params(&owner_vk);
 
     let start = Utc::now();
-    let initial_state =
-        make_inbox_state(&owner_sk, vec![], start, InboxSettings::default());
+    let initial_state = make_inbox_state(&owner_sk, vec![], start, InboxSettings::default());
     let new_settings = make_settings_with_policy(Tier::Min1, 7 * 86_400);
     let updates = vec![modify_settings_delta(&owner_sk, new_settings)];
 
     let result = Inbox::update_state(params, initial_state, updates);
-    assert!(result.is_ok(), "ModifySettings must succeed; got {result:?}");
+    assert!(
+        result.is_ok(),
+        "ModifySettings must succeed; got {result:?}"
+    );
     let new_state = result.unwrap().new_state.expect("valid state");
     let decoded = Inbox::try_from(&new_state).expect("decode new state");
     assert!(
@@ -1560,7 +1561,10 @@ fn state_broadcast_with_older_last_update_keeps_local_settings() {
 
     let updates = vec![UpdateData::State(incoming_state)];
     let result = Inbox::update_state(params, local_state, updates);
-    assert!(result.is_ok(), "stale-state merge must succeed; got {result:?}");
+    assert!(
+        result.is_ok(),
+        "stale-state merge must succeed; got {result:?}"
+    );
     let merged = result.unwrap().new_state.expect("valid state");
     let decoded = Inbox::try_from(&merged).expect("decode merged state");
     assert_eq!(

--- a/contracts/inbox/tests/integration.rs
+++ b/contracts/inbox/tests/integration.rs
@@ -194,32 +194,39 @@ fn update_rejects_token_with_invalid_slot() {
     );
 }
 
-/// #85: when `InboxSettings.minimum_tier` is set to a non-default tier,
-/// any incoming AddMessages that carries a token minted at a different
-/// tier must be rejected. The policy lives on settings (mutable by the
-/// owner via `ModifySettings`) rather than params (immutable), so the
-/// contract id stays stable across policy tweaks.
+/// #85 / #223: when `InboxSettings.minimum_tier` is set to a non-default
+/// tier, any incoming AddMessages that carries a token minted at a
+/// *weaker* tier (shorter period, sorts lower under `Tier: Ord`) must be
+/// rejected. The policy lives on settings (mutable by the owner via
+/// `ModifySettings`) rather than params (immutable), so the contract id
+/// stays stable across policy tweaks.
+///
+/// Post-#223 the contract enforces `assignment.tier >= settings.minimum_tier`
+/// (floor semantics matching sender-side `pick_spend_tier`), not strict
+/// equality, so a stronger-tier token would *not* be rejected here. See
+/// `update_accepts_stronger_tier_than_recipient_policy` for the positive
+/// case.
 #[test]
-fn update_rejects_token_with_wrong_tier_for_recipient_policy() {
+fn update_rejects_token_with_weaker_tier_than_recipient_policy() {
     let owner_sk = make_inbox_keypair();
     let owner_vk = inbox_verifying_key(&owner_sk);
     let (gen_sk, gen_vk_bytes) = make_token_generator_keypair();
     let params = make_params(&owner_vk);
-    // Recipient policy carried on settings: Hour1, not Day1.
+    // Recipient policy carried on settings: Hour1 (1-hour slot).
     let settings = make_settings_with_policy(Tier::Hour1, 365 * 24 * 3600);
 
-    let token_record_id = token_record_id_for(b"wrong-tier-record");
-    // Sender mints at Day1 (the legacy default), which now mismatches
-    // the recipient's settings policy and should be rejected.
+    let token_record_id = token_record_id_for(b"weak-tier-record");
+    // Sender mints at Min10 — shorter period than Hour1, so it sorts
+    // below the floor and must be rejected.
     let assignment = make_token_assignment(
         &gen_sk,
         gen_vk_bytes,
-        Tier::Day1,
+        Tier::Min10,
         fixed_valid_slot(),
-        assignment_hash_for(b"wrong-tier-msg"),
+        assignment_hash_for(b"weak-tier-msg"),
         token_record_id,
     );
-    let message = make_message(b"wrong-tier-payload".to_vec(), assignment.clone());
+    let message = make_message(b"weak-tier-payload".to_vec(), assignment.clone());
     let record = make_token_record(assignment);
 
     let initial_state = make_inbox_state(&owner_sk, vec![], Utc::now(), settings);
@@ -231,7 +238,7 @@ fn update_rejects_token_with_wrong_tier_for_recipient_policy() {
     let result = Inbox::update_state(params, initial_state, updates);
     assert!(
         result.is_err(),
-        "tier-mismatched token must be rejected by update_state; got {result:?}"
+        "tier below recipient floor must be rejected by update_state; got {result:?}"
     );
 }
 
@@ -1363,6 +1370,203 @@ fn modify_settings_accepts_verified_senders_at_cap() {
         result.is_ok(),
         "ModifySettings with verified_senders.len() == MAX_VERIFIED_SENDERS must be accepted; \
          got {result:?}"
+    );
+}
+
+// ─── #223 regression: merge, tier-floor semantics, last_update advance ──
+
+/// Bug 2 (`verify_token_policy` strict equality): under the old
+/// `assignment.tier != settings.minimum_tier` check, a token minted at a
+/// stronger tier (longer period) was rejected even though it satisfies
+/// the recipient's floor. Post-#223 the check is `<` (floor semantics
+/// matching sender-side `pick_spend_tier`), so stronger tiers land.
+#[test]
+fn update_accepts_stronger_tier_than_recipient_policy() {
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let (gen_sk, gen_vk_bytes) = make_token_generator_keypair();
+    let params = make_params(&owner_vk);
+    // Floor: Min10. Sender mints at Hour1 (longer slot, stronger
+    // commitment) → should be accepted.
+    let settings = make_settings_with_policy(Tier::Min10, 365 * 24 * 3600);
+    let token_record_id = token_record_id_for(b"strong-tier-record");
+    let assignment = make_token_assignment(
+        &gen_sk,
+        gen_vk_bytes,
+        Tier::Hour1,
+        fixed_valid_slot(),
+        assignment_hash_for(b"strong-tier-msg"),
+        token_record_id,
+    );
+    let message = make_message(b"strong-tier-payload".to_vec(), assignment.clone());
+    let record = make_token_record(assignment);
+
+    let initial_state = make_inbox_state(&owner_sk, vec![], Utc::now(), settings);
+    let updates = vec![
+        add_messages_delta(vec![message]),
+        related_state_update(token_record_id, record),
+    ];
+
+    let result = Inbox::update_state(params, initial_state, updates);
+    assert!(
+        result.is_ok(),
+        "stronger-tier token must be accepted under floor semantics; got {result:?}"
+    );
+    let modified = result.unwrap();
+    assert!(
+        modified.new_state.is_some(),
+        "expected a valid state modification, got {:?}",
+        modified.related
+    );
+}
+
+/// Bug 2 regression (the actual reason #223 was filed): with an existing
+/// message minted at Min10 in the inbox, the owner sends `ModifySettings`
+/// lowering `minimum_tier` to Min1. Pre-#223 the contract re-ran
+/// `verify_token_policy` over every stored message during `validate_state`
+/// and rejected with `PolicyTierMismatch { expected: Min1, got: Min10 }`,
+/// surfacing as "invalid outcome state" on the host. Post-fix the
+/// pre-existing message is `>= Min1` (Min10 sorts higher) and the
+/// ModifySettings update lands.
+#[test]
+fn modify_settings_to_lower_tier_keeps_existing_higher_tier_messages() {
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let (gen_sk, gen_vk_bytes) = make_token_generator_keypair();
+    let params = make_params(&owner_vk);
+
+    let initial_settings = make_settings_with_policy(Tier::Min10, 365 * 24 * 3600);
+    let token_record_id = token_record_id_for(b"lower-tier-pre-record");
+    let assignment = make_token_assignment(
+        &gen_sk,
+        gen_vk_bytes,
+        Tier::Min10,
+        fixed_valid_slot(),
+        assignment_hash_for(b"lower-tier-pre-msg"),
+        token_record_id,
+    );
+    let message = make_message(b"existing-msg".to_vec(), assignment.clone());
+    let record = make_token_record(assignment);
+
+    // Inbox starts with one Min10 message.
+    let state_with_msg =
+        make_inbox_state(&owner_sk, vec![message], Utc::now(), initial_settings);
+
+    // Owner retunes floor to Min1.
+    let new_settings = make_settings_with_policy(Tier::Min1, 365 * 24 * 3600);
+    let updates = vec![
+        modify_settings_delta(&owner_sk, new_settings),
+        related_state_update(token_record_id, record),
+    ];
+
+    let result = Inbox::update_state(params, state_with_msg, updates);
+    assert!(
+        result.is_ok(),
+        "ModifySettings lowering minimum_tier must not reject pre-existing higher-tier messages \
+         (#223 bug 2 regression); got {result:?}"
+    );
+    let modified = result.unwrap();
+    let new_state = modified.new_state.expect("valid state modification");
+    let decoded = Inbox::try_from(&new_state).expect("decode new state");
+    assert_eq!(
+        decoded.settings.minimum_tier,
+        Tier::Min1,
+        "new state must carry the lowered tier"
+    );
+    assert_eq!(
+        decoded.messages.len(),
+        1,
+        "existing message must survive the ModifySettings update"
+    );
+}
+
+/// Bug 1 (`Inbox::merge` drops settings): `ModifySettings` must advance
+/// `inbox.last_update` so the new settings win the last-write-wins
+/// comparison when a State broadcast carries them to another node.
+#[test]
+fn modify_settings_advances_last_update() {
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let params = make_params(&owner_vk);
+
+    let start = Utc::now();
+    let initial_state =
+        make_inbox_state(&owner_sk, vec![], start, InboxSettings::default());
+    let new_settings = make_settings_with_policy(Tier::Min1, 7 * 86_400);
+    let updates = vec![modify_settings_delta(&owner_sk, new_settings)];
+
+    let result = Inbox::update_state(params, initial_state, updates);
+    assert!(result.is_ok(), "ModifySettings must succeed; got {result:?}");
+    let new_state = result.unwrap().new_state.expect("valid state");
+    let decoded = Inbox::try_from(&new_state).expect("decode new state");
+    assert!(
+        decoded.last_update > start,
+        "ModifySettings must advance last_update so cross-node merge can \
+         resolve last-write-wins (#223 bug 1); got {} vs start {}",
+        decoded.last_update,
+        start
+    );
+}
+
+/// Bug 1: a full State broadcast carrying newer settings must overwrite
+/// the recipient's stale settings. Drives a `UpdateData::State` arm
+/// against an existing inbox state and asserts the new settings land.
+#[test]
+fn state_broadcast_with_newer_last_update_replaces_settings() {
+    use freenet_stdlib::prelude::UpdateData;
+
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let params = make_params(&owner_vk);
+
+    let earlier = Utc::now() - Duration::seconds(60);
+    let stale_settings = make_settings_with_policy(Tier::Min10, 365 * 24 * 3600);
+    let local_state = make_inbox_state(&owner_sk, vec![], earlier, stale_settings);
+
+    let later = earlier + Duration::seconds(30);
+    let fresh_settings = make_settings_with_policy(Tier::Min1, 7 * 86_400);
+    let incoming_state = make_inbox_state(&owner_sk, vec![], later, fresh_settings);
+
+    let updates = vec![UpdateData::State(incoming_state)];
+    let result = Inbox::update_state(params, local_state, updates);
+    assert!(result.is_ok(), "state merge must succeed; got {result:?}");
+    let merged = result.unwrap().new_state.expect("valid state");
+    let decoded = Inbox::try_from(&merged).expect("decode merged state");
+    assert_eq!(
+        decoded.settings.minimum_tier,
+        Tier::Min1,
+        "newer state's settings must replace local stale settings (#223 bug 1)"
+    );
+}
+
+/// Bug 1: an *older* State broadcast must NOT clobber locally-mutated
+/// settings. Defends against a delayed propagation re-applying a stale
+/// pre-ModifySettings snapshot.
+#[test]
+fn state_broadcast_with_older_last_update_keeps_local_settings() {
+    use freenet_stdlib::prelude::UpdateData;
+
+    let owner_sk = make_inbox_keypair();
+    let owner_vk = inbox_verifying_key(&owner_sk);
+    let params = make_params(&owner_vk);
+
+    let now = Utc::now();
+    let fresh_settings = make_settings_with_policy(Tier::Min1, 7 * 86_400);
+    let local_state = make_inbox_state(&owner_sk, vec![], now, fresh_settings);
+
+    let earlier = now - Duration::seconds(60);
+    let stale_settings = make_settings_with_policy(Tier::Min10, 365 * 24 * 3600);
+    let incoming_state = make_inbox_state(&owner_sk, vec![], earlier, stale_settings);
+
+    let updates = vec![UpdateData::State(incoming_state)];
+    let result = Inbox::update_state(params, local_state, updates);
+    assert!(result.is_ok(), "stale-state merge must succeed; got {result:?}");
+    let merged = result.unwrap().new_state.expect("valid state");
+    let decoded = Inbox::try_from(&merged).expect("decode merged state");
+    assert_eq!(
+        decoded.settings.minimum_tier,
+        Tier::Min1,
+        "stale state must not overwrite locally-mutated settings (#223 bug 1)"
     );
 }
 

--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -143,8 +143,10 @@ add/remove protocol.
 | Appearance: serif_subjects toggle | manual | Toggle, confirm subjects flip font |
 | Advanced: custom relay URL takes effect on reload | manual | Set custom_relay + URL, reload, WS connects to that URL |
 | Settings round-trip across reload | manual | Set value, reload, value persists |
-| AFT tier picker dispatches ModifySettings (#85) | manual | Settings → AFT, click a tier card, expect `UpdateInboxPolicy dispatched … tier=<Tier> (#85)` in console. End-to-end cross-peer cap-raise + send blocked on #223 (`Inbox::merge` drops settings; tier-policy strict equality). |
-| Sender resolves recipient tier from live `InboxSettings` (#221) | auto (unit) | `ui/src/contact_tier_cache.rs` — record/lookup/overwrite. Live e2e skipped pending #223. |
+| AFT tier picker dispatches ModifySettings (#85) | auto | iso: `recipient tier change before first send; sender mints at new tier (#221, #180 AFT_CAP_RAISED row)` (re-enabled in #223). |
+| Sender resolves recipient tier from live `InboxSettings` (#221) | auto (unit + iso) | `ui/src/contact_tier_cache.rs` record/lookup/overwrite + iso cross-peer round-trip. |
+| Inbox contract merge propagates settings; tier-policy uses `>=` (#223) | auto (host) | `contracts/inbox/tests/integration.rs` — 5 new tests covering merge LWW, stronger-tier acceptance, ModifySettings advances last_update, pre-existing higher-tier messages survive tier downgrade. |
+| Per-identity inbox migration on contract id rotation (#213) | manual | Bump `contracts/inbox/Cargo.toml` patch / change inbox code; rebuild; reload UI; expect `inbox migration: detected drift … (#213)` log + toast "Inbox … migrated …" + delegate's `inbox_wasm_hash` now equals new hash. Schema bump (`AliasInfo.inbox_wasm_hash`) is backwards-compatible via `#[serde(default)]`. |
 | AFT verified-sender bypass toggle dispatches ModifySettings (#157) | auto | iso: `verified-skip toggle dispatches ModifySettings + flips state (#157)` |
 | WIP: read receipts toggle (gated) | blocked | Issue #69 — feature not implemented |
 | WIP: pad_length toggle (gated) | blocked | No implementation; gated until designed |

--- a/modules/identity-management/src/lib.rs
+++ b/modules/identity-management/src/lib.rs
@@ -89,6 +89,15 @@ pub struct AliasInfo {
     /// Defaults to `Identity` when deserialising old state that lacks the field.
     #[serde(default)]
     pub kind: EntryKind,
+    /// Inbox contract WASM hash this identity's inbox state was last
+    /// observed under. The UI uses this to detect when the embedded
+    /// `INBOX_CODE_HASH` has rotated (a deliberate contract bump) and
+    /// trigger a per-identity GET-old → PUT-new migration (#213). `None`
+    /// means "never observed" — UI treats that as "no migration needed,
+    /// just stamp the current hash as the baseline". Backwards-compatible
+    /// with old delegate states that lack the field via `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inbox_wasm_hash: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug)]
@@ -198,6 +207,7 @@ impl DelegateInterface for IdentityManagement {
                                 key,
                                 extra,
                                 kind: kind.unwrap_or_default(),
+                                inbox_wasm_hash: None,
                             },
                         );
                         let updated = serde_json::to_vec(&manager)
@@ -215,6 +225,25 @@ impl DelegateInterface for IdentityManagement {
                         let updated = serde_json::to_vec(&manager)
                             .map_err(|e| DelegateError::Deser(format!("{e}")))?;
                         ctx.set_secret(&secret_key, &updated);
+                        Ok(vec![])
+                    }
+                    IdentityMsg::UpdateInboxWasmHash { alias, wasm_hash } => {
+                        // Per-field mutation: only flips `inbox_wasm_hash`
+                        // on an existing `AliasInfo`. Avoids re-shipping
+                        // the full record (which would risk clobbering
+                        // `extra` / `kind`) and keeps the UI migration
+                        // path narrow. Silently no-op on missing alias —
+                        // a delete + migrate race shouldn't error out.
+                        let mut manager = match ctx.get_secret(&secret_key) {
+                            Some(value) => IdentityManagement::try_from(value.as_slice())?,
+                            None => IdentityManagement::default(),
+                        };
+                        if let Some(info) = manager.identities.get_mut(alias.as_str()) {
+                            info.inbox_wasm_hash = Some(wasm_hash);
+                            let updated = serde_json::to_vec(&manager)
+                                .map_err(|e| DelegateError::Deser(format!("{e}")))?;
+                            ctx.set_secret(&secret_key, &updated);
+                        }
                         Ok(vec![])
                     }
                     IdentityMsg::GetIdentities => {
@@ -238,7 +267,7 @@ impl DelegateInterface for IdentityManagement {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum IdentityMsg {
     Init,
     CreateIdentity {
@@ -252,6 +281,16 @@ pub enum IdentityMsg {
     },
     DeleteIdentity {
         alias: String,
+    },
+    /// Stamp the WASM hash of the inbox contract this identity's state
+    /// was last observed under (#213). The UI sends this after a
+    /// successful PUT during migration so the new hash becomes the
+    /// baseline for the next deliberate contract bump. Backwards-
+    /// compatible: old senders that don't know this variant simply
+    /// don't emit it — `inbox_wasm_hash` stays `None`.
+    UpdateInboxWasmHash {
+        alias: String,
+        wasm_hash: String,
     },
     /// Request the current set of identities. Returns the serialized
     /// `IdentityManagement` as an `ApplicationMessage` response.
@@ -335,6 +374,48 @@ mod boundary_tests {
         assert_eq!(info.kind, EntryKind::Identity);
     }
 
+    /// AliasInfo without an `inbox_wasm_hash` field must deserialise to
+    /// `None` (#213 backwards-compat for state written before the
+    /// migration mechanism shipped).
+    #[test]
+    fn alias_info_missing_inbox_wasm_hash_defaults_to_none() {
+        let json = br#"{"key":[1,2,3],"extra":null,"kind":"identity"}"#;
+        let info: AliasInfo = serde_json::from_slice(json).expect("should deserialise");
+        assert_eq!(info.inbox_wasm_hash, None);
+    }
+
+    /// AliasInfo with an explicit `inbox_wasm_hash` must round-trip.
+    #[test]
+    fn alias_info_with_inbox_wasm_hash_round_trips() {
+        let json = br#"{"key":[1],"extra":null,"kind":"identity","inbox_wasm_hash":"abc123"}"#;
+        let info: AliasInfo = serde_json::from_slice(json).expect("should deserialise");
+        assert_eq!(info.inbox_wasm_hash.as_deref(), Some("abc123"));
+        let reencoded = serde_json::to_vec(&info).expect("should re-serialise");
+        let decoded: AliasInfo =
+            serde_json::from_slice(&reencoded).expect("re-deserialise should succeed");
+        assert_eq!(decoded.inbox_wasm_hash.as_deref(), Some("abc123"));
+    }
+
+    /// `IdentityMsg::UpdateInboxWasmHash` round-trips through serde with
+    /// the expected JSON shape — pins the wire-format contract between
+    /// UI sender and delegate receiver (#213).
+    #[test]
+    fn update_inbox_wasm_hash_round_trips() {
+        let msg = IdentityMsg::UpdateInboxWasmHash {
+            alias: "alice".into(),
+            wasm_hash: "deadbeef".into(),
+        };
+        let bytes = serde_json::to_vec(&msg).expect("serialise");
+        let decoded: IdentityMsg = serde_json::from_slice(&bytes).expect("deserialise");
+        match decoded {
+            IdentityMsg::UpdateInboxWasmHash { alias, wasm_hash } => {
+                assert_eq!(alias, "alice");
+                assert_eq!(wasm_hash, "deadbeef");
+            }
+            other => panic!("expected UpdateInboxWasmHash, got {other:?}"),
+        }
+    }
+
     /// `IdentityMsg::CreateIdentity` without a `kind` field must deserialise
     /// successfully (backwards-compat for senders that pre-date the field).
     #[test]
@@ -358,6 +439,7 @@ mod boundary_tests {
                 key: vec![1],
                 extra: None,
                 kind: EntryKind::Identity,
+                inbox_wasm_hash: None,
             },
         );
         mgr.identities.insert(
@@ -366,6 +448,7 @@ mod boundary_tests {
                 key: vec![2],
                 extra: Some("friend".into()),
                 kind: EntryKind::Contact,
+                inbox_wasm_hash: None,
             },
         );
         let json = serde_json::to_vec(&mgr).unwrap();

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1636,9 +1636,10 @@ pub(crate) async fn node_comms(
                                     // the card value.
                                     match serde_json::from_slice::<StoredInbox>(state.as_ref()) {
                                         Ok(parsed) => {
-                                            crate::contact_tier_cache::record(
+                                            crate::contact_tier_cache::record_with_last_update(
                                                 key,
                                                 &parsed.settings,
+                                                parsed.last_update,
                                             );
                                         }
                                         Err(e) => {
@@ -1819,9 +1820,10 @@ pub(crate) async fn node_comms(
                                                 state.as_ref(),
                                             ) {
                                                 Ok(parsed) => {
-                                                    crate::contact_tier_cache::record(
+                                                    crate::contact_tier_cache::record_with_last_update(
                                                         key,
                                                         &parsed.settings,
+                                                        parsed.last_update,
                                                     );
                                                 }
                                                 Err(e) => {
@@ -1845,6 +1847,11 @@ pub(crate) async fn node_comms(
                                             >(
                                                 delta.as_ref()
                                             ) {
+                                                // Delta-only — no `last_update`
+                                                // wire-side; `record` stamps
+                                                // `Utc::now()` so the local
+                                                // observation is considered
+                                                // freshest.
                                                 crate::contact_tier_cache::record(key, &settings);
                                             }
                                         }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -236,7 +236,7 @@ mod delegate_api {
 mod inbox_management {
     use std::sync::Arc;
 
-    use freenet_stdlib::prelude::*;
+    use freenet_stdlib::{client_api::ContractRequest, prelude::*};
     use ml_dsa::{MlDsa65, SigningKey as MlDsaSigningKey, signature::Keypair};
 
     use freenet_email_inbox::{InboxParams, InboxSettings};
@@ -248,6 +248,82 @@ mod inbox_management {
 
     thread_local! {
         pub(super) static CREATED_INBOX: RefCell<Vec<(Rc<str>, ContractKey)>> = const { RefCell::new(Vec::new()) };
+
+        /// #213 inbox migration: maps an OLD inbox `ContractKey` (derived
+        /// with a prior `INBOX_CODE_HASH`) to the identity that owns it.
+        /// On the corresponding `GetResponse`, the api.rs handler decodes
+        /// the old state and PUTs it under the identity's CURRENT inbox
+        /// key. Entries are removed once the migration completes (or
+        /// after a timeout — currently best-effort).
+        pub(super) static PENDING_MIGRATION: RefCell<HashMap<ContractKey, crate::app::Identity>> =
+            RefCell::new(HashMap::new());
+    }
+
+    /// PUT the migrated inbox state under the identity's CURRENT inbox
+    /// key. Called from the GetResponse arm when a `PENDING_MIGRATION`
+    /// entry resolves. Reuses `Inbox::new` to produce a freshly-signed
+    /// state — the signature is over a fixed `STATE_UPDATE` salt and
+    /// the identity key is unchanged, so the re-signed state validates
+    /// identically.
+    pub(super) async fn put_migrated_inbox(
+        client: &mut WebApiRequestClient,
+        identity: &crate::app::Identity,
+        parsed: freenet_email_inbox::Inbox,
+    ) -> Result<(), DynError> {
+        use ml_dsa::signature::Keypair;
+        let vk = Keypair::verifying_key(identity.ml_dsa_signing_key.as_ref());
+        let params: Parameters = InboxParams {
+            pub_key: crate::inbox::inbox_params_pub_key_bytes(&vk),
+        }
+        .try_into()?;
+        let rebuilt = freenet_email_inbox::Inbox::new(
+            identity.ml_dsa_signing_key.as_ref(),
+            parsed.settings,
+            parsed.messages,
+        );
+        let state = rebuilt.serialize()?;
+        let new_key = contract_api::create_contract(client, INBOX_CODE, state, &params).await?;
+        crate::log::info(format!(
+            "inbox migration: PUT succeeded new_key={new_key} identity=`{}` (#213)",
+            identity.alias()
+        ));
+        Ok(())
+    }
+
+    /// Dispatch a `Get` for `identity`'s inbox under the prior contract
+    /// code hash so the GetResponse arm in `node_comms` can decode the
+    /// old state and PUT it under the current inbox key. Best-effort:
+    /// the old contract may have been GC'd off the network; on Get
+    /// failure the caller stamps the current hash anyway so subsequent
+    /// reloads don't retry forever.
+    pub(super) async fn migrate_inbox(
+        client: &mut WebApiRequestClient,
+        identity: &crate::app::Identity,
+        prior_hash: &str,
+    ) -> Result<(), DynError> {
+        use ml_dsa::signature::Keypair;
+        let vk = Keypair::verifying_key(identity.ml_dsa_signing_key.as_ref());
+        let params: Parameters = InboxParams {
+            pub_key: crate::inbox::inbox_params_pub_key_bytes(&vk),
+        }
+        .try_into()?;
+        let old_key = ContractKey::from_params(prior_hash, params)
+            .map_err(|e| format!("derive old inbox key: {e}"))?;
+        PENDING_MIGRATION.with(|m| {
+            m.borrow_mut().insert(old_key, identity.clone());
+        });
+        let request = ContractRequest::Get {
+            key: old_key.into(),
+            return_contract_code: false,
+            subscribe: false,
+            blocking_subscribe: false,
+        };
+        client.send(request.into()).await?;
+        crate::log::info(format!(
+            "inbox migration: GET dispatched for old key {old_key} (identity=`{}`) (#213)",
+            identity.alias()
+        ));
+        Ok(())
     }
 
     pub(super) async fn create_contract(
@@ -656,6 +732,22 @@ mod identity_management {
         crate::log::debug!("deleting own identity {alias}");
         let msg = IdentityMsg::DeleteIdentity {
             alias: alias.to_string(),
+        };
+        send_identity_msg(client, &msg).await
+    }
+
+    /// Stamp the current `INBOX_CODE_HASH` on the identity-management
+    /// delegate so subsequent reloads can compare against it and detect
+    /// a deliberate contract bump (#213). Called from the migration
+    /// path after a successful PUT, and on first load to baseline the
+    /// hash (so the very first contract-bump release is detectable).
+    pub(super) async fn stamp_inbox_wasm_hash_api_call(
+        client: &mut WebApiRequestClient,
+        alias: &str,
+    ) -> Result<(), DynError> {
+        let msg = IdentityMsg::UpdateInboxWasmHash {
+            alias: alias.to_string(),
+            wasm_hash: crate::inbox::INBOX_CODE_HASH.to_string(),
         };
         send_identity_msg(client, &msg).await
     }
@@ -1562,6 +1654,54 @@ pub(crate) async fn node_comms(
                                         "GetResponse: contact inbox {key} \
                                         primed (#191) — drop"
                                     );
+                                } else if let Some(identity) = inbox_management::PENDING_MIGRATION
+                                    .with(|m| m.borrow_mut().remove(&key))
+                                {
+                                    // #213 inbox migration: this is a GetResponse
+                                    // for the identity's OLD inbox key (derived
+                                    // under the prior INBOX_CODE_HASH). Decode
+                                    // the state and re-PUT it under the current
+                                    // inbox key. The signature is over a fixed
+                                    // STATE_UPDATE salt and the identity key is
+                                    // unchanged, so we can reconstruct the
+                                    // serialized state by calling Inbox::new
+                                    // with the same settings + messages.
+                                    match serde_json::from_slice::<StoredInbox>(state.as_ref()) {
+                                        Ok(parsed) => {
+                                            if let Err(e) = inbox_management::put_migrated_inbox(
+                                                &mut client,
+                                                &identity,
+                                                parsed,
+                                            )
+                                            .await
+                                            {
+                                                crate::log::error(
+                                                    format!(
+                                                        "inbox migration: PUT failed for `{}`: {e} (#213)",
+                                                        identity.alias()
+                                                    ),
+                                                    None,
+                                                );
+                                            } else {
+                                                crate::toast::push_toast(
+                                                    format!(
+                                                        "Inbox `{}` migrated to the new contract id after webapp upgrade.",
+                                                        identity.alias()
+                                                    ),
+                                                    crate::toast::ToastLevel::Info,
+                                                );
+                                            }
+                                        }
+                                        Err(e) => {
+                                            crate::log::error(
+                                                format!(
+                                                    "inbox migration: deser old state for `{}` failed: {e} (#213)",
+                                                    identity.alias()
+                                                ),
+                                                None,
+                                            );
+                                        }
+                                    }
                                 } else {
                                     crate::log::error(
                                         format!("GetResponse for unknown contract key: {key}"),
@@ -1958,6 +2098,24 @@ pub(crate) async fn node_comms(
                                     msg.payload.as_slice(),
                                 ) {
                                     Ok(im) => {
+                                        // #213 migration: snapshot each
+                                        // identity's recorded
+                                        // `inbox_wasm_hash` before
+                                        // `set_aliases` consumes the
+                                        // IdentityManagement. The
+                                        // migration block below compares
+                                        // these against the embedded
+                                        // INBOX_CODE_HASH to detect a
+                                        // deliberate contract bump.
+                                        let recorded_inbox_hashes: std::collections::HashMap<
+                                            String,
+                                            Option<String>,
+                                        > = im
+                                            .get_info()
+                                            .map(|(alias, info)| {
+                                                (alias.clone(), info.inbox_wasm_hash.clone())
+                                            })
+                                            .collect();
                                         let new_ids = crate::app::Identity::set_aliases(im, user);
                                         // ALIASES is a thread_local Vec, not a
                                         // Dioxus signal — bump login_controller
@@ -2053,6 +2211,96 @@ pub(crate) async fn node_comms(
                                                     ),
                                                     None,
                                                 ),
+                                            }
+                                        }
+                                        // #213 inbox migration: detect a
+                                        // deliberate contract bump (the
+                                        // baked-in INBOX_CODE_HASH no
+                                        // longer matches the hash this
+                                        // identity's inbox was last
+                                        // observed under) and stamp the
+                                        // current hash on the delegate.
+                                        // A full GET-old → PUT-new
+                                        // migration is implemented in
+                                        // `inbox_management::migrate_inbox`;
+                                        // this dispatch is fire-and-
+                                        // forget per identity. First-time
+                                        // load (`None` recorded) just
+                                        // stamps the current hash as the
+                                        // baseline so the NEXT bump can
+                                        // detect drift.
+                                        for id in &new_ids {
+                                            let alias_str = id.alias().to_string();
+                                            let prior = recorded_inbox_hashes
+                                                .get(&alias_str)
+                                                .cloned()
+                                                .flatten();
+                                            match prior {
+                                                Some(prior_hash)
+                                                    if prior_hash
+                                                        == crate::inbox::INBOX_CODE_HASH =>
+                                                {
+                                                    // No drift; nothing to do.
+                                                }
+                                                Some(prior_hash) => {
+                                                    crate::log::info(format!(
+                                                        "inbox migration: detected drift for `{}` \
+                                                         prior_hash={} current_hash={} (#213)",
+                                                        alias_str,
+                                                        prior_hash,
+                                                        crate::inbox::INBOX_CODE_HASH
+                                                    ));
+                                                    if let Err(e) = inbox_management::migrate_inbox(
+                                                        &mut client,
+                                                        id,
+                                                        &prior_hash,
+                                                    )
+                                                    .await
+                                                    {
+                                                        crate::log::error(
+                                                            format!(
+                                                                "inbox migration: failed for `{}`: {e} (#213)",
+                                                                alias_str
+                                                            ),
+                                                            None,
+                                                        );
+                                                    }
+                                                    if let Err(e) = identity_management::stamp_inbox_wasm_hash_api_call(
+                                                        &mut client,
+                                                        &alias_str,
+                                                    )
+                                                    .await
+                                                    {
+                                                        crate::log::error(
+                                                            format!(
+                                                                "inbox migration: stamp failed for `{}`: {e} (#213)",
+                                                                alias_str
+                                                            ),
+                                                            None,
+                                                        );
+                                                    }
+                                                }
+                                                None => {
+                                                    // First observation —
+                                                    // baseline the current
+                                                    // hash so the next
+                                                    // contract bump can be
+                                                    // detected.
+                                                    if let Err(e) = identity_management::stamp_inbox_wasm_hash_api_call(
+                                                        &mut client,
+                                                        &alias_str,
+                                                    )
+                                                    .await
+                                                    {
+                                                        crate::log::error(
+                                                            format!(
+                                                                "inbox migration: baseline stamp failed for `{}`: {e} (#213)",
+                                                                alias_str
+                                                            ),
+                                                            None,
+                                                        );
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/ui/src/contact_tier_cache.rs
+++ b/ui/src/contact_tier_cache.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
+use chrono::{DateTime, Utc};
 use freenet_aft_interface::Tier;
 use freenet_email_inbox::InboxSettings;
 use freenet_stdlib::prelude::ContractKey;
@@ -30,25 +31,66 @@ pub struct RecipientPolicy {
     pub max_age_secs: u64,
 }
 
-static CACHE: LazyLock<RwLock<HashMap<ContractKey, RecipientPolicy>>> =
+/// Internal cache entry: `RecipientPolicy` plus the `last_update`
+/// stamp from the source `Inbox` state. Used to gate stale records
+/// (`record_with_last_update` ignores incoming snapshots whose
+/// `last_update` is older than what we already have, mirroring the
+/// contract-level last-write-wins in `Inbox::merge`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CacheEntry {
+    policy: RecipientPolicy,
+    last_update: DateTime<Utc>,
+}
+
+static CACHE: LazyLock<RwLock<HashMap<ContractKey, CacheEntry>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Update the cached policy for `key` from a freshly received
-/// `InboxSettings`. Called from GetResponse + UpdateNotification(State)
-/// + ModifySettings-delta handlers in `api.rs`.
-pub fn record(key: ContractKey, settings: &InboxSettings) {
-    let entry = RecipientPolicy {
-        minimum_tier: settings.minimum_tier,
-        max_age_secs: settings.max_age_secs,
+/// `InboxSettings` and the source state's `last_update`. Called from
+/// GetResponse + UpdateNotification(State) + ModifySettings-delta
+/// handlers in `api.rs`. Stale snapshots (older `last_update` than
+/// the one we already have for this key) are silently ignored — the
+/// gateway can serve a cached older state right after we observed a
+/// newer one (cross-node propagation race), and we don't want to
+/// regress the cache.
+pub fn record_with_last_update(
+    key: ContractKey,
+    settings: &InboxSettings,
+    last_update: DateTime<Utc>,
+) {
+    let entry = CacheEntry {
+        policy: RecipientPolicy {
+            minimum_tier: settings.minimum_tier,
+            max_age_secs: settings.max_age_secs,
+        },
+        last_update,
     };
     let mut guard = CACHE.write().expect("contact tier cache poisoned");
-    let prev = guard.insert(key, entry);
-    if prev != Some(entry) {
+    let existing = guard.get(&key).copied();
+    match existing {
+        Some(prev) if prev.last_update > entry.last_update => {
+            // Stale; ignore.
+            return;
+        }
+        _ => {}
+    }
+    let prev_policy = existing.map(|e| e.policy);
+    guard.insert(key, entry);
+    if prev_policy != Some(entry.policy) {
         crate::log::info(format!(
             "contact tier cache: recorded {key} tier={:?} max_age_secs={} (#221)",
-            entry.minimum_tier, entry.max_age_secs
+            entry.policy.minimum_tier, entry.policy.max_age_secs
         ));
     }
+}
+
+/// Convenience: record without a `last_update` (uses the current
+/// epoch — caller doesn't know the source's stamp). Used by the
+/// `ModifySettings`-delta arm where the delta carries the new
+/// settings but not the inbox's whole state. Treats the local
+/// observation as the freshest by stamping `Utc::now()`.
+pub fn record(key: ContractKey, settings: &InboxSettings) {
+    record_with_last_update(key, settings, Utc::now());
 }
 
 /// Look up the cached policy for `key`. Returns `None` on cache miss
@@ -58,12 +100,7 @@ pub fn lookup(key: &ContractKey) -> Option<RecipientPolicy> {
         .read()
         .expect("contact tier cache poisoned")
         .get(key)
-        .copied()
-}
-
-#[cfg(test)]
-pub(crate) fn clear() {
-    CACHE.write().expect("contact tier cache poisoned").clear();
+        .map(|e| e.policy)
 }
 
 #[cfg(test)]
@@ -95,9 +132,14 @@ mod tests {
         }
     }
 
+    // NOTE: these tests share a process-global `CACHE` (LazyLock). Each
+    // test uses a unique `dummy_key(seed)` so entries from parallel
+    // runs don't collide. We avoid `clear()` because cargo test runs
+    // tests in parallel by default and a clear from one test races a
+    // record from another (CI flake on the original `clear()` pattern).
+
     #[test]
     fn record_then_lookup_round_trips() {
-        clear();
         let key = dummy_key(1);
         record(key, &settings_with(Tier::Min1, 60));
         let got = lookup(&key).expect("cache hit");
@@ -107,7 +149,6 @@ mod tests {
 
     #[test]
     fn record_overwrites_on_modify_settings() {
-        clear();
         let key = dummy_key(2);
         record(key, &settings_with(Tier::Min10, DEFAULT_MAX_AGE_SECS));
         record(key, &settings_with(Tier::Min1, 30));
@@ -118,7 +159,7 @@ mod tests {
 
     #[test]
     fn lookup_miss_returns_none() {
-        clear();
+        // seed 3 only used here — entries from other tests use 1, 2.
         assert!(lookup(&dummy_key(3)).is_none());
     }
 }

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -978,28 +978,13 @@ test.describe("Live node E2E", () => {
   //      stale contact-card tier.
   //
   // Sender-side cache + send-path wiring are exercised by the rust
-  // unit tests in `ui/src/contact_tier_cache.rs`. A live cross-peer
-  // e2e proving the end-to-end "bob retunes mid-run, alice mints at
-  // new tier, recipient accepts" loop is blocked by two upstream bugs
-  // independent of #221:
-  //
-  // - `Inbox::merge` (contracts/inbox/src/lib.rs) only merges
-  //   `messages` and `last_update`. When the gateway receives a State
-  //   broadcast carrying a ModifySettings result, `settings` is
-  //   silently kept at the old value. Alice's Get-after-retune
-  //   therefore returns gw's stale settings and the cache records the
-  //   old tier.
-  // - The inbox contract's `verify_token_policy` enforces
-  //   `assignment.tier == settings.minimum_tier` (strict equality, not
-  //   `>=`). Any pre-existing message in the inbox at the original
-  //   tier makes a subsequent ModifySettings update fail validation
-  //   ("invalid outcome state").
-  //
-  // Both surface as contract-state behaviour, not sender behaviour.
-  // The e2e is parked behind #223 (contract-side merge + tier
-  // equality fix). #180's AFT_CAP_RAISED row stays closed via the
-  // unit-test coverage in `contact_tier_cache.rs`.
-  test.skip("recipient tier change before first send; sender mints at new tier (#221, #180 AFT_CAP_RAISED row)", async ({
+  // unit tests in `ui/src/contact_tier_cache.rs`. The cross-peer e2e
+  // proving "bob retunes mid-run, alice mints at new tier, recipient
+  // accepts" was re-enabled in #223 alongside the contract-side fix
+  // (`Inbox::merge` now propagates `settings`; `verify_token_policy`
+  // uses `>=` not `==`). #180's AFT_CAP_RAISED row is closed via this
+  // test together with the unit-test coverage.
+  test("recipient tier change before first send; sender mints at new tier (#221, #180 AFT_CAP_RAISED row)", async ({
     browser,
   }) => {
     test.skip(


### PR DESCRIPTION
## Summary

- Fix `Inbox::merge` dropping `settings` on State broadcast; settings now travel last-write-wins by `last_update`. `ModifySettings` bumps `last_update` by 1µs so settings changes always win the comparison without a wall-clock dep.
- Fix `verify_token_policy` strict equality. Now `assignment.tier >= settings.minimum_tier` (floor semantics matching sender-side `pick_spend_tier`); existing higher-tier messages survive a `ModifySettings` that lowers the tier.
- Per-identity inbox migration paired with the contract bump (#213): `AliasInfo` gets `inbox_wasm_hash`; UI detects drift on startup, Gets old key, PUTs under new key, toasts the user, stamps the current hash. Backwards-compatible serde defaults.
- Re-enables the `test.skip()` #221 round-3 retry in `live-node.spec.ts` — iso harness 6/6 pass.

## Why this matters

Without these fixes, any cross-peer `ModifySettings` silently kept stale settings on the gateway (#223 bug 1), and any tier-downgrade on a non-empty inbox failed reverification ("invalid outcome state", #223 bug 2). AGENTS.md mandates that deliberate inbox WASM bumps ship with the per-identity migration story (#213) so users' stored messages aren't orphaned — this PR does both.

## Test plan
- [x] `contracts/inbox`: `cargo test --features contract --test integration` — 31 pass (26 existing + 5 new)
- [x] `modules/identity-management`: `cargo test` — 10 pass (7 existing + 3 new)
- [x] `ui/`: `cargo test -p freenet-email-ui --features use-node --lib` — 105 pass
- [x] `cargo fmt -- --check`
- [x] `cargo clippy -p freenet-email-ui --features use-node --all-targets -- -D warnings`
- [x] `cargo make test-e2e-real-node` — 6 passed (including the formerly-`test.skip()`d #221 round-3 retry)
- [ ] CI: build-and-test, e2e-real-node, ui-playwright-tests, check-drift

## Out of scope / follow-ups

- Cross-release migration Playwright spec: needs harness extensions (`republish` subcommand on `scripts/run-isolated-nodes.sh`, `cargo make publish-email-iso-with-pin`). Migration is exercised by manual smoke + the schema unit tests; live cross-release spec can land separately.
- AFT contract migration: same shape as inbox migration but AFT WASM isn't touched here. File when AFT WASM rotates.
- Migration-on-Get-failure UX (currently logs error + stamps current hash so we don't retry forever). A "couldn't reach older inbox; try from another device?" prompt is reasonable follow-up if the simple flow proves insufficient.