### PR TITLE
fix(inbox): preserve sender_vk + signature_valid across kept_for path (#240)

### DIFF
--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -157,6 +157,18 @@ pub struct KeptMessage {
     /// `None` for entries written before this field existed.
     #[serde(default)]
     pub sent_at: Option<i64>,
+    /// Sender's ML-DSA-65 verifying key bytes (FIPS 204 encoded), copied
+    /// from the live `Message.sender_vk` at MarkRead. Empty for legacy
+    /// pre-#240 entries — those still demote to `Unverified` on read
+    /// until the next MarkRead re-stamps the row.
+    #[serde(default)]
+    pub sender_vk: Vec<u8>,
+    /// Crypto verification result captured at MarkRead. Combined with the
+    /// address-book lookup at render time so a verified-known sender
+    /// keeps their ✓ badge after the live contract row is evicted (#240).
+    /// `false` for legacy pre-#240 entries.
+    #[serde(default)]
+    pub signature_valid: bool,
 }
 
 /// Saved permission decision for a specific recipient.
@@ -863,6 +875,8 @@ mod boundary_tests {
                 content: "yo".into(),
                 kept_at: 42,
                 sent_at: None,
+                sender_vk: Vec::new(),
+                signature_valid: false,
             },
         );
         let bytes = serde_json::to_vec(&state).unwrap();
@@ -894,11 +908,47 @@ mod boundary_tests {
             content: "yo".into(),
             kept_at: 100,
             sent_at: Some(50),
+            sender_vk: Vec::new(),
+            signature_valid: false,
         };
         let bytes = serde_json::to_vec(&k).unwrap();
         let back: KeptMessage = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(back.sent_at, Some(50));
         assert_eq!(back.kept_at, 100);
+    }
+
+    /// Regression for #240: pre-#240 `KeptMessage` payloads (no
+    /// `sender_vk` / `signature_valid` fields) must still deserialise
+    /// with the new fields defaulted. Legacy entries demote to
+    /// `Unverified` at render time — wrong, but matches the pre-#240
+    /// behaviour and self-heals on next MarkRead.
+    #[test]
+    fn kept_message_missing_verification_fields_defaults_empty() {
+        let json = br#"{"from":"bob","title":"hi","content":"yo","kept_at":42,"sent_at":7}"#;
+        let k: KeptMessage = serde_json::from_slice(json).expect("should deserialise");
+        assert!(k.sender_vk.is_empty());
+        assert!(!k.signature_valid);
+        assert_eq!(k.sent_at, Some(7));
+    }
+
+    /// New writes carry verification metadata; both fields must
+    /// round-trip across the delegate stash so a verified-sender row
+    /// keeps its ✓ badge after the live contract row is evicted (#240).
+    #[test]
+    fn kept_message_with_verification_round_trips() {
+        let k = KeptMessage {
+            from: "bob".into(),
+            title: "hi".into(),
+            content: "yo".into(),
+            kept_at: 100,
+            sent_at: Some(50),
+            sender_vk: vec![1, 2, 3, 4, 5],
+            signature_valid: true,
+        };
+        let bytes = serde_json::to_vec(&k).unwrap();
+        let back: KeptMessage = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(back.sender_vk, vec![1, 2, 3, 4, 5]);
+        assert!(back.signature_valid);
     }
 
     #[test]

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -863,6 +863,30 @@ fn kept_render_time(kept: &mail_local_state::KeptMessage) -> chrono::DateTime<ch
         .unwrap_or_else(chrono::Utc::now)
 }
 
+/// Reconstruct a `Message` from a kept-locally snapshot when the live
+/// contract row has been evicted. Propagates verification metadata
+/// (`sender_vk`, `signature_valid`) captured at MarkRead so verified
+/// senders keep their ✓ badge after eviction (#240). Legacy pre-#240
+/// snapshots default both to empty/false and demote to `Unverified` at
+/// render time — self-heals on the next MarkRead.
+fn kept_to_message(
+    mid: mail_local_state::MessageId,
+    kept: mail_local_state::KeptMessage,
+) -> Message {
+    let time = kept_render_time(&kept);
+    Message {
+        id: mid,
+        from: kept.from.into(),
+        title: kept.title.into(),
+        content: kept.content.into(),
+        read: true,
+        time,
+        sender_vk: kept.sender_vk,
+        signature_valid: kept.signature_valid,
+        assignment_hash: [0u8; 32],
+    }
+}
+
 impl From<MessageModel> for Message {
     fn from(value: MessageModel) -> Self {
         Message {
@@ -1466,18 +1490,7 @@ fn MessageList() -> Element {
                 if crate::local_state::is_archived(&alias, mid) {
                     continue;
                 }
-                let time = kept_render_time(&kept);
-                emails.push(Message {
-                    id: mid,
-                    from: kept.from.into(),
-                    title: kept.title.into(),
-                    content: kept.content.into(),
-                    read: true,
-                    time,
-                    sender_vk: Vec::new(),
-                    signature_valid: false,
-                    assignment_hash: [0u8; 32],
-                });
+                emails.push(kept_to_message(mid, kept));
             }
             crate::log::debug!("active id: {:?}; emails number: {}", id.alias, emails.len());
         }
@@ -2147,6 +2160,8 @@ fn OpenMessage(msg: Message) -> Element {
                 content: msg.content.to_string(),
                 kept_at: chrono::Utc::now().timestamp_millis(),
                 sent_at: Some(msg.time.timestamp_millis()),
+                sender_vk: msg.sender_vk.clone(),
+                signature_valid: msg.signature_valid,
             };
             crate::local_state::local_mark_read(&alias, msg.id, kept.clone());
             #[cfg(feature = "use-node")]
@@ -3122,6 +3137,7 @@ mod kept_render_time_tests {
             content: "yo".into(),
             kept_at: 10_000,      // "click time"
             sent_at: Some(1_000), // "send time"
+            ..Default::default()
         };
         let t = kept_render_time(&kept);
         assert_eq!(t.timestamp_millis(), 1_000, "must use sender's send time");
@@ -3137,6 +3153,7 @@ mod kept_render_time_tests {
             content: "yo".into(),
             kept_at: 5_000,
             sent_at: None,
+            ..Default::default()
         };
         let t = kept_render_time(&kept);
         assert_eq!(t.timestamp_millis(), 5_000);
@@ -3154,8 +3171,59 @@ mod kept_render_time_tests {
             content: "x".into(),
             kept_at: i64::MAX,
             sent_at: Some(i64::MAX),
+            ..Default::default()
         };
         let _ = kept_render_time(&kept);
+    }
+}
+
+#[cfg(test)]
+mod kept_to_message_tests {
+    use super::kept_to_message;
+    use crate::inbox::VerificationState;
+    use mail_local_state::KeptMessage;
+
+    /// Regression for #240: a verified-sender row that gets evicted
+    /// from the live contract must keep its `sender_vk` +
+    /// `signature_valid` so the badge stays ✓ instead of demoting to ⚠.
+    #[test]
+    fn propagates_verification_metadata() {
+        let kept = KeptMessage {
+            from: "bob".into(),
+            title: "hi".into(),
+            content: "yo".into(),
+            kept_at: 100,
+            sent_at: Some(50),
+            sender_vk: vec![9, 8, 7, 6, 5],
+            signature_valid: true,
+        };
+        let msg = kept_to_message(42, kept);
+        assert_eq!(&*msg.sender_vk, &[9, 8, 7, 6, 5]);
+        assert!(msg.signature_valid);
+        assert!(msg.read);
+    }
+
+    /// Legacy pre-#240 entries lack the verification fields entirely;
+    /// the helper must default `signature_valid` to false so the row
+    /// renders as `Unverified` (matches pre-#240 behaviour). It self-
+    /// heals on next MarkRead.
+    #[test]
+    fn legacy_entries_demote_to_unverified() {
+        let kept = KeptMessage {
+            from: "bob".into(),
+            title: "hi".into(),
+            content: "yo".into(),
+            kept_at: 100,
+            sent_at: Some(50),
+            ..Default::default()
+        };
+        let msg = kept_to_message(42, kept);
+        assert!(msg.sender_vk.is_empty());
+        assert!(!msg.signature_valid);
+        assert!(matches!(
+            msg.verification_state(),
+            VerificationState::Unverified
+        ));
     }
 }
 

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -603,6 +603,8 @@ mod tests {
             content: "body".into(),
             kept_at: 0,
             sent_at: None,
+            sender_vk: Vec::new(),
+            signature_valid: false,
         }
     }
 
@@ -818,6 +820,8 @@ mod tests {
                         content: "body".into(),
                         kept_at: SHARED_KEPT_AT,
                         sent_at: None,
+                        sender_vk: Vec::new(),
+                        signature_valid: false,
                     },
                 );
             }


### PR DESCRIPTION
## Summary

- Extend `KeptMessage` with `sender_vk: Vec<u8>` + `signature_valid: bool` (both `#[serde(default)]` for pre-#240 compat) so a verified-sender row keeps its ✓ badge after eviction from the live contract.
- Populate them at the MarkRead write site (`ui/src/app.rs`) from the live `Message.sender_vk` / `signature_valid`.
- Extract `kept_to_message(mid, kept)` so the kept-path reader is unit-testable. Reader propagates the fields instead of defaulting to `Vec::new()` / `false`.
- Closes #240.

## Why this matters

Per #234: live inbox rows fall into the `kept_for` path on every MarkRead (by design — the contract removes the row, the UI keeps a local copy). Pre-this-fix, every read demoted a verified sender to ⚠ unverified the moment they were clicked. The user's `verified` contact state was being silently overwritten by the kept-path defaults.

This mirrors the shape of #229 (which fixed the same data-loss class for `sent_at`). No protocol or schema bump beyond what #229 already did.

## Test plan

- [x] `cargo test -p mail-local-state` — 28 passed, including new `kept_message_missing_verification_fields_defaults_empty` + `kept_message_with_verification_round_trips`.
- [x] `cargo test -p freenet-email-ui --features example-data,no-sync --no-default-features --lib` — 116 passed, including new `kept_to_message_tests::{propagates_verification_metadata, legacy_entries_demote_to_unverified}`.
- [x] `cargo clippy` — clean.
- [x] Regression repro: revert reader's two field assignments to the pre-#240 defaults — `propagates_verification_metadata` fails with `left: []  right: [9, 8, 7, 6, 5]`.