### PR TITLE
fix(inbox): preserve sender time across kept_for path (#229)

### DIFF
--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -148,10 +148,15 @@ pub struct KeptMessage {
     pub from: String,
     pub title: String,
     pub content: String,
-    /// Unix millis at the time `MarkRead` was issued; the contract message
-    /// timestamp is not currently surfaced through the UI's `Message` type
-    /// so we keep our own.
+    /// Unix millis at the time `MarkRead` was issued.
     pub kept_at: i64,
+    /// Sender's original send time captured at MarkRead, surfaced from
+    /// `DecryptedMessage.time`. The kept-row render path prefers this over
+    /// `kept_at` so a row whose live contract entry has been evicted keeps
+    /// showing the send time rather than mutating to the click time (#229).
+    /// `None` for entries written before this field existed.
+    #[serde(default)]
+    pub sent_at: Option<i64>,
 }
 
 /// Saved permission decision for a specific recipient.
@@ -857,6 +862,7 @@ mod boundary_tests {
                 title: "hi".into(),
                 content: "yo".into(),
                 kept_at: 42,
+                sent_at: None,
             },
         );
         let bytes = serde_json::to_vec(&state).unwrap();

--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -872,6 +872,35 @@ mod boundary_tests {
         assert_eq!(back.aliases["alice"].kept["7"].content.as_str(), "yo");
     }
 
+    /// Pre-#229 `KeptMessage` payloads (no `sent_at` field) must keep loading
+    /// with `sent_at = None`. The UI render path falls back to `kept_at` in
+    /// that case — wrong but indistinguishable from the old behaviour.
+    #[test]
+    fn kept_message_missing_sent_at_defaults_none() {
+        let json = br#"{"from":"bob","title":"hi","content":"yo","kept_at":42}"#;
+        let k: KeptMessage = serde_json::from_slice(json).expect("should deserialise");
+        assert_eq!(k.sent_at, None);
+        assert_eq!(k.kept_at, 42);
+    }
+
+    /// New writes carry the sender's send time; it must round-trip across
+    /// the delegate stash so the kept-path render keeps showing the actual
+    /// send time after reload (#229).
+    #[test]
+    fn kept_message_with_sent_at_round_trips() {
+        let k = KeptMessage {
+            from: "bob".into(),
+            title: "hi".into(),
+            content: "yo".into(),
+            kept_at: 100,
+            sent_at: Some(50),
+        };
+        let bytes = serde_json::to_vec(&k).unwrap();
+        let back: KeptMessage = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(back.sent_at, Some(50));
+        assert_eq!(back.kept_at, 100);
+    }
+
     #[test]
     fn alias_state_missing_kept_defaults_empty() {
         let json = br#"{"drafts":{},"read":[1]}"#;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1446,10 +1446,9 @@ fn MessageList() -> Element {
                 // Legacy entries (pre-#229) lack sent_at and fall back to
                 // kept_at — wrong but indistinguishable from the old
                 // behaviour, and self-heals next time the row is read.
-                let time = chrono::DateTime::from_timestamp_millis(
-                    kept.sent_at.unwrap_or(kept.kept_at),
-                )
-                .unwrap_or_else(chrono::Utc::now);
+                let time =
+                    chrono::DateTime::from_timestamp_millis(kept.sent_at.unwrap_or(kept.kept_at))
+                        .unwrap_or_else(chrono::Utc::now);
                 emails.push(Message {
                     id: mid,
                     from: kept.from.into(),

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1441,8 +1441,15 @@ fn MessageList() -> Element {
                 if crate::local_state::is_archived(&alias, mid) {
                     continue;
                 }
-                let time = chrono::DateTime::from_timestamp_millis(kept.kept_at)
-                    .unwrap_or_else(chrono::Utc::now);
+                // Prefer sender's send time over click time so a kept row
+                // doesn't mutate to the click time after eviction (#229).
+                // Legacy entries (pre-#229) lack sent_at and fall back to
+                // kept_at — wrong but indistinguishable from the old
+                // behaviour, and self-heals next time the row is read.
+                let time = chrono::DateTime::from_timestamp_millis(
+                    kept.sent_at.unwrap_or(kept.kept_at),
+                )
+                .unwrap_or_else(chrono::Utc::now);
                 emails.push(Message {
                     id: mid,
                     from: kept.from.into(),
@@ -2121,6 +2128,7 @@ fn OpenMessage(msg: Message) -> Element {
                 title: msg.title.to_string(),
                 content: msg.content.to_string(),
                 kept_at: chrono::Utc::now().timestamp_millis(),
+                sent_at: Some(msg.time.timestamp_millis()),
             };
             crate::local_state::local_mark_read(&alias, msg.id, kept.clone());
             #[cfg(feature = "use-node")]

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -839,6 +839,16 @@ pub(crate) fn compose_post_send(send_succeeded: bool) -> ComposePostSend {
     }
 }
 
+/// Time column shown for a kept-locally row whose live contract entry has
+/// been evicted. Prefer the sender's send time (`sent_at`) over the
+/// MarkRead click time (`kept_at`). Legacy entries (pre-#229) lack
+/// `sent_at`; they fall back to `kept_at` — wrong but matches the
+/// pre-#229 behaviour and self-heals the next time the row is read.
+fn kept_render_time(kept: &mail_local_state::KeptMessage) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::from_timestamp_millis(kept.sent_at.unwrap_or(kept.kept_at))
+        .unwrap_or_else(chrono::Utc::now)
+}
+
 impl From<MessageModel> for Message {
     fn from(value: MessageModel) -> Self {
         Message {
@@ -1441,14 +1451,7 @@ fn MessageList() -> Element {
                 if crate::local_state::is_archived(&alias, mid) {
                     continue;
                 }
-                // Prefer sender's send time over click time so a kept row
-                // doesn't mutate to the click time after eviction (#229).
-                // Legacy entries (pre-#229) lack sent_at and fall back to
-                // kept_at — wrong but indistinguishable from the old
-                // behaviour, and self-heals next time the row is read.
-                let time =
-                    chrono::DateTime::from_timestamp_millis(kept.sent_at.unwrap_or(kept.kept_at))
-                        .unwrap_or_else(chrono::Utc::now);
+                let time = kept_render_time(&kept);
                 emails.push(Message {
                     id: mid,
                     from: kept.from.into(),
@@ -3087,6 +3090,59 @@ mod time_format_tests {
         let s = format_time_full(old);
         assert!(s.contains('·'), "got {s:?}");
         assert!(s.contains(':'), "got {s:?}");
+    }
+}
+
+#[cfg(test)]
+mod kept_render_time_tests {
+    use super::kept_render_time;
+    use mail_local_state::KeptMessage;
+
+    /// Regression for #229: the live row had time = sender's send time
+    /// (9:39). After eviction the kept-path row used to render with
+    /// click time (10:20). With the fix the row keeps the send time.
+    #[test]
+    fn prefers_sent_at_over_kept_at_when_present() {
+        let kept = KeptMessage {
+            from: "bob".into(),
+            title: "hi".into(),
+            content: "yo".into(),
+            kept_at: 10_000,      // "click time"
+            sent_at: Some(1_000), // "send time"
+        };
+        let t = kept_render_time(&kept);
+        assert_eq!(t.timestamp_millis(), 1_000, "must use sender's send time");
+    }
+
+    /// Legacy entries (pre-#229 stored snapshots) lack `sent_at` and
+    /// must still render with `kept_at` as a graceful fallback.
+    #[test]
+    fn falls_back_to_kept_at_for_legacy_entries() {
+        let kept = KeptMessage {
+            from: "bob".into(),
+            title: "hi".into(),
+            content: "yo".into(),
+            kept_at: 5_000,
+            sent_at: None,
+        };
+        let t = kept_render_time(&kept);
+        assert_eq!(t.timestamp_millis(), 5_000);
+    }
+
+    /// Out-of-range millis (e.g. corrupt or future-dated entries) must
+    /// not panic; helper falls back to `Utc::now()`. We just assert the
+    /// call returns without panicking — the actual value depends on
+    /// wall-clock.
+    #[test]
+    fn out_of_range_falls_back_to_now() {
+        let kept = KeptMessage {
+            from: "x".into(),
+            title: "x".into(),
+            content: "x".into(),
+            kept_at: i64::MAX,
+            sent_at: Some(i64::MAX),
+        };
+        let _ = kept_render_time(&kept);
     }
 }
 

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -602,6 +602,7 @@ mod tests {
             title: title.into(),
             content: "body".into(),
             kept_at: 0,
+            sent_at: None,
         }
     }
 
@@ -816,6 +817,7 @@ mod tests {
                         title: format!("msg-{id}"),
                         content: "body".into(),
                         kept_at: SHARED_KEPT_AT,
+                        sent_at: None,
                     },
                 );
             }


### PR DESCRIPTION
## Summary

- `KeptMessage` only persisted `kept_at` (click time). Once the inbox contract dropped the live row, the kept-path reconstruction in `app.rs:1410-1428` re-emitted the message with the click time, so an inbox row's displayed time mutated from \"9:39\" (send time) to \"10:20\" (click time) the moment two conditions coincided (read + live-row eviction).
- Add `KeptMessage.sent_at: Option<i64>` (defaulted for legacy entries), populated at MarkRead from `DecryptedMessage.time`. Reader prefers `sent_at`, falling back to `kept_at`.
- Eviction itself (why rows fall into the kept path so fast) is tracked in #234 — out of scope here.

Fixes #229.

## Test plan

- [x] `cargo test -p mail-local-state`
- [x] `cargo test -p freenet-email-ui`
- [x] `cargo check -p freenet-email-ui` (default + `--no-default-features --features example-data,no-sync`)
- [ ] Manual: receive a message, click it, observe the displayed time persists across a synthetic eviction (or after the row naturally falls through to kept_for)