### PR TITLE
ci(facade): gate published params on prod pubkey + add publish-facade task (#214 F1+F2)

### DIFF
--- a/.github/workflows/check-contract-wasm.yml
+++ b/.github/workflows/check-contract-wasm.yml
@@ -140,3 +140,53 @@ jobs:
           path: contracts/facade/target/wasm32-unknown-unknown/release/freenet_email_facade.wasm
           if-no-files-found: warn
           retention-days: 7
+
+      # Issue #214 F1: facade.parameters IS the production verifying
+      # key (32 bytes ed25519). The committed facade contract id is
+      # `hash(facade.wasm, facade.parameters)`, so swapping the
+      # parameters silently rotates the stable bookmarkable URL —
+      # exactly the failure #200 was designed to prevent. Hard-code
+      # the production pubkey here as a tripwire: a PR that touches
+      # published-contract/facade.parameters MUST update this hex,
+      # which is a visible, reviewable change.
+      #
+      # Production pubkey is the ed25519 verifying key under
+      # ~/.config/freenet-email/web-container-keys.toml. Rotating the
+      # production key requires bumping this constant in the same PR.
+      - name: Verify facade.parameters matches production pubkey
+        run: |
+          EXPECTED="31dd371fedc842994c6e571a0868e5eece1367a7d8cc16c498a57c985526ae46"
+          ACTUAL=$(xxd -p -c 64 published-contract/facade.parameters | tr -d '\n')
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "::error::facade.parameters does not match the production verifying key."
+              echo "  expected: $EXPECTED"
+              echo "  actual:   $ACTUAL"
+              echo ""
+              echo "This means either:"
+              echo "  (a) the snapshot was signed with the test key by mistake, or"
+              echo "  (b) the production key was rotated — bump EXPECTED in"
+              echo "      .github/workflows/check-contract-wasm.yml in the same PR."
+              exit 1
+          fi
+          echo "✅ facade.parameters matches the committed production pubkey."
+
+      # Same tripwire for webapp.parameters. The web-container id
+      # rotates per release (intentional, see #198), but the signing
+      # key must still be the production key — never the committed
+      # test key from test-contract/web-container-keys.toml.
+      - name: Verify webapp.parameters matches production pubkey
+        run: |
+          EXPECTED="31dd371fedc842994c6e571a0868e5eece1367a7d8cc16c498a57c985526ae46"
+          ACTUAL=$(xxd -p -c 64 published-contract/webapp.parameters | tr -d '\n')
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "::error::webapp.parameters does not match the production verifying key."
+              echo "  expected: $EXPECTED"
+              echo "  actual:   $ACTUAL"
+              echo ""
+              echo "If this commit was meant to refresh the TEST snapshot"
+              echo "(\`cargo make update-published-contract\`), do not push"
+              echo "the test snapshot to main — only the production snapshot"
+              echo "(\`update-published-contract-prod\`) is committed."
+              exit 1
+          fi
+          echo "✅ webapp.parameters matches the committed production pubkey."

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -424,6 +424,38 @@ fdev --port "$PORT" publish \
     --state "$STATE"
 '''
 
+[tasks.publish-facade]
+description = "Publish (PUT) the facade contract to the live Freenet network — ONE-TIME prod publish only"
+dependencies = ["build-facade", "sign-facade-state"]
+script_runner = "bash"
+script = '''
+set -euo pipefail
+ROOT="${CARGO_MAKE_WORKING_DIRECTORY}"
+WASM="$ROOT/published-contract/facade.wasm"
+PARAMS="$ROOT/published-contract/facade.parameters"
+STATE="$ROOT/target/facade/facade.state"
+if [ ! -f "$WASM" ] || [ ! -f "$PARAMS" ]; then
+    echo "error: facade wasm/parameters missing — run \`cargo make update-published-facade\` first" >&2
+    exit 1
+fi
+if [ ! -f "$STATE" ]; then
+    echo "error: $STATE missing — sign-facade-state dependency should have produced it" >&2
+    exit 1
+fi
+# IMPORTANT: this is a one-shot. The facade contract id MUST stay
+# byte-stable forever (it's the bookmarkable URL); re-PUTting it on a
+# network that already has the contract is wasteful but harmless.
+# Per-release pointer flips use `fdev execute update --as-state`
+# inside scripts/release.sh, NOT this task.
+echo "publishing facade contract $(cat "$ROOT/published-contract/facade-id.txt") to the live network"
+echo "  (no --port: targets whichever node owns 7509)"
+fdev publish \
+    --code "$WASM" \
+    --parameters "$PARAMS" \
+    contract \
+    --state "$STATE"
+'''
+
 [tasks.check-facade-byte-equal]
 description = "Verify the freshly built facade wasm matches the committed published-contract/facade.wasm"
 script_runner = "bash"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -319,13 +319,15 @@ git commit -m "chore(facade): commit production facade snapshot"
 # web-container id. After this, every subsequent release.sh run flips
 # its state via UPDATE.
 cargo make publish-facade-test    # for the local sandbox
-# OR for production:
-fdev publish \
-    --code published-contract/facade.wasm \
-    --parameters published-contract/facade.parameters \
-    contract --state target/facade/facade.state \
-    network
+# OR for production (one-shot, requires WEB_CONTAINER_KEY_FILE or
+# the default ~/.config/freenet-email/web-container-keys.toml):
+cargo make publish-facade
 ```
+
+`publish-facade` mirrors `publish-facade-test` but drops the
+`--port` override so fdev publishes to the live-network node. It is a
+one-time-per-environment operation — every subsequent release flips
+the facade pointer via UPDATE, not PUT.
 
 **Snapshot stability (#206)**: the committed
 `published-contract/facade.{wasm,parameters,id.txt}` snapshot is the


### PR DESCRIPTION
## Summary

Closes the two remaining follow-ups from #214:

- **F1 — CI pubkey gate**: `.github/workflows/check-contract-wasm.yml` now
  asserts that both `published-contract/facade.parameters` and
  `published-contract/webapp.parameters` are byte-equal to the hex of
  the production ed25519 verifying key
  (`31dd371fedc842994c6e571a0868e5eece1367a7d8cc16c498a57c985526ae46`).
  Without this gate, anyone refreshing `published-contract/` from a
  build that picked up a different keyfile silently rotates the
  facade contract id — defeating the point of #200's stable
  bookmarkable URL. Key rotation now requires bumping the constant
  in the same PR, which is a visible, reviewable change.

- **F2 — `publish-facade` prod task**: new `cargo make publish-facade`
  mirrors `publish-facade-test` minus the `--port` override. Replaces
  the hand-rolled `fdev publish ...` block in RELEASING.md
  §"One-time facade publish" so the prod bootstrap is symmetric with
  the sandbox path. Per-release pointer flips remain on
  `fdev execute update --as-state` from `scripts/release.sh` — this
  task is strictly for the one-time PUT per environment.

F3 (`--as-state` cleanup in release.sh) already landed and was
verified end-to-end during the v0.1.9 release.

## Test plan

- [x] `cargo make --list-all-steps` shows the new `publish-facade` task
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/check-contract-wasm.yml'))"`)
- [x] Hex comparison reproduces locally (`xxd -p -c 64 published-contract/facade.parameters` matches the expected constant)
- [ ] CI: `check-contract-wasm.yml` green on this PR — confirms the gate accepts the committed snapshot
- [ ] CI: manual sanity — temporarily commit a swapped `facade.parameters` (or test webapp.parameters from a refresh of `update-published-contract`) and verify the gate fails. (Will not push this; relying on the diff being visible enough.)

Refs #214.