### PR TITLE
fix(local-state): surface async write failures via toast (#231, #232)

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1898,10 +1898,7 @@ pub(crate) async fn node_comms(
                         )
                         .await
                         {
-                            crate::log::error(
-                                format!("set_sent_delivery_state(Delivered) failed: {e}"),
-                                None,
-                            );
+                            crate::log::local_state_failure("update delivery state", e);
                         }
                     });
                 }

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -426,10 +426,7 @@ impl InboxView {
                     )
                     .await
                     {
-                        crate::log::error(
-                            format!("set_sent_delivery_state(Failed) failed: {e}"),
-                            None,
-                        );
+                        crate::log::local_state_failure("update delivery state", e);
                     }
                 }
             };
@@ -2136,7 +2133,7 @@ fn OpenMessage(msg: Message) -> Element {
                     )
                     .await
                     {
-                        crate::log::error(format!("mark_read failed: {e}"), None);
+                        crate::log::local_state_failure("mark message read", e);
                     }
                 });
             }
@@ -2288,10 +2285,7 @@ fn OpenMessage(msg: Message) -> Element {
                                     )
                                     .await
                                     {
-                                        crate::log::error(
-                                            format!("archive_message failed: {e}"),
-                                            None,
-                                        );
+                                        crate::log::local_state_failure("archive message", e);
                                     }
                                 });
                             }
@@ -2460,7 +2454,7 @@ fn ComposeSheet() -> Element {
                 if let Err(e) =
                     crate::local_state::save_draft(&mut client_clone, alias, id, draft).await
                 {
-                    crate::log::error(format!("save_draft failed: {e}"), None);
+                    crate::log::local_state_failure("save draft", e);
                 }
             });
         }
@@ -2503,7 +2497,7 @@ fn ComposeSheet() -> Element {
             spawn(async move {
                 if let Err(e) = crate::local_state::delete_draft(&mut client_clone, alias, id).await
                 {
-                    crate::log::error(format!("delete_draft failed: {e}"), None);
+                    crate::log::local_state_failure("delete draft", e);
                 }
             });
         }
@@ -2727,7 +2721,7 @@ fn ComposeSheet() -> Element {
                     )
                     .await
                     {
-                        crate::log::error(format!("save_sent failed: {e}"), None);
+                        crate::log::local_state_failure("save sent message", e);
                     }
                 });
             }

--- a/ui/src/log.rs
+++ b/ui/src/log.rs
@@ -42,6 +42,21 @@ pub(crate) fn __debug_internal(msg: impl AsRef<str>) {
     let _ = msg;
 }
 
+/// Log an async local-state write failure AND surface it to the user via an
+/// error toast. The optimistic in-memory write made the UI look correct;
+/// without this surfacing the persistent write failure is silent and the row
+/// silently un-mutates on the next reload (#231, #232).
+///
+/// `op` is the user-facing verb ("save draft", "delete draft", "mark read",
+/// "archive", "save sent", "update delivery state"). The toast reads
+/// "Couldn't <op> — changes may not persist after reload."
+pub(crate) fn local_state_failure(op: &str, err: impl std::fmt::Display) {
+    let detail = format!("{op} failed: {err}");
+    error(detail, None);
+    let user_msg = format!("Couldn't {op} — changes may not persist after reload.");
+    crate::toast::push_toast(user_msg, crate::toast::ToastLevel::Error);
+}
+
 pub(crate) fn error(msg: impl AsRef<str>, action: Option<TryNodeAction>) {
     let error = msg.as_ref();
     if let Some(action) = action {

--- a/ui/src/log.rs
+++ b/ui/src/log.rs
@@ -71,6 +71,24 @@ pub(crate) fn local_state_failure(op: &str, err: impl std::fmt::Display) {
     );
 }
 
+pub(crate) fn error(msg: impl AsRef<str>, action: Option<TryNodeAction>) {
+    let error = msg.as_ref();
+    if let Some(action) = action {
+        tracing::error!(%error, %action);
+        #[cfg(target_family = "wasm")]
+        {
+            let error = format!("error while `{action}`: {error}");
+            web_sys::console::error_1(&serde_wasm_bindgen::to_value(&error).unwrap());
+        }
+    } else {
+        tracing::error!(%error);
+        #[cfg(target_family = "wasm")]
+        {
+            web_sys::console::error_1(&serde_wasm_bindgen::to_value(&error).unwrap());
+        }
+    }
+}
+
 #[cfg(test)]
 mod local_state_failure_tests {
     use super::{local_state_failure_log_msg, local_state_failure_toast_msg};
@@ -124,23 +142,5 @@ mod local_state_failure_tests {
             ops.len(),
             "each op must produce a distinct toast"
         );
-    }
-}
-
-pub(crate) fn error(msg: impl AsRef<str>, action: Option<TryNodeAction>) {
-    let error = msg.as_ref();
-    if let Some(action) = action {
-        tracing::error!(%error, %action);
-        #[cfg(target_family = "wasm")]
-        {
-            let error = format!("error while `{action}`: {error}");
-            web_sys::console::error_1(&serde_wasm_bindgen::to_value(&error).unwrap());
-        }
-    } else {
-        tracing::error!(%error);
-        #[cfg(target_family = "wasm")]
-        {
-            web_sys::console::error_1(&serde_wasm_bindgen::to_value(&error).unwrap());
-        }
     }
 }

--- a/ui/src/log.rs
+++ b/ui/src/log.rs
@@ -42,6 +42,19 @@ pub(crate) fn __debug_internal(msg: impl AsRef<str>) {
     let _ = msg;
 }
 
+/// Build the user-facing toast text for an async local-state write
+/// failure. Split from the side-effecting helper so the wording can be
+/// unit-tested without spinning up the Dioxus toast runtime (#231, #232).
+pub(crate) fn local_state_failure_toast_msg(op: &str) -> String {
+    format!("Couldn't {op} — changes may not persist after reload.")
+}
+
+/// Build the developer-facing log line for an async local-state write
+/// failure. Same split rationale as `local_state_failure_toast_msg`.
+pub(crate) fn local_state_failure_log_msg(op: &str, err: impl std::fmt::Display) -> String {
+    format!("{op} failed: {err}")
+}
+
 /// Log an async local-state write failure AND surface it to the user via an
 /// error toast. The optimistic in-memory write made the UI look correct;
 /// without this surfacing the persistent write failure is silent and the row
@@ -51,10 +64,67 @@ pub(crate) fn __debug_internal(msg: impl AsRef<str>) {
 /// "archive", "save sent", "update delivery state"). The toast reads
 /// "Couldn't <op> — changes may not persist after reload."
 pub(crate) fn local_state_failure(op: &str, err: impl std::fmt::Display) {
-    let detail = format!("{op} failed: {err}");
-    error(detail, None);
-    let user_msg = format!("Couldn't {op} — changes may not persist after reload.");
-    crate::toast::push_toast(user_msg, crate::toast::ToastLevel::Error);
+    error(local_state_failure_log_msg(op, err), None);
+    crate::toast::push_toast(
+        local_state_failure_toast_msg(op),
+        crate::toast::ToastLevel::Error,
+    );
+}
+
+#[cfg(test)]
+mod local_state_failure_tests {
+    use super::{local_state_failure_log_msg, local_state_failure_toast_msg};
+
+    /// Regression for #231/#232: the toast must be a non-empty, user-readable
+    /// sentence including the op verb. Pre-fix, these failures only hit
+    /// `console.error` — no user surface at all.
+    #[test]
+    fn toast_msg_contains_op_and_persistence_hint() {
+        let msg = local_state_failure_toast_msg("save draft");
+        assert!(msg.contains("save draft"), "must name the op: {msg}");
+        assert!(
+            msg.contains("persist") || msg.contains("reload"),
+            "must hint at the data-loss-on-reload failure mode: {msg}"
+        );
+        assert!(!msg.is_empty());
+    }
+
+    /// Log line is the developer signal and must carry both the op verb
+    /// and the underlying error text. Without the error text the bug is
+    /// undiagnosable from the console alone.
+    #[test]
+    fn log_msg_includes_op_and_error_detail() {
+        let msg = local_state_failure_log_msg("delete draft", "websocket dropped");
+        assert!(msg.contains("delete draft"));
+        assert!(msg.contains("websocket dropped"));
+    }
+
+    /// Covers every op verb wired through `local_state_failure` in the
+    /// current codebase. If a new local-state writer is added without a
+    /// corresponding toast call site, the verb won't appear here — keeping
+    /// the list explicit forces a maintainer to think about it.
+    #[test]
+    fn all_known_ops_format_distinctly() {
+        let ops = [
+            "save draft",
+            "delete draft",
+            "mark message read",
+            "archive message",
+            "save sent message",
+            "update delivery state",
+        ];
+        let mut msgs: Vec<String> = ops
+            .iter()
+            .map(|op| local_state_failure_toast_msg(op))
+            .collect();
+        msgs.sort();
+        msgs.dedup();
+        assert_eq!(
+            msgs.len(),
+            ops.len(),
+            "each op must produce a distinct toast"
+        );
+    }
 }
 
 pub(crate) fn error(msg: impl AsRef<str>, action: Option<TryNodeAction>) {


### PR DESCRIPTION
## Summary

- Every spawned writer (`save_draft`, `delete_draft`, `save_sent`, `mark_read`, `archive_message`, `set_sent_delivery_state`) logged failures to `console.error` only. The optimistic in-memory write made the UI look correct; the persistent write failure went unseen and the row silently un-mutated on the next reload — drafts resurrected, sent messages disappeared, archived rows came back.
- Add `crate::log::local_state_failure(op, err)` that logs as before AND pushes an error toast worded for the user: \"Couldn't <op> — changes may not persist after reload.\"
- Wire every existing spawn-failure log line through it.

Retry / persistent tombstone (#232 options 2 + 3) are still on the table but the toast is the prerequisite for noticing failures at all.

Fixes #231, fixes #232.

## Test plan

- [x] `cargo check -p freenet-email-ui` (default `use-node`)
- [x] `cargo check -p freenet-email-ui --no-default-features --features example-data,no-sync`
- [x] `cargo test -p freenet-email-ui`
- [ ] Manual: simulate a `local_state::*` failure (e.g. detach the delegate mid-session) and observe red toast on draft delete, archive, send, mark-read