### PR TITLE
feat(send): address recipient inbox under their advertised WASM hash (#251)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,6 +448,25 @@ deliberate inbox-contract bump so users skipping releases still
 recover. The current `INBOX_CODE_HASH` must never appear in the slice
 — enforced by the `current_hash_not_in_legacy` test.
 
+**Sender-side recipient hash (#251 improvement 4)**: the inbox WASM
+hash a recipient was running at import time is captured on the
+contact (`StoredContactKeys.inbox_wasm_hash`,
+`Contact.inbox_wasm_hash`) from the import-fetch `GetResponse`'s
+`key.code_hash()`. The send path
+(`inbox.rs::start_sending`, `aft.rs::assign_token`,
+`inbox.rs::inbox_key_for_with_hash`) addresses the recipient's
+inbox under THAT hash, falling back to the sender's embedded
+`INBOX_CODE_HASH` when the field is absent (own-identity sends,
+contacts imported before this shipped). This decouples sender and
+recipient upgrade schedules — an upgraded sender can still deliver
+to a non-upgraded recipient. Stored as a bs58 string (encoded via
+plain `bs58::encode`, NOT `CodeHash::encode` whose `to_lowercase`
+breaks the roundtrip with `ContractKey::from_params`). Migration
+to a fresher hash on the recipient's side is out of scope — the
+hash sticks until the user re-imports the contact card; the
+in-protocol upgrade pointer (#251 improvement 1) is the longer-
+term fix for that.
+
 **Persistent migration retry (#251 improvement 5)**:
 `AliasInfo.pending_migration_from: Option<String>` is stamped on the
 identity-management delegate via `IdentityMsg::SetPendingMigrationFrom`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,6 +467,17 @@ hash sticks until the user re-imports the contact card; the
 in-protocol upgrade pointer (#251 improvement 1) is the longer-
 term fix for that.
 
+Every helper that derives a contact's on-chain inbox key from its
+ML-DSA VK MUST go through `inbox_key_for_with_hash` with the
+contact's `inbox_wasm_hash` (fallback to `INBOX_CODE_HASH`) — using
+`inbox_key_for` (sender's hash) silently breaks contact recognition
+for cross-version contacts. Currently:
+`ui/src/app/address_book.rs::is_contact_inbox_key`,
+`::lookup_by_bs58`, and the rehydrate + CreateContact prime GETs in
+`ui/src/api.rs` (~1442 and ~2540). `inbox_key_for` is still correct
+for OWN-identity derivations (own inbox is at the sender's embedded
+hash by construction).
+
 **Persistent migration retry (#251 improvement 5)**:
 `AliasInfo.pending_migration_from: Option<String>` is stamped on the
 identity-management delegate via `IdentityMsg::SetPendingMigrationFrom`

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -382,11 +382,15 @@ impl AftRecords {
     // recipient's inbox contract (ML-DSA-65 verifying key bytes, caller-computed).
     // `recipient_required_tier` / `recipient_max_age_secs`: recipient's
     // anti-flood policy from their `InboxParams` / `ContactCard` (#85).
+    // `recipient_inbox_wasm_hash`: recipient's inbox WASM code hash
+    // (#251 improvement 4). `None` falls back to the sender's embedded
+    // `INBOX_CODE_HASH` (preserves pre-#251 behaviour).
     pub async fn assign_token(
         client: &mut WebApiRequestClient,
         recipient_inbox_pub_key: Vec<u8>,
         recipient_required_tier: Tier,
         recipient_max_age_secs: u64,
+        recipient_inbox_wasm_hash: Option<&str>,
         generator_id: &Identity,
         assignment_hash: [u8; 32],
     ) -> Result<DelegateKey, DynError> {
@@ -420,8 +424,8 @@ impl AftRecords {
             pub_key: recipient_inbox_pub_key,
         }
         .try_into()?;
-        let inbox_key =
-            ContractKey::from_params(crate::inbox::INBOX_CODE_HASH, inbox_params.clone())?;
+        let inbox_code_hash = recipient_inbox_wasm_hash.unwrap_or(crate::inbox::INBOX_CODE_HASH);
+        let inbox_key = ContractKey::from_params(inbox_code_hash, inbox_params.clone())?;
         let delegate_params = DelegateParameters::new(seed_bytes);
 
         let record_params = TokenDelegateParameters::new(&sender_vk);

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1438,38 +1438,53 @@ pub(crate) async fn node_comms(
                     // node when delivered. Without this, send fails with
                     // "missing contract parameters" at update.rs:619 and
                     // the message silently never reaches the recipient.
+                    // #251 improvement 4: prime under the contact's
+                    // advertised WASM hash, not the sender's
+                    // `INBOX_CODE_HASH`. A cross-version contact's
+                    // actual contract id is derived from the
+                    // recipient's hash + params; priming under the
+                    // sender's hash fetches a ghost key and the
+                    // subsequent send re-derives correctly but finds
+                    // an empty local store → "missing contract
+                    // parameters at update.rs:619".
                     match crate::app::address_book::vk_from_bytes(&contact.ml_dsa_vk_bytes) {
-                        Ok(vk) => match crate::inbox::inbox_key_for(&vk) {
-                            Ok(inbox_key) => {
-                                let req = freenet_stdlib::client_api::ContractRequest::Get {
-                                    key: inbox_key.into(),
-                                    return_contract_code: true,
-                                    subscribe: true,
-                                    blocking_subscribe: false,
-                                };
-                                if let Err(e) = client.send(req.into()).await {
-                                    crate::log::error(
-                                        format!(
-                                            "prime contact inbox {inbox_key} for {} failed: {e}",
+                        Ok(vk) => {
+                            let code_hash = contact
+                                .inbox_wasm_hash
+                                .as_deref()
+                                .unwrap_or(crate::inbox::INBOX_CODE_HASH);
+                            match crate::inbox::inbox_key_for_with_hash(&vk, code_hash) {
+                                Ok(inbox_key) => {
+                                    let req = freenet_stdlib::client_api::ContractRequest::Get {
+                                        key: inbox_key.into(),
+                                        return_contract_code: true,
+                                        subscribe: true,
+                                        blocking_subscribe: false,
+                                    };
+                                    if let Err(e) = client.send(req.into()).await {
+                                        crate::log::error(
+                                            format!(
+                                                "prime contact inbox {inbox_key} for {} failed: {e}",
+                                                contact.local_alias
+                                            ),
+                                            None,
+                                        );
+                                    } else {
+                                        crate::log::info(format!(
+                                            "primed contact inbox {inbox_key} for {} (#191)",
                                             contact.local_alias
-                                        ),
-                                        None,
-                                    );
-                                } else {
-                                    crate::log::info(format!(
-                                        "primed contact inbox {inbox_key} for {} (#191)",
-                                        contact.local_alias
-                                    ));
+                                        ));
+                                    }
                                 }
-                            }
-                            Err(e) => crate::log::error(
-                                format!(
-                                    "derive inbox_key for contact {}: {e}",
-                                    contact.local_alias
+                                Err(e) => crate::log::error(
+                                    format!(
+                                        "derive inbox_key for contact {}: {e}",
+                                        contact.local_alias
+                                    ),
+                                    None,
                                 ),
-                                None,
-                            ),
-                        },
+                            }
+                        }
                         Err(e) => crate::log::error(
                             format!("decode ml_dsa_vk for contact {}: {e}", contact.local_alias),
                             None,
@@ -2533,43 +2548,57 @@ pub(crate) async fn node_comms(
                                         // the local node's contract store is empty,
                                         // so the first send to a known contact would
                                         // fail with "missing contract parameters".
+                                        // #251 improvement 4: derive under the
+                                        // contact's advertised WASM hash so
+                                        // cross-version contacts prime under
+                                        // their real on-chain id, not a ghost
+                                        // key under the sender's
+                                        // `INBOX_CODE_HASH`.
                                         for contact in crate::app::address_book::all_contacts() {
                                             match crate::app::address_book::vk_from_bytes(
                                                 &contact.ml_dsa_vk_bytes,
                                             ) {
-                                                Ok(vk) => match crate::inbox::inbox_key_for(&vk) {
-                                                    Ok(inbox_key) => {
-                                                        let req = freenet_stdlib::client_api::ContractRequest::Get {
-                                                            key: inbox_key.into(),
-                                                            return_contract_code: true,
-                                                            subscribe: true,
-                                                            blocking_subscribe: false,
-                                                        };
-                                                        if let Err(e) =
-                                                            client.send(req.into()).await
-                                                        {
-                                                            crate::log::error(
-                                                                format!(
-                                                                    "rehydrate prime contact inbox {inbox_key} for {} failed: {e}",
+                                                Ok(vk) => {
+                                                    let code_hash = contact
+                                                        .inbox_wasm_hash
+                                                        .as_deref()
+                                                        .unwrap_or(crate::inbox::INBOX_CODE_HASH);
+                                                    match crate::inbox::inbox_key_for_with_hash(
+                                                        &vk, code_hash,
+                                                    ) {
+                                                        Ok(inbox_key) => {
+                                                            let req = freenet_stdlib::client_api::ContractRequest::Get {
+                                                                key: inbox_key.into(),
+                                                                return_contract_code: true,
+                                                                subscribe: true,
+                                                                blocking_subscribe: false,
+                                                            };
+                                                            if let Err(e) =
+                                                                client.send(req.into()).await
+                                                            {
+                                                                crate::log::error(
+                                                                    format!(
+                                                                        "rehydrate prime contact inbox {inbox_key} for {} failed: {e}",
+                                                                        contact.local_alias
+                                                                    ),
+                                                                    None,
+                                                                );
+                                                            } else {
+                                                                crate::log::info(format!(
+                                                                    "rehydrate primed contact inbox {inbox_key} for {} (#191)",
                                                                     contact.local_alias
-                                                                ),
-                                                                None,
-                                                            );
-                                                        } else {
-                                                            crate::log::info(format!(
-                                                                "rehydrate primed contact inbox {inbox_key} for {} (#191)",
-                                                                contact.local_alias
-                                                            ));
+                                                                ));
+                                                            }
                                                         }
-                                                    }
-                                                    Err(e) => crate::log::error(
-                                                        format!(
-                                                            "rehydrate derive inbox_key for contact {}: {e}",
-                                                            contact.local_alias
+                                                        Err(e) => crate::log::error(
+                                                            format!(
+                                                                "rehydrate derive inbox_key for contact {}: {e}",
+                                                                contact.local_alias
+                                                            ),
+                                                            None,
                                                         ),
-                                                        None,
-                                                    ),
-                                                },
+                                                    }
+                                                }
                                                 Err(e) => crate::log::error(
                                                     format!(
                                                         "rehydrate decode ml_dsa_vk for contact {}: {e}",

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -234,11 +234,13 @@ mod delegate_api {
 
 /// Decode an import-fetch `GetResponse` into an
 /// `ImportFetchOutcome`. Pulls the recipient's ML-DSA vk from the
-/// contract's parameters and the ek + tier policy from the inbox state.
+/// contract's parameters, the ek + tier policy from the inbox state,
+/// and the inbox WASM code hash from the response's contract key.
 #[cfg(feature = "use-node")]
 fn decode_import_fetch(
     contract: &Option<freenet_stdlib::prelude::ContractContainer>,
     state: &[u8],
+    key: &freenet_stdlib::prelude::ContractKey,
 ) -> contact_import::ImportFetchOutcome {
     use freenet_email_inbox::{Inbox as InboxState, InboxParams};
 
@@ -268,11 +270,24 @@ fn decode_import_fetch(
             "recipient inbox is missing ek (legacy state pre-#249)".into(),
         );
     }
+    // #251 improvement 4: capture the recipient's inbox WASM code
+    // hash from the GetResponse key so the sender can derive the
+    // recipient's inbox `ContractKey` against the recipient's hash
+    // (not the sender's embedded `INBOX_CODE_HASH`) at send time.
+    //
+    // Encoded with a plain `bs58::encode` (no `to_lowercase`) so the
+    // string roundtrips through `ContractKey::from_params` cleanly.
+    // `CodeHash::encode` would lowercase the output, which then fails
+    // bs58 decode back to the original bytes.
+    let inbox_wasm_hash = bs58::encode(key.code_hash().as_ref())
+        .with_alphabet(bs58::Alphabet::BITCOIN)
+        .into_string();
     contact_import::ImportFetchOutcome::Ok {
         ml_dsa_vk_bytes: params.pub_key,
         ml_kem_ek_bytes: parsed.owner_ek_bytes,
         required_tier: parsed.settings.minimum_tier,
         max_age_secs: parsed.settings.max_age_secs,
+        inbox_wasm_hash,
     }
 }
 
@@ -307,6 +322,17 @@ pub(crate) mod contact_import {
             ml_kem_ek_bytes: Vec<u8>,
             required_tier: freenet_aft_interface::Tier,
             max_age_secs: u64,
+            /// bs58-encoded inbox contract WASM code hash, captured
+            /// from the GetResponse's `key.code_hash()` at import time
+            /// (#251 improvement 4). The sender uses this hash —
+            /// rather than its own embedded `INBOX_CODE_HASH` — to
+            /// derive the recipient's inbox `ContractKey` when sending,
+            /// so a non-upgraded recipient still receives messages
+            /// from an upgraded sender. The recipient advertised this
+            /// hash implicitly by publishing under the corresponding
+            /// contract id; capturing the wire value avoids any
+            /// schema bump on the user-facing `ContactCard`.
+            inbox_wasm_hash: String,
         },
         /// Fetch failed (network error, contract unknown, malformed state, etc.).
         Failed(String),
@@ -845,6 +871,7 @@ mod identity_management {
             verified: contact.verified,
             required_tier: contact.required_tier,
             max_age_secs: contact.max_age_secs,
+            inbox_wasm_hash: contact.inbox_wasm_hash.clone(),
         };
         let msg = IdentityMsg::CreateIdentity {
             alias: contact.local_alias.to_string(),
@@ -1860,7 +1887,8 @@ pub(crate) async fn node_comms(
                                 let import_addr = contact_import::PENDING
                                     .with(|m| m.borrow_mut().remove(key.id()));
                                 if let Some(inbox_address) = import_addr {
-                                    let outcome = decode_import_fetch(&contract, state.as_ref());
+                                    let outcome =
+                                        decode_import_fetch(&contract, state.as_ref(), &key);
                                     contact_import::RESULTS.with(|m| {
                                         m.borrow_mut().insert(
                                             inbox_address,

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -369,6 +369,7 @@ impl InboxView {
         recipient_ml_dsa_vk: ml_dsa::VerifyingKey<MlDsa65>,
         recipient_required_tier: freenet_aft_interface::Tier,
         recipient_max_age_secs: u64,
+        recipient_inbox_wasm_hash: Option<String>,
         title: &str,
         content: &str,
         // Optional `(sender_alias, sent_id, inbox_key)` so the future can
@@ -400,6 +401,7 @@ impl InboxView {
                 return Ok(futs);
             };
             let ack_meta_async = ack_meta.clone();
+            let recipient_hash_async = recipient_inbox_wasm_hash.clone();
             let f = async move {
                 let res = content_clone
                     .start_sending(
@@ -408,6 +410,7 @@ impl InboxView {
                         recipient_ml_dsa_vk,
                         recipient_required_tier,
                         recipient_max_age_secs,
+                        recipient_hash_async.as_deref(),
                         &id,
                     )
                     .await;
@@ -449,6 +452,8 @@ impl InboxView {
         // ack_meta is unused on the offline path; explicitly ignored.
         #[cfg(not(feature = "use-node"))]
         let _ = ack_meta;
+        #[cfg(not(feature = "use-node"))]
+        let _ = recipient_inbox_wasm_hash;
         #[cfg(all(feature = "example-data", not(feature = "use-node")))]
         {
             // In offline mode, deliver the message to an in-memory mailbox
@@ -704,6 +709,7 @@ impl User {
             required_tier: freenet_aft_interface::Tier::Min10,
             max_age_secs: freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
             verified: true,
+            inbox_wasm_hash: None,
         });
         User {
             logged: false,
@@ -2677,9 +2683,17 @@ fn ComposeSheet() -> Element {
 
         // Derive the recipient's inbox key BEFORE moving `recipient_vk` into
         // `send_message` so we can pair the eventual UpdateResponse back to
-        // the Sent row's `SentId`.
+        // the Sent row's `SentId`. #251 improvement 4: derive against the
+        // recipient's advertised WASM hash when known so the ack pairing
+        // matches the actual contract id the runtime will route to.
         #[cfg(feature = "use-node")]
-        let inbox_key_for_ack = crate::inbox::inbox_key_for(&recipient_vk);
+        let inbox_key_for_ack = crate::inbox::inbox_key_for_with_hash(
+            &recipient_vk,
+            recipient
+                .inbox_wasm_hash
+                .as_deref()
+                .unwrap_or(crate::inbox::INBOX_CODE_HASH),
+        );
 
         // #221: prefer the live `InboxSettings` cached from the contact's
         // inbox state over the values frozen in the contact card. Cards
@@ -2738,6 +2752,7 @@ fn ComposeSheet() -> Element {
             recipient_vk,
             recipient_required_tier,
             recipient_max_age_secs,
+            recipient.inbox_wasm_hash.clone(),
             &title_val,
             &content_val,
             ack_meta,

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -346,7 +346,7 @@ pub fn lookup(alias: &str) -> Option<Recipient> {
 /// fingerprint. Unknown addresses return `None`; the UI surfaces "import
 /// as contact first".
 pub fn lookup_by_bs58(addr: &str) -> Option<Recipient> {
-    use crate::inbox::inbox_key_for;
+    use crate::inbox::{INBOX_CODE_HASH, inbox_key_for, inbox_key_for_with_hash};
     use std::str::FromStr;
     let trimmed = addr.trim();
     let target = freenet_stdlib::prelude::ContractInstanceId::from_str(trimmed).ok()?;
@@ -355,7 +355,13 @@ pub fn lookup_by_bs58(addr: &str) -> Option<Recipient> {
         ab.borrow().values().find_map(|entry| match entry {
             Entry::Contact(c) => {
                 let vk = vk_from_bytes(&c.ml_dsa_vk_bytes).ok()?;
-                let key = inbox_key_for(&vk).ok()?;
+                // #251 improvement 4: address-book lookup must derive the
+                // contact's inbox key under the contact's advertised
+                // hash, not the sender's `INBOX_CODE_HASH`. A
+                // cross-version contact's actual contract id differs
+                // from `inbox_key_for(vk)` once the sender upgrades.
+                let code_hash = c.inbox_wasm_hash.as_deref().unwrap_or(INBOX_CODE_HASH);
+                let key = inbox_key_for_with_hash(&vk, code_hash).ok()?;
                 if *key.id() == target {
                     let fingerprint = c.fingerprint();
                     Some(Recipient {
@@ -406,14 +412,24 @@ pub fn lookup_by_bs58(addr: &str) -> Option<Recipient> {
 /// can't render a contact's inbox (the messages are encrypted to the
 /// contact's ml_kem key, not ours) — the prime is fire-and-forget.
 pub fn is_contact_inbox_key(key: &freenet_stdlib::prelude::ContractKey) -> bool {
-    use crate::inbox::inbox_key_for;
+    use crate::inbox::{INBOX_CODE_HASH, inbox_key_for_with_hash};
     ADDRESS_BOOK.with(|ab| {
         ab.borrow().values().any(|e| match e {
+            // #251 improvement 4: derive each contact's inbox key under
+            // the contact's advertised WASM hash. A cross-version
+            // contact's actual `key.id()` is derived from THAT hash, not
+            // the sender's `INBOX_CODE_HASH`; falling back to the
+            // sender's hash here silently failed to match
+            // UpdateNotifications + GetResponses for cross-version
+            // contacts, breaking tier-cache priming + ack pairing.
             Entry::Contact(c) => match vk_from_bytes(&c.ml_dsa_vk_bytes) {
-                Ok(vk) => match inbox_key_for(&vk) {
-                    Ok(contact_key) => contact_key.id() == key.id(),
-                    Err(_) => false,
-                },
+                Ok(vk) => {
+                    let code_hash = c.inbox_wasm_hash.as_deref().unwrap_or(INBOX_CODE_HASH);
+                    match inbox_key_for_with_hash(&vk, code_hash) {
+                        Ok(contact_key) => contact_key.id() == key.id(),
+                        Err(_) => false,
+                    }
+                }
                 Err(_) => false,
             },
             Entry::Own(_) => false,

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -153,6 +153,11 @@ pub struct Contact {
     pub max_age_secs: u64,
     /// True when the user explicitly confirmed the fingerprint with the sender.
     pub verified: bool,
+    /// bs58-encoded inbox contract WASM code hash for this contact's
+    /// inbox, captured at import time (#251 improvement 4). `None`
+    /// for contacts that pre-date this field. See
+    /// `StoredContactKeys.inbox_wasm_hash`.
+    pub inbox_wasm_hash: Option<String>,
 }
 
 impl Contact {
@@ -195,6 +200,11 @@ pub struct Recipient {
     /// True only for contacts whose fingerprint was confirmed by the user.
     pub verified: bool,
     pub is_own: bool,
+    /// Recipient's inbox WASM code hash (#251 improvement 4). `None`
+    /// means "fall back to the sender's embedded `INBOX_CODE_HASH`"
+    /// — preserves pre-#251 behaviour for own identities and for
+    /// contacts imported before this field shipped.
+    pub inbox_wasm_hash: Option<String>,
 }
 
 impl Recipient {
@@ -309,6 +319,7 @@ pub fn lookup(alias: &str) -> Option<Recipient> {
                     max_age_secs: id.max_age_secs,
                     verified: true,
                     is_own: true,
+                    inbox_wasm_hash: None,
                 }
             }
             Entry::Contact(c) => {
@@ -322,6 +333,7 @@ pub fn lookup(alias: &str) -> Option<Recipient> {
                     max_age_secs: c.max_age_secs,
                     verified: c.verified,
                     is_own: false,
+                    inbox_wasm_hash: c.inbox_wasm_hash.clone(),
                 }
             }
         })
@@ -355,6 +367,7 @@ pub fn lookup_by_bs58(addr: &str) -> Option<Recipient> {
                         max_age_secs: c.max_age_secs,
                         verified: c.verified,
                         is_own: false,
+                        inbox_wasm_hash: c.inbox_wasm_hash.clone(),
                     })
                 } else {
                     None
@@ -376,6 +389,7 @@ pub fn lookup_by_bs58(addr: &str) -> Option<Recipient> {
                         max_age_secs: id.max_age_secs,
                         verified: true,
                         is_own: true,
+                        inbox_wasm_hash: None,
                     })
                 } else {
                     None
@@ -519,6 +533,16 @@ pub struct StoredContactKeys {
     pub required_tier: Tier,
     #[serde(default = "default_max_age_secs")]
     pub max_age_secs: u64,
+    /// bs58-encoded inbox contract WASM code hash for this contact's
+    /// inbox, captured from the GetResponse at import time
+    /// (#251 improvement 4). The sender uses this hash to derive the
+    /// recipient's inbox `ContractKey`, so a non-upgraded recipient
+    /// still receives messages from an upgraded sender. `None` for
+    /// contacts imported before this field shipped — send path falls
+    /// back to the sender's embedded `INBOX_CODE_HASH` (pre-#251
+    /// behaviour).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inbox_wasm_hash: Option<String>,
 }
 
 impl StoredContactKeys {
@@ -541,6 +565,7 @@ impl StoredContactKeys {
             verified,
             required_tier: state.settings.minimum_tier,
             max_age_secs: state.settings.max_age_secs,
+            inbox_wasm_hash: None,
         }
     }
 
@@ -553,6 +578,7 @@ impl StoredContactKeys {
             required_tier: self.required_tier,
             max_age_secs: self.max_age_secs,
             verified: self.verified,
+            inbox_wasm_hash: self.inbox_wasm_hash,
         }
     }
 }
@@ -685,6 +711,41 @@ mod tests {
         );
     }
 
+    /// Older delegate payloads omit `inbox_wasm_hash` entirely. They
+    /// must still decode and default to `None` so existing contacts
+    /// keep working after the #251 improvement 4 schema bump.
+    #[test]
+    fn stored_contact_keys_missing_inbox_wasm_hash_defaults_to_none() {
+        let json = br#"{
+            "ml_dsa_vk_bytes":[1,2,3],
+            "ml_kem_ek_bytes":[4,5,6],
+            "suggested_alias":null,
+            "verified":false
+        }"#;
+        let decoded: StoredContactKeys =
+            serde_json::from_slice(json).expect("legacy payload must decode");
+        assert_eq!(decoded.inbox_wasm_hash, None);
+    }
+
+    /// New payloads with `inbox_wasm_hash` round-trip cleanly so the
+    /// sender always sees the recipient's advertised hash after a
+    /// delegate reload.
+    #[test]
+    fn stored_contact_keys_with_inbox_wasm_hash_round_trips() {
+        let original = StoredContactKeys {
+            ml_dsa_vk_bytes: vec![1; 1952],
+            ml_kem_ek_bytes: vec![2; 1184],
+            suggested_alias: Some("alice".into()),
+            verified: true,
+            required_tier: Tier::Min10,
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
+            inbox_wasm_hash: Some("EeAHzLBKgFG2dF7TdpeP3JLrHEqKnaznT7WVtnutaQXH".into()),
+        };
+        let bytes = serde_json::to_vec(&original).expect("serialise");
+        let decoded: StoredContactKeys = serde_json::from_slice(&bytes).expect("deserialise");
+        assert_eq!(decoded.inbox_wasm_hash, original.inbox_wasm_hash);
+    }
+
     fn make_contact(alias: &str, vk: u8, ek: u8) -> Contact {
         Contact {
             local_alias: alias.into(),
@@ -694,6 +755,7 @@ mod tests {
             required_tier: Tier::Day1,
             max_age_secs: DEFAULT_MAX_AGE_SECS,
             verified: false,
+            inbox_wasm_hash: None,
         }
     }
 
@@ -898,6 +960,7 @@ mod tests {
             required_tier: Tier::Day1,
             max_age_secs: DEFAULT_MAX_AGE_SECS,
             verified: false,
+            inbox_wasm_hash: None,
         };
         insert_contact(contact).unwrap();
 
@@ -925,6 +988,7 @@ mod tests {
             required_tier: Tier::Day1,
             max_age_secs: DEFAULT_MAX_AGE_SECS,
             verified: false,
+            inbox_wasm_hash: None,
         })
         .unwrap();
 
@@ -959,6 +1023,7 @@ mod tests {
             required_tier: Tier::Day1,
             max_age_secs: DEFAULT_MAX_AGE_SECS,
             verified: true,
+            inbox_wasm_hash: None,
         })
         .unwrap();
 

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -1908,7 +1908,19 @@ pub(super) fn ShareContactModal() -> Element {
 /// — the four fields recovered from the inbox contract on a successful
 /// `FetchContactKeys` round-trip, ready to flow into
 /// `StoredContactKeys` on confirm.
-type FetchedKeys = (Vec<u8>, Vec<u8>, freenet_aft_interface::Tier, u64);
+///
+/// Fields: `(ml_dsa_vk, ml_kem_ek, required_tier, max_age_secs,
+/// inbox_wasm_hash)`. The last entry is `None` for offline-mode
+/// fixtures (no node round-trip to capture the recipient's actual
+/// inbox WASM hash) and the send path falls back to the sender's
+/// embedded `INBOX_CODE_HASH` — same behaviour as pre-#251.
+type FetchedKeys = (
+    Vec<u8>,
+    Vec<u8>,
+    freenet_aft_interface::Tier,
+    u64,
+    Option<String>,
+);
 
 #[allow(non_snake_case)]
 pub(super) fn ImportContactForm() -> Element {
@@ -1947,6 +1959,7 @@ pub(super) fn ImportContactForm() -> Element {
                                 ml_kem_ek_bytes,
                                 required_tier,
                                 max_age_secs,
+                                inbox_wasm_hash,
                             } => {
                                 let fp = crate::app::address_book::fingerprint_words(
                                     &ml_dsa_vk_bytes,
@@ -1958,6 +1971,7 @@ pub(super) fn ImportContactForm() -> Element {
                                     ml_kem_ek_bytes,
                                     required_tier,
                                     max_age_secs,
+                                    Some(inbox_wasm_hash),
                                 )));
                                 error_msg.set(String::new());
                             }
@@ -2058,8 +2072,8 @@ pub(super) fn ImportContactForm() -> Element {
                         ek_bytes,
                         Tier::Min10,
                         freenet_email_inbox::DEFAULT_MAX_AGE_SECS,
+                        None,
                     )));
-                    return;
                 }
 
                 #[cfg(feature = "use-node")]
@@ -2219,7 +2233,9 @@ pub(super) fn ImportContactForm() -> Element {
                         onclick: move |_| {
                             let alias_str = local_alias.read().clone();
                             if alias_str.is_empty() { return; }
-                            let Some((vk, ek, tier, max_age)) = fetched_keys.read().clone() else {
+                            let Some((vk, ek, tier, max_age, inbox_wasm_hash)) =
+                                fetched_keys.read().clone()
+                            else {
                                 error_msg.set("Still fetching keys — wait a moment.".into());
                                 return;
                             };
@@ -2234,6 +2250,7 @@ pub(super) fn ImportContactForm() -> Element {
                                 verified: *verified.read(),
                                 required_tier: tier,
                                 max_age_secs: max_age,
+                                inbox_wasm_hash,
                             };
                             let contact = stored.into_contact(
                                 alias_str.into(),

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -1488,4 +1488,78 @@ mod tests {
             panic!("unexpected request type");
         }
     }
+
+    /// #251 improvement 4: `inbox_key_for_with_hash` against two
+    /// different code hashes must yield two different `ContractKey`s
+    /// for the same vk — the whole reason the helper exists. Also pin
+    /// that `inbox_key_for` is exactly the `INBOX_CODE_HASH` instance
+    /// of the helper, so the two stay in lockstep.
+    #[cfg(feature = "use-node")]
+    #[test]
+    fn inbox_key_for_with_hash_distinguishes_code_hashes() {
+        let sk = fresh_signing_key();
+        let vk = MlDsaKeypair::verifying_key(&sk);
+        let synthetic = bs58::encode([7u8; 32])
+            .with_alphabet(bs58::Alphabet::BITCOIN)
+            .into_string();
+        let current = inbox_key_for_with_hash(&vk, INBOX_CODE_HASH).expect("current key");
+        let other = inbox_key_for_with_hash(&vk, &synthetic).expect("other key");
+        assert_ne!(
+            current.id(),
+            other.id(),
+            "different code hashes must produce different contract instance ids — \
+             otherwise the send-time switch in #251 improvement 4 is a no-op",
+        );
+        let default = inbox_key_for(&vk).expect("default key");
+        assert_eq!(
+            current.id(),
+            default.id(),
+            "inbox_key_for must equal inbox_key_for_with_hash(.., INBOX_CODE_HASH)",
+        );
+    }
+
+    /// `bs58::encode(key.code_hash().as_ref())` must roundtrip through
+    /// the same bs58 BITCOIN alphabet that `ContractKey::from_params`
+    /// uses internally. `freenet_stdlib::CodeHash::encode` lowercases
+    /// its output, which would break this roundtrip — pin the chosen
+    /// alternative (#251 improvement 4).
+    #[test]
+    fn code_hash_bs58_roundtrips_byte_identical() {
+        let bytes: [u8; 32] = [
+            0x01, 0x02, 0x03, 0xAB, 0xCD, 0xEF, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80,
+            0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+            0x88, 0x99, 0xAA, 0xBB,
+        ];
+        let encoded = bs58::encode(bytes)
+            .with_alphabet(bs58::Alphabet::BITCOIN)
+            .into_string();
+        // The encoding must contain mixed case — lowercasing it would
+        // change the decoded bytes (case-sensitive bs58 alphabet).
+        assert!(
+            encoded.chars().any(|c| c.is_ascii_uppercase())
+                && encoded.chars().any(|c| c.is_ascii_lowercase()),
+            "fixture chosen to exercise mixed-case bs58 output, got {encoded}",
+        );
+        let mut decoded = [0u8; 32];
+        bs58::decode(&encoded)
+            .with_alphabet(bs58::Alphabet::BITCOIN)
+            .onto(&mut decoded)
+            .expect("decode");
+        assert_eq!(decoded, bytes, "bs58 BITCOIN alphabet must roundtrip");
+
+        // Decode lowercased — must yield DIFFERENT bytes, demonstrating
+        // why we cannot use `CodeHash::encode` (which lowercases).
+        let lowered = encoded.to_lowercase();
+        let mut decoded_lower = [0u8; 32];
+        let lower_ok = bs58::decode(&lowered)
+            .with_alphabet(bs58::Alphabet::BITCOIN)
+            .onto(&mut decoded_lower)
+            .is_ok();
+        if lower_ok {
+            assert_ne!(
+                decoded_lower, bytes,
+                "lowercased bs58 must NOT roundtrip — proves the workaround is load-bearing",
+            );
+        }
+    }
 }

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -135,12 +135,27 @@ pub(crate) fn inbox_params_pub_key_bytes(ml_dsa_vk: &MlDsaVerifyingKey<MlDsa65>)
 pub(crate) fn inbox_key_for(
     ml_dsa_vk: &MlDsaVerifyingKey<MlDsa65>,
 ) -> Result<ContractKey, DynError> {
+    inbox_key_for_with_hash(ml_dsa_vk, INBOX_CODE_HASH)
+}
+
+/// Same as `inbox_key_for` but derives against an explicit code hash —
+/// used by the send path (#251 improvement 4) so the sender can address
+/// the recipient's inbox under the recipient's WASM hash rather than
+/// the sender's embedded `INBOX_CODE_HASH`. A non-upgraded recipient
+/// still receives messages from an upgraded sender.
+///
+/// Callers that hold a recipient's `Contact.inbox_wasm_hash` should
+/// pass it here. `None` callers can stay on `inbox_key_for`.
+pub(crate) fn inbox_key_for_with_hash(
+    ml_dsa_vk: &MlDsaVerifyingKey<MlDsa65>,
+    code_hash: &str,
+) -> Result<ContractKey, DynError> {
     let params = InboxParams {
         pub_key: inbox_params_pub_key_bytes(ml_dsa_vk),
     }
     .try_into()
     .map_err(|e| format!("{e}"))?;
-    ContractKey::from_params(INBOX_CODE_HASH, params).map_err(|e| format!("{e}").into())
+    ContractKey::from_params(code_hash, params).map_err(|e| format!("{e}").into())
 }
 
 /// Verify a detached ML-DSA-65 signature over `ciphertext` using the
@@ -516,6 +531,7 @@ pub(crate) struct DecryptedMessage {
 }
 
 impl DecryptedMessage {
+    #[allow(clippy::too_many_arguments)]
     pub async fn start_sending(
         self,
         client: &mut WebApiRequestClient,
@@ -523,6 +539,7 @@ impl DecryptedMessage {
         recipient_ml_dsa_vk: MlDsaVerifyingKey<MlDsa65>,
         recipient_required_tier: freenet_aft_interface::Tier,
         recipient_max_age_secs: u64,
+        recipient_inbox_wasm_hash: Option<&str>,
         from: &Identity,
     ) -> Result<(), DynError> {
         let (hash, _) = self.assignment_hash_and_signed_content()?;
@@ -532,11 +549,17 @@ impl DecryptedMessage {
             bs58::encode(hash).into_string()
         ));
         let inbox_pub_key_bytes = inbox_params_pub_key_bytes(&recipient_ml_dsa_vk);
+        // #251 improvement 4: address the recipient's inbox under the
+        // recipient's advertised WASM hash when known. Falls back to
+        // the sender's `INBOX_CODE_HASH` for own-identity sends and
+        // for contacts imported before the field shipped.
+        let code_hash = recipient_inbox_wasm_hash.unwrap_or(INBOX_CODE_HASH);
         let delegate_key = AftRecords::assign_token(
             client,
             inbox_pub_key_bytes.clone(),
             recipient_required_tier,
             recipient_max_age_secs,
+            recipient_inbox_wasm_hash,
             from,
             hash,
         )
@@ -546,8 +569,7 @@ impl DecryptedMessage {
         }
         .try_into()
         .map_err(|e| format!("{e}"))?;
-        let inbox_key =
-            ContractKey::from_params(INBOX_CODE_HASH, params).map_err(|e| format!("{e}"))?;
+        let inbox_key = ContractKey::from_params(code_hash, params).map_err(|e| format!("{e}"))?;
         crate::log::info(format!(
             "send.start_sending: token requested, awaiting AFT delegate response from=`{}` inbox_key={inbox_key} (release-visible diagnostic for #174)",
             from.alias()


### PR DESCRIPTION
## Summary
- Decouples sender and recipient upgrade schedules: an upgraded sender can now deliver to a non-upgraded recipient.
- Captures the recipient's inbox WASM code hash from the import-fetch `GetResponse`'s `key.code_hash()` (`return_contract_code: true` already pulls the container).
- Persists on `StoredContactKeys` / `Contact` / `Recipient` (\`#\[serde(default)\]\` for backwards-compat).
- Send path derives the recipient's \`ContractKey\` against the recipient's hash via new \`inbox_key_for_with_hash\`; falls back to embedded \`INBOX_CODE_HASH\` for own-identity sends and pre-#251 contacts.
- User-facing \`ContactCard\` (bare bs58 inbox id) is unchanged — the hash is captured from the contract container during the import GET, not embedded in the card.
- Encoded with plain \`bs58::encode\` rather than \`CodeHash::encode\` (which lowercases and breaks the roundtrip through \`ContractKey::from_params\`).

Closes #251 improvement 4.

## Test plan
- [x] \`cargo test --workspace --lib\` — 193 tests green, two new tests pin \`StoredContactKeys\` legacy-payload back-compat + new-field roundtrip.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo clippy -p freenet-email-ui --features example-data,no-sync --no-default-features --all-targets -- -D warnings\` (offline-build path)
- [x] \`cargo fmt -p freenet-email-ui -p identity-management\`
- [ ] Manual: exercise on iso-nodes with two builds at different \`INBOX_CODE_HASH\` values — out of scope for one PR (no shipped legacy hash to test against yet); covered by mechanical typing + serde tests.