### PR TITLE
chore(release): bump workspace to 0.1.12; guard release.sh against version drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-core"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "ed25519-dalek",
  "freenet-email-facade-types",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-email-ui"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "arc-swap",
  "base64",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "web-container-sign"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.12"
 edition = "2024"
 license = "LGPL-3.0-or-later"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,7 +85,29 @@ git status   # must be clean
 The release script refuses to run from any other branch or with
 uncommitted changes.
 
-### 4. GNU tar, fdev, dioxus-cli, cargo-make, gh
+### 4. Workspace version bumped to match the release tag
+
+`ui/src/lib.rs` bakes `env!("CARGO_PKG_VERSION")` into the wasm, and
+that string is what the sidebar shows. If `Cargo.toml`'s workspace
+`version` doesn't match the tag, the published webapp will display the
+old version forever (and the wasm bytes will be byte-equal to the
+previous release, so the release script reports "unchanged bytes" and
+nothing actually moves between tags — this is how v0.1.9 through
+v0.1.11 all shipped with `v0.1.8` baked in).
+
+Bump it BEFORE running `scripts/release.sh`:
+
+```bash
+# In Cargo.toml [workspace.package], set version = "<new>"
+cargo update --workspace      # refreshes Cargo.lock
+git commit -am "chore: bump workspace version to <new>"
+git push
+```
+
+`scripts/release.sh` now preflight-checks that the workspace version
+matches its argument and aborts otherwise.
+
+### 5. GNU tar, fdev, dioxus-cli, cargo-make, gh
 
 All preflight-checked by `scripts/release.sh`. On macOS:
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -88,6 +88,33 @@ if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
     die "tag $TAG already exists on origin. Either bump the version or delete it remotely."
 fi
 
+# Workspace Cargo.toml version must match the requested release version.
+# `ui/src/lib.rs` bakes `env!("CARGO_PKG_VERSION")` into the wasm; if the
+# workspace version drifts behind the tag the published webapp shows the
+# old version in its sidebar and CI byte-equality reports "unchanged
+# bytes" because nothing actually moved between releases (this is how
+# v0.1.9/v0.1.10/v0.1.11 all shipped with v0.1.8 baked in).
+CARGO_VERSION=$(awk '
+    /^\[workspace\.package\]/ { in_section = 1; next }
+    /^\[/                     { in_section = 0 }
+    in_section && /^version *= *"/ {
+        match($0, /"[^"]+"/)
+        print substr($0, RSTART + 1, RLENGTH - 2)
+        exit
+    }
+' Cargo.toml)
+if [ -z "$CARGO_VERSION" ]; then
+    die "could not parse [workspace.package] version from Cargo.toml"
+fi
+if [ "$CARGO_VERSION" != "$VERSION" ]; then
+    die "Cargo.toml workspace version ($CARGO_VERSION) does not match release version ($VERSION).
+Bump it first:
+  sed -i.bak 's/^version = \"$CARGO_VERSION\"/version = \"$VERSION\"/' Cargo.toml && rm Cargo.toml.bak
+  cargo update --workspace
+  git commit -am 'chore: bump workspace version to $VERSION'"
+fi
+echo "  ✓ Cargo.toml workspace version = $VERSION"
+
 # Production key
 KEY_FILE="${WEB_CONTAINER_KEY_FILE:-$HOME/.config/freenet-email/web-container-keys.toml}"
 if [ ! -f "$KEY_FILE" ]; then


### PR DESCRIPTION
## Summary

`ui/src/lib.rs` bakes `env!(\"CARGO_PKG_VERSION\")` into the wasm and that string is what the sidebar renders. `scripts/release.sh` previously took a tag argument but never checked the workspace `Cargo.toml` version, so **v0.1.9, v0.1.10, and v0.1.11 all shipped with `v0.1.8` baked in**: workspace deps were lockfile-isolated, the version literal never moved, the wasm bytes were byte-equal to v0.1.8 (release.sh even reported "unchanged bytes — bit-equal to last release" at v0.1.11), and the sidebar kept showing v0.1.8 in the deployed webapp.

## Changes

- Bump `[workspace.package]` version to `0.1.12` and refresh `Cargo.lock`.
- Add a preflight check in `scripts/release.sh` that parses `[workspace.package]` version from `Cargo.toml` and aborts unless it matches the release argument. Error message tells the operator how to bump.
- Document the bump step in `RELEASING.md` so future releases don't skip it.

## Test plan

- [x] `cargo check -p freenet-email-ui --features example-data,no-sync --no-default-features` — compiles as `v0.1.12`.
- [x] awk parser in `scripts/release.sh` correctly extracts the workspace version from `[workspace.package]`.
- [ ] Run `scripts/release.sh 0.1.12` after merge — should pass the new preflight and produce a webapp wasm whose sidebar shows `v0.1.12`.