### PR TITLE
fix(inbox): harden migration against multi-hop gaps and flaky GETs (#251)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,19 +422,42 @@ token ledgers stay accessible across releases. To deliberately rotate
 =x.y.z pin in the relevant Cargo.toml and pair the change with the
 per-identity migration story.
 
-**Inbox migration (#213/#223, shipped)**: on UI startup the
-`set_aliases` callback in `ui/src/api.rs` compares the embedded
-`INBOX_CODE_HASH` against the `inbox_wasm_hash` recorded on each
-identity in the identity-management delegate. On drift it dispatches
-a Get for the old inbox key (derived from the prior hash + identity
-vk), and the GetResponse arm decodes the old state, re-signs via
-`Inbox::new`, and PUTs it under the current inbox key. Toast surfaces
-the migration to the user. On first observation (`inbox_wasm_hash =
-None`) the UI stamps the current hash as a baseline so the next bump
-is detectable. The schema bump on the delegate is backwards-compatible
-(`#[serde(default)]` on `AliasInfo.inbox_wasm_hash`). AFT contract
-migration follows the same shape if and when AFT WASM rotates — not
-yet implemented; file a follow-up when needed.
+**Inbox migration (#213/#223, shipped; #251 hardening)**: on UI
+startup the `set_aliases` callback in `ui/src/api.rs` compares the
+embedded `INBOX_CODE_HASH` against the `inbox_wasm_hash` recorded on
+each identity in the identity-management delegate. On drift it
+dispatches GETs for the old inbox keys (chained over every plausible
+historical hash — see below), and the GetResponse arm decodes the
+old state, re-signs via `Inbox::new`, and PUTs it under the current
+inbox key. Toast surfaces the migration to the user. On first
+observation (`inbox_wasm_hash = None`) the UI stamps the current
+hash as a baseline so the next bump is detectable. The schema bump
+on the delegate is backwards-compatible (`#[serde(default)]` on
+`AliasInfo.inbox_wasm_hash`). AFT contract migration follows the
+same shape if and when AFT WASM rotates — not yet implemented; file
+a follow-up when needed.
+
+**Chained migration (#251 improvement 2)**: `LEGACY_INBOX_CODE_HASHES`
+in `ui/src/inbox.rs` is an append-only oldest→newest list of every
+prior `INBOX_CODE_HASH`. `build_migration_candidates` walks from the
+recorded hash forward and `migrate_inbox` dispatches a GET per
+candidate; the first GetResponse to resolve wins, suppressed by
+`MIGRATED_IDENTITIES` (keyed by ML-DSA verifying-key bytes, not the
+mutable alias). Append the previous hash to the slice as part of any
+deliberate inbox-contract bump so users skipping releases still
+recover. The current `INBOX_CODE_HASH` must never appear in the slice
+— enforced by the `current_hash_not_in_legacy` test.
+
+**Persistent migration retry (#251 improvement 5)**:
+`AliasInfo.pending_migration_from: Option<String>` is stamped on the
+identity-management delegate via `IdentityMsg::SetPendingMigrationFrom`
+BEFORE dispatching the migration GETs, and cleared (set to `None`)
+only when the PUT under the current inbox key succeeds. On startup
+`select_migrate_from` (in `ui/src/inbox.rs`) prefers a non-None
+pending marker over the recorded hash, so a session whose GET never
+resolved (node offline, contract expired) re-attempts on the next
+session. Stale markers (`prior == current` with a leftover pending
+value) are cleared in the no-drift branch.
 
 **Facade lockfile isolation (issue #198)**: the facade contract and its
 shared types crate live OUTSIDE the freenet-email workspace:

--- a/modules/identity-management/src/lib.rs
+++ b/modules/identity-management/src/lib.rs
@@ -98,6 +98,16 @@ pub struct AliasInfo {
     /// with old delegate states that lack the field via `#[serde(default)]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inbox_wasm_hash: Option<String>,
+    /// Hash this identity's inbox is being migrated FROM, if a migration
+    /// is currently in flight (#251 improvement 5). Set by the UI before
+    /// dispatching the GET against the old contract key; cleared after
+    /// the PUT under the new key succeeds. Persisting the in-flight
+    /// state lets the UI re-attempt the migration on the next session
+    /// if the GET never resolved (node offline, contract expired).
+    /// Backwards-compatible with older delegate states via
+    /// `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_migration_from: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug)]
@@ -208,6 +218,7 @@ impl DelegateInterface for IdentityManagement {
                                 extra,
                                 kind: kind.unwrap_or_default(),
                                 inbox_wasm_hash: None,
+                                pending_migration_from: None,
                             },
                         );
                         let updated = serde_json::to_vec(&manager)
@@ -243,6 +254,34 @@ impl DelegateInterface for IdentityManagement {
                             let updated = serde_json::to_vec(&manager)
                                 .map_err(|e| DelegateError::Deser(format!("{e}")))?;
                             ctx.set_secret(&secret_key, &updated);
+                        }
+                        Ok(vec![])
+                    }
+                    IdentityMsg::SetPendingMigrationFrom { alias, prior_hash } => {
+                        // Per-field mutation for #251 improvement 5.
+                        // `Some(hash)` marks a migration in flight from
+                        // that hash; `None` clears the marker after a
+                        // successful PUT. No-op on missing alias for
+                        // the same reason as UpdateInboxWasmHash, but
+                        // logged because silent no-ops on persistent-
+                        // state messages have been a debugging cost
+                        // before.
+                        let mut manager = match ctx.get_secret(&secret_key) {
+                            Some(value) => IdentityManagement::try_from(value.as_slice())?,
+                            None => IdentityManagement::default(),
+                        };
+                        if let Some(info) = manager.identities.get_mut(alias.as_str()) {
+                            info.pending_migration_from = prior_hash;
+                            let updated = serde_json::to_vec(&manager)
+                                .map_err(|e| DelegateError::Deser(format!("{e}")))?;
+                            ctx.set_secret(&secret_key, &updated);
+                        } else {
+                            #[cfg(feature = "contract")]
+                            {
+                                freenet_stdlib::log::info(&format!(
+                                    "SetPendingMigrationFrom: alias `{alias}` missing; ignoring"
+                                ));
+                            }
                         }
                         Ok(vec![])
                     }
@@ -291,6 +330,17 @@ pub enum IdentityMsg {
     UpdateInboxWasmHash {
         alias: String,
         wasm_hash: String,
+    },
+    /// Set or clear the `pending_migration_from` marker on an identity
+    /// (#251 improvement 5). The UI stamps `Some(prior_hash)` before
+    /// dispatching the migration GET and `None` after the PUT under
+    /// the current key succeeds. On startup with a non-None marker
+    /// and `inbox_wasm_hash` still != `INBOX_CODE_HASH`, the UI
+    /// re-attempts the migration. Backwards-compatible: old senders
+    /// don't emit this variant.
+    SetPendingMigrationFrom {
+        alias: String,
+        prior_hash: Option<String>,
     },
     /// Request the current set of identities. Returns the serialized
     /// `IdentityManagement` as an `ApplicationMessage` response.
@@ -416,6 +466,36 @@ mod boundary_tests {
         }
     }
 
+    /// AliasInfo without `pending_migration_from` must deserialise to
+    /// `None` (#251 backwards-compat).
+    #[test]
+    fn alias_info_missing_pending_migration_defaults_to_none() {
+        let json = br#"{"key":[1],"extra":null,"kind":"identity","inbox_wasm_hash":"abc"}"#;
+        let info: AliasInfo = serde_json::from_slice(json).expect("should deserialise");
+        assert_eq!(info.pending_migration_from, None);
+    }
+
+    /// `IdentityMsg::SetPendingMigrationFrom` round-trips with both
+    /// `Some` and `None` payloads (#251).
+    #[test]
+    fn set_pending_migration_round_trips() {
+        for prior in [Some("oldhash".to_string()), None] {
+            let msg = IdentityMsg::SetPendingMigrationFrom {
+                alias: "alice".into(),
+                prior_hash: prior.clone(),
+            };
+            let bytes = serde_json::to_vec(&msg).expect("serialise");
+            let decoded: IdentityMsg = serde_json::from_slice(&bytes).expect("deserialise");
+            match decoded {
+                IdentityMsg::SetPendingMigrationFrom { alias, prior_hash } => {
+                    assert_eq!(alias, "alice");
+                    assert_eq!(prior_hash, prior);
+                }
+                other => panic!("expected SetPendingMigrationFrom, got {other:?}"),
+            }
+        }
+    }
+
     /// `IdentityMsg::CreateIdentity` without a `kind` field must deserialise
     /// successfully (backwards-compat for senders that pre-date the field).
     #[test]
@@ -440,6 +520,7 @@ mod boundary_tests {
                 extra: None,
                 kind: EntryKind::Identity,
                 inbox_wasm_hash: None,
+                pending_migration_from: None,
             },
         );
         mgr.identities.insert(
@@ -449,6 +530,7 @@ mod boundary_tests {
                 extra: Some("friend".into()),
                 kind: EntryKind::Contact,
                 inbox_wasm_hash: None,
+                pending_migration_from: None,
             },
         );
         let json = serde_json::to_vec(&mgr).unwrap();

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -369,6 +369,18 @@ mod inbox_management {
         /// after a timeout — currently best-effort).
         pub(super) static PENDING_MIGRATION: RefCell<HashMap<ContractKey, crate::app::Identity>> =
             RefCell::new(HashMap::new());
+
+        /// #251 improvement 2: tracks identities whose migration is
+        /// either already in-flight or completed this session, keyed by
+        /// ML-DSA verifying-key bytes (NOT alias — aliases mutate via
+        /// rename). Chained migration dispatches GETs against several
+        /// historical inbox keys for the same identity; the entry is
+        /// inserted BEFORE the PUT await so a second GetResponse
+        /// arriving during the await is suppressed (closes TOCTOU). On
+        /// PUT failure the entry is removed to allow retry on the next
+        /// candidate response.
+        pub(super) static MIGRATED_IDENTITIES: RefCell<std::collections::HashSet<Vec<u8>>> =
+            RefCell::new(std::collections::HashSet::new());
     }
 
     /// PUT the migrated inbox state under the identity's CURRENT inbox
@@ -425,26 +437,43 @@ mod inbox_management {
     ) -> Result<(), DynError> {
         use ml_dsa::signature::Keypair;
         let vk = Keypair::verifying_key(identity.ml_dsa_signing_key.as_ref());
-        let params: Parameters = InboxParams {
-            pub_key: crate::inbox::inbox_params_pub_key_bytes(&vk),
+        let pub_key = crate::inbox::inbox_params_pub_key_bytes(&vk);
+
+        // #251 improvement 2: chained migration. Build the candidate
+        // chain via `build_migration_candidates` — always starts with
+        // `prior_hash` itself, then every legacy entry that follows
+        // it (or every legacy entry, if `prior_hash` is not in the
+        // list — see the helper for the rationale). GET each in turn;
+        // the GetResponse arm in `node_comms` picks the first one
+        // that resolves and re-PUTs under the CURRENT key, suppressing
+        // duplicate responses via `MIGRATED_IDENTITIES`.
+        let candidates = crate::inbox::build_migration_candidates(
+            prior_hash,
+            crate::inbox::LEGACY_INBOX_CODE_HASHES,
+        );
+
+        for candidate in candidates {
+            let params: Parameters = InboxParams {
+                pub_key: pub_key.clone(),
+            }
+            .try_into()?;
+            let old_key = ContractKey::from_params(&candidate, params)
+                .map_err(|e| format!("derive old inbox key: {e}"))?;
+            PENDING_MIGRATION.with(|m| {
+                m.borrow_mut().insert(old_key, identity.clone());
+            });
+            let request = ContractRequest::Get {
+                key: old_key.into(),
+                return_contract_code: false,
+                subscribe: false,
+                blocking_subscribe: false,
+            };
+            client.send(request.into()).await?;
+            crate::log::info(format!(
+                "inbox migration: GET dispatched for old key {old_key} (identity=`{}`, hash={candidate}) (#213, #251)",
+                identity.alias()
+            ));
         }
-        .try_into()?;
-        let old_key = ContractKey::from_params(prior_hash, params)
-            .map_err(|e| format!("derive old inbox key: {e}"))?;
-        PENDING_MIGRATION.with(|m| {
-            m.borrow_mut().insert(old_key, identity.clone());
-        });
-        let request = ContractRequest::Get {
-            key: old_key.into(),
-            return_contract_code: false,
-            subscribe: false,
-            blocking_subscribe: false,
-        };
-        client.send(request.into()).await?;
-        crate::log::info(format!(
-            "inbox migration: GET dispatched for old key {old_key} (identity=`{}`) (#213)",
-            identity.alias()
-        ));
         Ok(())
     }
 
@@ -872,6 +901,34 @@ mod identity_management {
         let msg = IdentityMsg::UpdateInboxWasmHash {
             alias: alias.to_string(),
             wasm_hash: crate::inbox::INBOX_CODE_HASH.to_string(),
+        };
+        send_identity_msg(client, &msg).await
+    }
+
+    /// Mark an in-flight migration on the identity-management delegate
+    /// so the next session can re-attempt the GET if this one never
+    /// resolves (#251 improvement 5).
+    pub(super) async fn set_pending_migration_api_call(
+        client: &mut WebApiRequestClient,
+        alias: &str,
+        prior_hash: &str,
+    ) -> Result<(), DynError> {
+        let msg = IdentityMsg::SetPendingMigrationFrom {
+            alias: alias.to_string(),
+            prior_hash: Some(prior_hash.to_string()),
+        };
+        send_identity_msg(client, &msg).await
+    }
+
+    /// Clear the in-flight migration marker after a successful PUT
+    /// under the current inbox key (#251 improvement 5).
+    pub(super) async fn clear_pending_migration_api_call(
+        client: &mut WebApiRequestClient,
+        alias: &str,
+    ) -> Result<(), DynError> {
+        let msg = IdentityMsg::SetPendingMigrationFrom {
+            alias: alias.to_string(),
+            prior_hash: None,
         };
         send_identity_msg(client, &msg).await
     }
@@ -1864,40 +1921,104 @@ pub(crate) async fn node_comms(
                                     // unchanged, so we can reconstruct the
                                     // serialized state by calling Inbox::new
                                     // with the same settings + messages.
-                                    match serde_json::from_slice::<StoredInbox>(state.as_ref()) {
-                                        Ok(parsed) => {
-                                            if let Err(e) = inbox_management::put_migrated_inbox(
-                                                &mut client,
-                                                &identity,
-                                                parsed,
-                                            )
-                                            .await
-                                            {
+                                    //
+                                    // #251 improvement 2: chained migration may
+                                    // dispatch GETs against several historical
+                                    // keys. The first one to land wins; later
+                                    // responses for the same identity are
+                                    // ignored via MIGRATED_IDENTITIES (keyed
+                                    // by ML-DSA verifying-key bytes — alias
+                                    // mutates via rename). The insert happens
+                                    // BEFORE awaiting the PUT to close the
+                                    // TOCTOU window between guard check and
+                                    // PUT completion. On PUT failure we
+                                    // remove the entry so the next candidate
+                                    // response can retry.
+                                    let alias_str = identity.alias().to_string();
+                                    let vk_key = {
+                                        use ml_dsa::signature::Keypair;
+                                        let vk = Keypair::verifying_key(
+                                            identity.ml_dsa_signing_key.as_ref(),
+                                        );
+                                        crate::inbox::inbox_params_pub_key_bytes(&vk)
+                                    };
+                                    let claimed = inbox_management::MIGRATED_IDENTITIES.with(|s| {
+                                        let mut set = s.borrow_mut();
+                                        if set.contains(&vk_key) {
+                                            false
+                                        } else {
+                                            set.insert(vk_key.clone());
+                                            true
+                                        }
+                                    });
+                                    if !claimed {
+                                        crate::log::debug!(
+                                            "inbox migration: skipping duplicate GetResponse for {key} (identity=`{alias_str}`) — already claimed this session"
+                                        );
+                                    } else {
+                                        match serde_json::from_slice::<StoredInbox>(state.as_ref())
+                                        {
+                                            Ok(parsed) => {
+                                                if let Err(e) =
+                                                    inbox_management::put_migrated_inbox(
+                                                        &mut client,
+                                                        &identity,
+                                                        parsed,
+                                                    )
+                                                    .await
+                                                {
+                                                    crate::log::error(
+                                                        format!(
+                                                            "inbox migration: PUT failed for `{alias_str}`: {e} (#213)"
+                                                        ),
+                                                        None,
+                                                    );
+                                                    inbox_management::MIGRATED_IDENTITIES.with(
+                                                        |s| {
+                                                            s.borrow_mut().remove(&vk_key);
+                                                        },
+                                                    );
+                                                } else {
+                                                    // #251 improvement 5:
+                                                    // clear the persistent
+                                                    // pending-migration marker
+                                                    // now that the PUT
+                                                    // succeeded. Until this
+                                                    // clear lands, subsequent
+                                                    // session restarts would
+                                                    // re-attempt the GET.
+                                                    if let Err(e) = identity_management::clear_pending_migration_api_call(
+                                                        &mut client,
+                                                        &alias_str,
+                                                    )
+                                                    .await
+                                                    {
+                                                        crate::log::error(
+                                                            format!(
+                                                                "inbox migration: clear pending marker for `{alias_str}` failed: {e} (#251)"
+                                                            ),
+                                                            None,
+                                                        );
+                                                    }
+                                                    crate::toast::push_toast(
+                                                        format!(
+                                                            "Inbox `{alias_str}` migrated to the new contract id after webapp upgrade."
+                                                        ),
+                                                        crate::toast::ToastLevel::Info,
+                                                    );
+                                                }
+                                            }
+                                            Err(e) => {
                                                 crate::log::error(
                                                     format!(
-                                                        "inbox migration: PUT failed for `{}`: {e} (#213)",
-                                                        identity.alias()
+                                                        "inbox migration: deser old state for `{alias_str}` failed: {e} (#213)"
                                                     ),
                                                     None,
                                                 );
-                                            } else {
-                                                crate::toast::push_toast(
-                                                    format!(
-                                                        "Inbox `{}` migrated to the new contract id after webapp upgrade.",
-                                                        identity.alias()
-                                                    ),
-                                                    crate::toast::ToastLevel::Info,
-                                                );
+                                                inbox_management::MIGRATED_IDENTITIES.with(|s| {
+                                                    s.borrow_mut().remove(&vk_key);
+                                                });
                                             }
-                                        }
-                                        Err(e) => {
-                                            crate::log::error(
-                                                format!(
-                                                    "inbox migration: deser old state for `{}` failed: {e} (#213)",
-                                                    identity.alias()
-                                                ),
-                                                None,
-                                            );
                                         }
                                     }
                                 } else {
@@ -2317,6 +2438,22 @@ pub(crate) async fn node_comms(
                                                 (alias.clone(), info.inbox_wasm_hash.clone())
                                             })
                                             .collect();
+                                        // #251 improvement 5: snapshot
+                                        // the persistent pending-migration
+                                        // marker per identity. If set and
+                                        // the current INBOX_CODE_HASH
+                                        // still differs from the recorded
+                                        // hash, the previous session's
+                                        // GET never resolved — re-attempt.
+                                        let recorded_pending_migrations: std::collections::HashMap<
+                                            String,
+                                            Option<String>,
+                                        > = im
+                                            .get_info()
+                                            .map(|(alias, info)| {
+                                                (alias.clone(), info.pending_migration_from.clone())
+                                            })
+                                            .collect();
                                         let new_ids = crate::app::Identity::set_aliases(im, user);
                                         // ALIASES is a thread_local Vec, not a
                                         // Dioxus signal — bump login_controller
@@ -2436,21 +2573,52 @@ pub(crate) async fn node_comms(
                                                 .get(&alias_str)
                                                 .cloned()
                                                 .flatten();
-                                            match prior {
-                                                Some(prior_hash)
-                                                    if prior_hash
-                                                        == crate::inbox::INBOX_CODE_HASH =>
-                                                {
-                                                    // No drift; nothing to do.
-                                                }
+                                            let pending_marker = recorded_pending_migrations
+                                                .get(&alias_str)
+                                                .cloned()
+                                                .flatten();
+                                            // #251 improvement 5: drift
+                                            // selection (prior vs pending
+                                            // marker vs current) is a pure
+                                            // helper in `inbox.rs` so the
+                                            // precedence rules can be
+                                            // unit-tested.
+                                            let migrate_from = crate::inbox::select_migrate_from(
+                                                prior.as_deref(),
+                                                pending_marker.as_deref(),
+                                                crate::inbox::INBOX_CODE_HASH,
+                                            );
+                                            match migrate_from {
                                                 Some(prior_hash) => {
                                                     crate::log::info(format!(
                                                         "inbox migration: detected drift for `{}` \
-                                                         prior_hash={} current_hash={} (#213)",
+                                                         prior_hash={} current_hash={} pending={} (#213, #251)",
                                                         alias_str,
                                                         prior_hash,
-                                                        crate::inbox::INBOX_CODE_HASH
+                                                        crate::inbox::INBOX_CODE_HASH,
+                                                        pending_marker.is_some()
                                                     ));
+                                                    // Stamp the pending
+                                                    // marker BEFORE
+                                                    // dispatching the GET
+                                                    // so a crash mid-flow
+                                                    // still allows the
+                                                    // next session to
+                                                    // recover (#251).
+                                                    if let Err(e) = identity_management::set_pending_migration_api_call(
+                                                        &mut client,
+                                                        &alias_str,
+                                                        &prior_hash,
+                                                    )
+                                                    .await
+                                                    {
+                                                        crate::log::error(
+                                                            format!(
+                                                                "inbox migration: mark pending failed for `{alias_str}`: {e} (#251)"
+                                                            ),
+                                                            None,
+                                                        );
+                                                    }
                                                     if let Err(e) = inbox_management::migrate_inbox(
                                                         &mut client,
                                                         id,
@@ -2460,12 +2628,22 @@ pub(crate) async fn node_comms(
                                                     {
                                                         crate::log::error(
                                                             format!(
-                                                                "inbox migration: failed for `{}`: {e} (#213)",
-                                                                alias_str
+                                                                "inbox migration: failed for `{alias_str}`: {e} (#213)"
                                                             ),
                                                             None,
                                                         );
                                                     }
+                                                    // Stamp the current
+                                                    // hash so drift
+                                                    // doesn't keep firing
+                                                    // each session even
+                                                    // when the GET never
+                                                    // resolves. The
+                                                    // pending marker is
+                                                    // the source of truth
+                                                    // for retry — it's
+                                                    // cleared only on
+                                                    // successful PUT.
                                                     if let Err(e) = identity_management::stamp_inbox_wasm_hash_api_call(
                                                         &mut client,
                                                         &alias_str,
@@ -2474,29 +2652,47 @@ pub(crate) async fn node_comms(
                                                     {
                                                         crate::log::error(
                                                             format!(
-                                                                "inbox migration: stamp failed for `{}`: {e} (#213)",
-                                                                alias_str
+                                                                "inbox migration: stamp failed for `{alias_str}`: {e} (#213)"
                                                             ),
                                                             None,
                                                         );
                                                     }
                                                 }
                                                 None => {
-                                                    // First observation —
-                                                    // baseline the current
-                                                    // hash so the next
-                                                    // contract bump can be
-                                                    // detected.
-                                                    if let Err(e) = identity_management::stamp_inbox_wasm_hash_api_call(
-                                                        &mut client,
-                                                        &alias_str,
-                                                    )
-                                                    .await
+                                                    // No drift OR first
+                                                    // observation. Baseline
+                                                    // the current hash if
+                                                    // we haven't yet.
+                                                    if prior.is_none()
+                                                        && let Err(e) = identity_management::stamp_inbox_wasm_hash_api_call(
+                                                            &mut client,
+                                                            &alias_str,
+                                                        )
+                                                        .await
                                                     {
                                                         crate::log::error(
                                                             format!(
-                                                                "inbox migration: baseline stamp failed for `{}`: {e} (#213)",
-                                                                alias_str
+                                                                "inbox migration: baseline stamp failed for `{alias_str}`: {e} (#213)"
+                                                            ),
+                                                            None,
+                                                        );
+                                                    }
+                                                    // #251 improvement 5
+                                                    // cleanup: clear stale
+                                                    // pending marker if
+                                                    // prior == current
+                                                    // but a leftover
+                                                    // marker survived.
+                                                    if pending_marker.is_some()
+                                                        && let Err(e) = identity_management::clear_pending_migration_api_call(
+                                                            &mut client,
+                                                            &alias_str,
+                                                        )
+                                                        .await
+                                                    {
+                                                        crate::log::error(
+                                                            format!(
+                                                                "inbox migration: clear stale pending marker for `{alias_str}` failed: {e} (#251)"
                                                             ),
                                                             None,
                                                         );

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -54,6 +54,69 @@ pub(crate) const INBOX_CODE_HASH: &str = include_str!("../../build/inbox_code_ha
 #[cfg(not(feature = "use-node"))]
 pub(crate) const INBOX_CODE_HASH: &str = "";
 
+/// Historical `INBOX_CODE_HASH` values, oldest → newest. Each entry is a
+/// hash the inbox contract WASM previously had under a prior release.
+/// Used by the migration path (#251 improvement 2) to handle multi-hop
+/// version gaps: if a user comes back online after two or more deliberate
+/// contract bumps, the recorded `inbox_wasm_hash` may be older than the
+/// most recent prior hash. The migration walks the slice starting at the
+/// recorded hash and dispatches GETs against every newer historical key
+/// until one resolves. Append-only: never reorder, never delete entries.
+/// The current `INBOX_CODE_HASH` must NOT appear in this list.
+pub(crate) const LEGACY_INBOX_CODE_HASHES: &[&str] = &[];
+
+/// Build the ordered list of candidate code hashes to GET for a
+/// migration starting from `prior_hash`. The returned vec always
+/// contains `prior_hash` first, then every entry in `legacy` that
+/// follows it (if `prior_hash` is present in `legacy`) — or every
+/// entry in `legacy` other than `prior_hash` (if `prior_hash` is NOT
+/// present, meaning the recorded hash predates the committed legacy
+/// list; we walk the whole list to maximise recovery odds).
+///
+/// Pure function — extracted from `migrate_inbox` so the chain-build
+/// logic can be unit-tested without a node round trip.
+pub(crate) fn build_migration_candidates(prior_hash: &str, legacy: &[&str]) -> Vec<String> {
+    let mut out: Vec<String> = vec![prior_hash.to_string()];
+    let start_idx = legacy
+        .iter()
+        .position(|h| *h == prior_hash)
+        .map_or(0, |i| i + 1);
+    for h in &legacy[start_idx..] {
+        if *h != prior_hash {
+            out.push((*h).to_string());
+        }
+    }
+    out
+}
+
+/// Decide which prior hash to migrate FROM on startup, given the
+/// recorded `inbox_wasm_hash` (`prior`), the persistent
+/// pending-migration marker (`pending`), and the embedded
+/// `current` hash.
+///
+/// Rules:
+/// - If `prior == current`: no drift; ignore any stale marker (caller
+///   is responsible for clearing it separately).
+/// - Else if `pending` is set: prefer the marker (it's the source of
+///   truth for in-flight retries — see #251 improvement 5).
+/// - Else if `prior` is set: standard single-hop drift.
+/// - Else: first observation; nothing to migrate.
+///
+/// Pure function — extracted so the precedence rules can be
+/// table-tested without a node.
+pub(crate) fn select_migrate_from(
+    prior: Option<&str>,
+    pending: Option<&str>,
+    current: &str,
+) -> Option<String> {
+    match (prior, pending) {
+        (Some(p), _) if p == current => None,
+        (_, Some(pending)) => Some(pending.to_string()),
+        (Some(p), None) => Some(p.to_string()),
+        (None, None) => None,
+    }
+}
+
 /// Encode the `InboxParams.pub_key` bytes for an inbox owned by this identity.
 ///
 /// After Stage 2 the inbox contract ID is derived from the ML-DSA-65 verifying
@@ -1009,6 +1072,97 @@ impl InboxModel {
         };
         client.send(request.into()).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod migration_logic_tests {
+    use super::*;
+
+    #[test]
+    fn candidates_single_when_legacy_empty() {
+        let out = build_migration_candidates("h0", &[]);
+        assert_eq!(out, vec!["h0"]);
+    }
+
+    #[test]
+    fn candidates_skip_entries_at_or_before_prior() {
+        let legacy = ["h0", "h1", "h2"];
+        let out = build_migration_candidates("h1", &legacy);
+        assert_eq!(out, vec!["h1", "h2"]);
+    }
+
+    #[test]
+    fn candidates_walk_all_when_prior_absent() {
+        let legacy = ["h0", "h1"];
+        let out = build_migration_candidates("unknown", &legacy);
+        assert_eq!(out, vec!["unknown", "h0", "h1"]);
+    }
+
+    #[test]
+    fn candidates_no_duplicate_when_prior_at_end() {
+        let legacy = ["h0", "h1"];
+        let out = build_migration_candidates("h1", &legacy);
+        assert_eq!(out, vec!["h1"]);
+    }
+
+    #[test]
+    fn select_no_drift_when_prior_matches_current() {
+        assert_eq!(select_migrate_from(Some("cur"), None, "cur"), None);
+    }
+
+    #[test]
+    fn select_ignores_pending_when_prior_matches_current() {
+        // Stale marker case — drift logic returns None, caller clears
+        // the marker separately.
+        assert_eq!(select_migrate_from(Some("cur"), Some("stale"), "cur"), None);
+    }
+
+    #[test]
+    fn select_prefers_pending_over_prior() {
+        assert_eq!(
+            select_migrate_from(Some("old"), Some("older"), "cur"),
+            Some("older".to_string())
+        );
+    }
+
+    #[test]
+    fn select_falls_back_to_prior_when_no_pending() {
+        assert_eq!(
+            select_migrate_from(Some("old"), None, "cur"),
+            Some("old".to_string())
+        );
+    }
+
+    #[test]
+    fn select_uses_pending_when_prior_absent() {
+        // Indicates state corruption — prior was never stamped but a
+        // marker exists. Conservative behavior: retry the migration.
+        assert_eq!(
+            select_migrate_from(None, Some("older"), "cur"),
+            Some("older".to_string())
+        );
+    }
+
+    #[test]
+    fn select_none_on_first_observation() {
+        assert_eq!(select_migrate_from(None, None, "cur"), None);
+    }
+
+    /// The current `INBOX_CODE_HASH` must NOT appear in
+    /// `LEGACY_INBOX_CODE_HASHES`. Violating this invariant would make
+    /// `migrate_inbox` GET the current key as an "old" candidate and
+    /// re-PUT identical state. Only checked under `use-node` because
+    /// the constant is otherwise empty.
+    #[cfg(feature = "use-node")]
+    #[test]
+    fn current_hash_not_in_legacy() {
+        let current = INBOX_CODE_HASH;
+        assert!(
+            !LEGACY_INBOX_CODE_HASHES.contains(&current),
+            "INBOX_CODE_HASH ({current}) must not appear in LEGACY_INBOX_CODE_HASHES — \
+             append it only AFTER bumping to a new hash",
+        );
     }
 }
 


### PR DESCRIPTION
Closes #251 (improvements 2 + 5).

## Summary

Hardens the #213 inbox migration mechanism against two real-world failure modes that the current single-hop flow doesn't handle:

- **Multi-hop version gaps** — if a user skips a release, the recorded `inbox_wasm_hash` may be older than the most recent prior hash. The previous code only ever tried one GET.
- **Flaky / offline node during migration** — the previous code stamped the current hash unconditionally after dispatching the GET, so if the GET never resolved, no retry ever fired.

## Improvements

### #251 #2 — chained migration over historical hashes
- `LEGACY_INBOX_CODE_HASHES: &[&str]` (append-only oldest→newest list) in `ui/src/inbox.rs`.
- `build_migration_candidates` walks from the recorded hash forward; `migrate_inbox` dispatches one GET per candidate.
- The first GetResponse to resolve wins, deduped via `MIGRATED_IDENTITIES` (keyed by ML-DSA verifying-key bytes — alias mutates via rename).
- Set populated BEFORE `put_migrated_inbox.await` to close TOCTOU between guard check and PUT completion; entry removed on PUT failure so the next candidate response can retry.

### #251 #5 — persistent migration retry in delegate
- `AliasInfo.pending_migration_from: Option<String>` (`#[serde(default)]`, backwards-compat).
- New `IdentityMsg::SetPendingMigrationFrom { alias, prior_hash }` variant.
- UI stamps `Some(prior_hash)` BEFORE dispatching the migration GET; cleared (`None`) only on successful PUT.
- Startup `select_migrate_from` prefers a non-None pending marker over the recorded hash, so a session whose GET never resolved re-attempts on the next session.
- Stale markers (`prior == current` with a leftover pending value) are cleared in the no-drift branch.

## Testing

- 10 new unit tests in `inbox::migration_logic_tests` covering `build_migration_candidates` (4 cases) and `select_migrate_from` (5 cases), plus `current_hash_not_in_legacy` invariant test.
- 2 new tests in `identity-management::boundary_tests` covering the new `AliasInfo` field default and the new `IdentityMsg` variant round-trip.
- `cargo test -p identity-management` — 12/12 pass.
- `cargo test -p freenet-email-ui --lib` — 141/141 pass.
- `cargo clippy -p freenet-email-ui --target wasm32-unknown-unknown -- -D warnings` — clean.
- `cargo clippy -p identity-management -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Test plan

- [ ] CI green on the rebuilt workflow set
- [ ] Manual smoke: load existing identity, observe `inbox migration: detected drift ... pending=false (#213, #251)` in console only when an actual contract bump happens; no migration triggered when there's no drift
- [ ] After a contract bump landed in main: verify `pending_migration_from` is set + cleared correctly on a successful migration round-trip (network logs)

## Out of scope

#251 #1 (in-protocol upgrade pointer — contract state schema change), #3 (AFT contract migration + lockfile isolation), and #4 (recipient WASM hash in contact card) are deferred to follow-up PRs per design discussion.

[AI-assisted - Claude]