### PR TITLE
fix(contacts): require verify when phrase present + clickable badge (#228)

### DIFF
--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -1915,7 +1915,20 @@ pub(super) fn ImportContactForm() -> Element {
         }
     };
 
-    let can_import = fingerprint_words.read().is_some() && !local_alias.read().is_empty();
+    // If the pasted blob includes the `verify: <six-words>` prefix the
+    // sharing flow emits (see share_text format at login.rs:1038), require
+    // the user to tick the verify checkbox before allowing Import. Falling
+    // through to a permanently-unverified contact silently breaks the
+    // verified-only acceptance flow (#228, settings.rs:1434).
+    let has_verify_phrase = paste_text
+        .read()
+        .lines()
+        .next()
+        .map(|l| l.trim_start().starts_with("verify: "))
+        .unwrap_or(false);
+    let can_import = fingerprint_words.read().is_some()
+        && !local_alias.read().is_empty()
+        && (!has_verify_phrase || *verified.read());
 
     let cancel = move |_| {
         import_contact_form.write().0 = false;
@@ -2008,6 +2021,12 @@ pub(super) fn ImportContactForm() -> Element {
                                 }
                                 span { class: "verify-sub",
                                     "Phone, in person, Signal — anything but this app. Untick if you have not."
+                                }
+                                if has_verify_phrase && !*verified.read() {
+                                    span { class: "verify-sub",
+                                        style: "color:#991b1b;",
+                                        "Required: this contact card includes a verify phrase. Tick once you've matched the six words out-of-band."
+                                    }
                                 }
                             }
                         }
@@ -2229,9 +2248,23 @@ fn ContactsSection() -> Element {
                                         "✓ verified"
                                     }
                                 } else {
-                                    span { class: "badge badge-warn",
-                                        "data-testid": "contact-verify-badge",
-                                        "⚠ unverified"
+                                    {
+                                        // Badge is itself the verify CTA so the
+                                        // "⚠ unverified" affordance isn't passive
+                                        // (#228 option B).
+                                        let pending_badge = contact.clone();
+                                        rsx! {
+                                            button {
+                                                class: "badge badge-warn btn-link",
+                                                style: "cursor:pointer; border:0; background:transparent; padding:0; font:inherit;",
+                                                title: "Verify this contact's fingerprint",
+                                                "data-testid": "contact-verify-badge",
+                                                onclick: move |_| {
+                                                    verify_pending.write().0 = Some(pending_badge.clone());
+                                                },
+                                                "⚠ unverified"
+                                            }
+                                        }
                                     }
                                 }
                                 if !verified {

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -1915,20 +1915,19 @@ pub(super) fn ImportContactForm() -> Element {
         }
     };
 
-    // If the pasted blob includes the `verify: <six-words>` prefix the
-    // sharing flow emits (see share_text format at login.rs:1038), require
-    // the user to tick the verify checkbox before allowing Import. Falling
-    // through to a permanently-unverified contact silently breaks the
-    // verified-only acceptance flow (#228, settings.rs:1434).
+    // Surface (but don't block on) the verify checkbox when the pasted blob
+    // includes the `verify: <six-words>` prefix the sharing flow emits (see
+    // share_text format at login.rs:1038). Permanently-unverified contacts
+    // silently break the verified-only acceptance flow (settings.rs:1434),
+    // so the import modal calls it out; recovery still happens via the
+    // clickable badge in ContactsSection (#228).
     let has_verify_phrase = paste_text
         .read()
         .lines()
         .next()
         .map(|l| l.trim_start().starts_with("verify: "))
         .unwrap_or(false);
-    let can_import = fingerprint_words.read().is_some()
-        && !local_alias.read().is_empty()
-        && (!has_verify_phrase || *verified.read());
+    let can_import = fingerprint_words.read().is_some() && !local_alias.read().is_empty();
 
     let cancel = move |_| {
         import_contact_form.write().0 = false;
@@ -2025,7 +2024,7 @@ pub(super) fn ImportContactForm() -> Element {
                                 if has_verify_phrase && !*verified.read() {
                                     span { class: "verify-sub",
                                         style: "color:#991b1b;",
-                                        "Required: this contact card includes a verify phrase. Tick once you've matched the six words out-of-band."
+                                        "The sender included a verify phrase. Importing unverified is allowed, but verified-only inboxes will reject your messages until you tick this once you've matched the six words out-of-band."
                                     }
                                 }
                             }

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -815,10 +815,22 @@ test.describe("Import contact verify-check (#52)", () => {
       row.locator('[data-testid="contact-verify-badge"]'),
     ).toContainText("⚠");
 
-    // Row exposes a Verify button only while the badge is amber.
-    await row.locator('[data-testid="fm-contact-verify"]').click();
-
+    // The ⚠ badge itself is the primary CTA — clicking it opens the
+    // verify modal (#228). The adjacent Verify button still works as a
+    // fallback (covered below).
+    await row.locator('[data-testid="contact-verify-badge"]').click();
     const verifyModal = page.locator('[data-testid="fm-verify-contact-modal"]');
+    await expect(verifyModal).toBeVisible({ timeout: 5_000 });
+    // Close it so the rest of the test exercises the explicit Verify button.
+    await page.keyboard.press("Escape").catch(() => {});
+    await verifyModal
+      .locator(".modal-x")
+      .click()
+      .catch(() => {});
+    await expect(verifyModal).toBeHidden({ timeout: 5_000 });
+
+    // Row also exposes an explicit Verify button while the badge is amber.
+    await row.locator('[data-testid="fm-contact-verify"]').click();
     await expect(verifyModal).toBeVisible({ timeout: 5_000 });
 
     // Submit is disabled until the same six-word checkbox is ticked.


### PR DESCRIPTION
## Summary

- **Import-contact form** disables the Import button when the pasted blob carries the `verify: <six-words>` line (the standard share format from `share_text`) and the user hasn't ticked the verify checkbox. Adds a red explainer under the checkbox.
- **ContactsSection** \"⚠ unverified\" badge is now a button that opens `VerifyContactModal` — the affordance was passive before, and the Verify button next to it was easy to miss.

**Out of scope** (follow-up): compose-page \"unverified\" badge and inbox-detail verification badge. `VerifyContactPending` is currently provided in the login-pane context only; making the modal reachable from the app pane needs cross-context signal plumbing.

Fixes #228 (badge + import gating); follow-up issue to be filed for the remaining surfaces.

## Test plan

- [x] `cargo check -p freenet-email-ui` (default + `--no-default-features --features example-data,no-sync`)
- [x] `cargo test -p freenet-email-ui`
- [ ] Manual: paste a `verify: …\\ncontact://…` blob → Import disabled until checkbox ticked
- [ ] Manual: click \"⚠ unverified\" badge in Contacts → VerifyContactModal opens