### PR TITLE
ci(check-drift): run webapp.parameters tripwire before rebuild step (#241)

### DIFF
--- a/.github/workflows/check-contract-wasm.yml
+++ b/.github/workflows/check-contract-wasm.yml
@@ -79,6 +79,33 @@ jobs:
         if: steps.cache-bins.outputs.cache-hit != 'true'
         run: cargo install --force fdev
 
+      # Issue #214 F1 tripwire — must run BEFORE the rebuild step below,
+      # which overwrites published-contract/webapp.parameters with a
+      # file signed by the committed test key. The committed-on-main
+      # parameters MUST be the production verifying key.
+      #
+      # The web-container contract id rotates per release (intentional,
+      # see #198), but the signing key must still be the production key
+      # — never the committed test key from
+      # test-contract/web-container-keys.toml. See issue #241 for the
+      # ordering bug this fixes.
+      - name: Verify webapp.parameters matches production pubkey
+        run: |
+          EXPECTED="31dd371fedc842994c6e571a0868e5eece1367a7d8cc16c498a57c985526ae46"
+          ACTUAL=$(xxd -p -c 64 published-contract/webapp.parameters | tr -d '\n')
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "::error::webapp.parameters does not match the production verifying key."
+              echo "  expected: $EXPECTED"
+              echo "  actual:   $ACTUAL"
+              echo ""
+              echo "If this commit was meant to refresh the TEST snapshot"
+              echo "(\`cargo make update-published-contract\`), do not push"
+              echo "the test snapshot to main — only the production snapshot"
+              echo "(\`update-published-contract-prod\`) is committed."
+              exit 1
+          fi
+          echo "✅ webapp.parameters matches the committed production pubkey."
+
       - name: Rebuild published contract from source
         run: cargo make update-published-contract
 
@@ -170,23 +197,3 @@ jobs:
           fi
           echo "✅ facade.parameters matches the committed production pubkey."
 
-      # Same tripwire for webapp.parameters. The web-container id
-      # rotates per release (intentional, see #198), but the signing
-      # key must still be the production key — never the committed
-      # test key from test-contract/web-container-keys.toml.
-      - name: Verify webapp.parameters matches production pubkey
-        run: |
-          EXPECTED="31dd371fedc842994c6e571a0868e5eece1367a7d8cc16c498a57c985526ae46"
-          ACTUAL=$(xxd -p -c 64 published-contract/webapp.parameters | tr -d '\n')
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-              echo "::error::webapp.parameters does not match the production verifying key."
-              echo "  expected: $EXPECTED"
-              echo "  actual:   $ACTUAL"
-              echo ""
-              echo "If this commit was meant to refresh the TEST snapshot"
-              echo "(\`cargo make update-published-contract\`), do not push"
-              echo "the test snapshot to main — only the production snapshot"
-              echo "(\`update-published-contract-prod\`) is committed."
-              exit 1
-          fi
-          echo "✅ webapp.parameters matches the committed production pubkey."


### PR DESCRIPTION
## Summary

- Move the `Verify webapp.parameters matches production pubkey` step in `.github/workflows/check-contract-wasm.yml` to run BEFORE `cargo make update-published-contract`, so it reads the actual committed file instead of the test-key-signed copy that the rebuild writes on top of it.
- Fixes #241 — the tripwire (#214 F1, added in #227) has been failing on every PR since merge because of this ordering bug. Reproduced on #235, #236, #237, #238, #239.

## Why this fix and not the alternatives

- Option 1 from the issue (move the check). Lowest-friction, keeps both the byte-equality drift step and the production-key tripwire intact.
- Option 2 (use `update-published-contract-prod`) requires the production private key in CI, which it should never have.
- Option 3 (stash + restore) adds shell noise to the workflow for no functional benefit.

`update-published-contract` only rewrites `web_container_contract.wasm`, `webapp.parameters`, and `contract-id.txt`. The facade tripwire (`facade.parameters`) is unaffected by the rebuild and stays in its original location.

## Test plan

- [ ] check-drift job goes green on this PR (proves the tripwire passes against the committed production key when run pre-rebuild).
- [ ] If someone pushes a test-key-signed `webapp.parameters` to a branch, the tripwire still fires (manually verified locally by `xxd -p -c 64 published-contract/webapp.parameters` returning the committed `31dd37…` production hex).