### PR TITLE
docs(readme): point at stable facade URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,95 @@
-# Mail
+# Freenet Mail
 
 A decentralized email client that runs on [Freenet](https://freenet.org) —
 no servers, no accounts, end-to-end encrypted, and rate-limited by
 Anti-Flood Tokens instead of a central authority.
 
-Messages are stored in per-user inbox contracts on the Freenet network,
-encrypted with post-quantum ML-KEM-768 (NIST FIPS 203) and authenticated
-with ML-DSA-65 (NIST FIPS 204). The UI is a Dioxus web app served from
-a signed web-container contract under a deterministic, reproducible
-contract id.
+Messages live in per-user inbox contracts on the Freenet network,
+encrypted with post-quantum ML-KEM-768 (NIST FIPS 203) and
+authenticated with ML-DSA-65 (NIST FIPS 204). The UI is a Dioxus
+web app served from a signed web-container contract, fronted by a
+stable **facade contract** so the bookmarkable URL never changes
+between releases.
 
-> **Status**: pre-alpha. The protocol and contract ids will change.
-> Don't use this for anything you'd mind losing.
+> **Status**: pre-alpha. The protocol may still change. Don't store
+> anything you'd mind losing.
 
 ## Try it
 
 1. **Install Freenet.** Follow the
    [Freenet quickstart](https://freenet.org/quickstart/) to get a
-   network-connected node running.
+   network-connected node running on `127.0.0.1:7509`.
 
-2. **Open the webapp** in a browser at the published contract id:
+2. **Open the app at the stable URL:**
 
    ```
-   http://127.0.0.1:7509/v1/contract/web/<contract-id>/
+   http://127.0.0.1:7509/v1/contract/web/122f6AR7PyF8d8mhczuNQM4xrLtBf5t8g2iB7PEVT7KC/
    ```
 
-   The latest committed contract id lives at
-   [`published-contract/contract-id.txt`](published-contract/contract-id.txt)
-   in this repo. The `7509` port and `/v1/contract/web/` path are the
-   defaults for the Freenet HTTP/WebSocket gateway in current builds —
-   adjust for your setup.
+   That contract id is the **facade** — a thin pointer contract that
+   serves a tiny HTML+JS loader. The loader forwards the browser to
+   whichever web-container release is current. The facade id is
+   byte-stable across every release (see [#198](https://github.com/iduartgomez/freenet-email/issues/198),
+   [#200](https://github.com/iduartgomez/freenet-email/issues/200),
+   [#206](https://github.com/iduartgomez/freenet-email/issues/206)),
+   so once you bookmark it, future releases land automatically without
+   the URL changing.
 
-3. **Create an identity** in the app. Your private keys are held by the
-   identity delegate inside the Freenet node sandbox, never in browser
-   storage.
+   The current canonical id is also committed at
+   [`published-contract/facade-id.txt`](published-contract/facade-id.txt).
+
+3. **Create an identity** in the app. Your private keys live inside
+   the identity delegate, in the Freenet node sandbox — never in
+   browser storage.
 
 4. **Send a message.** The first send burns one Anti-Flood Token,
    minted automatically by your local node.
 
 ## How it works
 
-Three contracts and a delegate make up the full system:
+Three on-chain contracts and one delegate make up the system:
 
-- **Web container contract** — hosts the compiled Dioxus UI. Signed
-  with an ed25519 key committed to
-  [`test-contract/`](test-contract/) for sandbox builds, and with an
-  offline-generated production key for real releases.
-- **Inbox contract** — one per user. Stores ML-KEM-encapsulated,
-  ChaCha20-Poly1305-encrypted messages, with ML-DSA-65 signatures
-  on every state delta for ownership verification.
-- **Anti-Flood Token contracts** — mint/burn tokens that gate each
-  message send, preventing spam without a central authority.
-- **Identity delegate** — holds the user's private keys inside the
-  Freenet delegate sandbox, never exposed to the webapp.
+- **Facade contract** ([`contracts/facade/`](contracts/facade/)) —
+  stable bookmarkable entry point. Its state is a signed
+  `FacadePointer { current_app_id, prev_app_ids }`; the served
+  payload is a static HTML+JS shell that `postMessage`s the gateway
+  shell to navigate to the current web-container. Per release the
+  facade wasm is unchanged — only the pointer state is updated, via
+  `fdev execute update --as-state` signed with the production key.
+- **Web container contract** ([`contracts/web-container/`](contracts/web-container/)) —
+  hosts the compiled Dioxus UI. Its contract id is
+  `hash(wasm, ed25519_pubkey)` and rotates whenever the wasm bytes
+  change. The facade pointer absorbs the rotation so users never see
+  it.
+- **Inbox contract** ([`contracts/inbox/`](contracts/inbox/)) —
+  one per user. Stores ML-KEM-encapsulated, ChaCha20-Poly1305
+  encrypted messages, with ML-DSA-65 signatures on every state delta
+  for ownership verification. Lockfile-isolated
+  ([#199](https://github.com/iduartgomez/freenet-email/issues/199))
+  so workspace dep bumps can't rotate the contract id and orphan
+  stored mail; a per-identity migration path
+  ([#213](https://github.com/iduartgomez/freenet-email/issues/213),
+  [#223](https://github.com/iduartgomez/freenet-email/issues/223))
+  re-signs and re-PUTs when deliberate rotation is needed.
+- **Anti-Flood Token contracts + delegate**
+  ([`modules/antiflood-tokens/`](modules/antiflood-tokens/)) —
+  mint/burn tokens that gate each message send. Prevents spam
+  without a central authority.
+- **Identity delegate**
+  ([`modules/identity-management/`](modules/identity-management/)) —
+  holds the user's private keys inside the Freenet delegate sandbox,
+  never exposed to the webapp.
+
+### Why two contracts in front of the UI?
+
+A Freenet contract id is `hash(wasm, parameters)`. Any change to the
+UI rebuilds the wasm and rotates the id. Without a stable pointer,
+every release would orphan every bookmark. The facade is a tiny
+wasm contract that's deliberately frozen — its lockfile is isolated
+from the workspace, its rustc version is pinned in
+`rust-toolchain.toml`, and CI byte-checks every PR against the
+committed `published-contract/facade.wasm`. Releases flip the
+pointer state inside the facade rather than re-deploying it.
 
 ## Contributing
 
@@ -60,7 +97,8 @@ See [`AGENTS.md`](AGENTS.md) for the developer guide: build setup,
 feature-flag matrix, publishing pipeline, Playwright tests, and the
 manual E2E checklist.
 
-See [`RELEASING.md`](RELEASING.md) for the release runbook.
+See [`RELEASING.md`](RELEASING.md) for the production release
+runbook, including facade pointer flips and recovery.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Replace rotating web-container URL with the stable facade id (`122f6AR7PyF8d8mhczuNQM4xrLtBf5t8g2iB7PEVT7KC`) in the Try-it section
- Add a short \"how it works\" rewrite covering facade vs web-container vs inbox vs AFT vs identity delegate
- Explain why two contracts front the UI (rotating id + stable pointer), with cross-refs to #198 / #199 / #200 / #206 / #213 / #223

## Test plan
- [x] Local render — markdown links resolve to in-repo paths
- [x] Facade id matches `published-contract/facade-id.txt`