### PR TITLE
fix(ui): style contact modals in inbox view, overlay Settings, default verify-on-send off

### DIFF
--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -57,7 +57,7 @@ manual gap by adding a test, flip status to `auto` and link the test.
 | Import contact: alias → resolves in compose | auto | offline: `import contact card → appears in contacts section → compose accepts alias` |
 | Verify checkbox tick → badge flips to verified | auto | offline: `ticking the verify card flips the contact's badge to verified` |
 | Verify button promotes unverified contact in place (#87) | auto | offline: `Verify button promotes an unverified contact in place` |
-| `verify_on_send` blocks unverified-contact send (toast) | manual | Disable verify on import, Send → expect "Recipient is not verified" toast, no Sent row |
+| `verify_on_send` blocks unverified-contact send (toast) | manual | Enable "Require known key to send" (off by default), import a contact without ticking verify, Send → expect "Recipient is not verified" toast, no Sent row |
 | Edit / delete contact | manual | Open Contacts, click row, edit label / description, save; delete and confirm gone |
 | Self-card in Contacts (own identity) | manual | Confirm own identity surfaces in Contacts with "you" indicator (or absent — verify intended behavior) |
 | Contact import + reload + UpdateNotification stays sane (#198/#204) | auto | iso: `contact import + reload + UpdateNotification stays sane (#204)` |

--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -271,7 +271,7 @@ pub struct IdentityPrivacyPrefs {
 impl Default for IdentityPrivacyPrefs {
     fn default() -> Self {
         Self {
-            verify_on_send: true,
+            verify_on_send: false,
             hide_unsigned: false,
             pad_length: true,
             read_receipts: false,
@@ -1026,7 +1026,7 @@ mod boundary_tests {
         assert_eq!(s.settings.aft.required_tier, "Min10");
         assert!(s.settings.aft.allow_known);
         assert!(!s.settings.aft.allow_anon);
-        assert!(s.settings.privacy.verify_on_send);
+        assert!(!s.settings.privacy.verify_on_send);
         assert!(s.settings.auto_sign);
     }
 

--- a/ui/public/vendor/css/components/settings.css
+++ b/ui/public/vendor/css/components/settings.css
@@ -650,5 +650,117 @@
       background: rgba(241, 245, 249, 0.4);
     }
 
+    /* Contact-modal form fields. Mirrors the .field/.input/.textarea +
+       verify-words/token-block/verify-check rules from login.css
+       (@scope .fm-pre) so the Import/Share modals rendered inside
+       div.fm-app pick up the same layout as on the pre-login surface.
+       Without these the labels render inline-left of the inputs and
+       the textarea overlaps its label (#158 follow-up). */
+    .pulse-dot {
+      width: 5px; height: 5px; border-radius: 50%; background: var(--trust); flex: 0 0 5px;
+      animation: fm-keypulse 3s ease infinite;
+    }
+    .field { display: flex; flex-direction: column; gap: 7px; margin-bottom: 18px; }
+    .field-label {
+      font-family: "Geist Mono", monospace; font-size: 8.5px;
+      letter-spacing: 0.13em; text-transform: uppercase; color: var(--ink4);
+    }
+    .field-help { font-size: 11.5px; color: var(--ink3); font-style: italic; line-height: 1.5; }
+    .input,
+    .textarea {
+      width: 100%; background: #fff;
+      border: 1px solid var(--line); border-radius: 8px;
+      padding: 11px 14px; font-size: 13.5px; color: var(--ink1);
+      letter-spacing: -0.005em;
+      transition: border-color .12s ease, box-shadow .12s ease;
+    }
+    .input:focus,
+    .textarea:focus {
+      border-color: var(--accent-mid);
+      box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.08);
+    }
+    .input::placeholder,
+    .textarea::placeholder { color: var(--ink4); }
+    .textarea {
+      min-height: 120px; resize: vertical;
+      font-family: "Geist Mono", monospace; font-size: 11.5px; line-height: 1.6;
+    }
+
+    .verify-words {
+      background: linear-gradient(180deg, rgba(239, 246, 255, 0.6), rgba(220, 252, 231, 0.4));
+      border: 1px solid var(--line2);
+      border-radius: 10px; padding: 18px 20px;
+      margin: 6px 0 18px;
+    }
+    .verify-words-label {
+      font-family: "Geist Mono", monospace; font-size: 8px;
+      letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink3);
+      display: flex; align-items: center; gap: 7px; margin-bottom: 11px;
+    }
+    .verify-words-grid {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px 16px;
+    }
+    .verify-word { display: flex; flex-direction: column; gap: 3px; }
+    .verify-word .num {
+      font-family: "Geist Mono", monospace; font-size: 8px; color: var(--ink4);
+      letter-spacing: 0.12em;
+    }
+    .verify-word .w {
+      font-family: "Geist Mono", monospace; font-size: 14px; font-weight: 500;
+      color: var(--ink0); letter-spacing: 0.01em;
+    }
+
+    .token-block {
+      background: var(--c1); border: 1px solid var(--line2);
+      border-radius: 9px; padding: 13px 15px;
+      font-family: "Geist Mono", monospace; font-size: 11px;
+      color: var(--ink2); line-height: 1.55;
+      word-break: break-all; letter-spacing: 0;
+      max-height: 130px; overflow: auto;
+      position: relative;
+    }
+    .token-block .scheme { color: var(--accent); font-weight: 500; }
+    .copy-row { display: flex; align-items: center; gap: 8px; margin-top: 10px; }
+
+    .verify-check {
+      display: flex; gap: 14px; align-items: flex-start;
+      background: #fff; border: 1.5px solid var(--line); border-radius: 10px;
+      padding: 16px 18px; cursor: default;
+      transition: border-color .15s ease, background .15s ease;
+      margin: 14px 0 6px;
+    }
+    .verify-check:hover { border-color: var(--c3); }
+    .verify-check.checked {
+      border-color: var(--trust);
+      background: linear-gradient(180deg, rgba(220, 252, 231, 0.4), rgba(220, 252, 231, 0.15));
+    }
+    .verify-check input { appearance: none; display: none; }
+    .verify-box {
+      width: 22px; height: 22px; border-radius: 6px;
+      border: 1.5px solid var(--c3); background: #fff; flex: 0 0 22px;
+      display: flex; align-items: center; justify-content: center;
+      transition: background .15s ease, border-color .15s ease;
+      margin-top: 1px;
+    }
+    .verify-check.checked .verify-box {
+      background: var(--trust); border-color: var(--trust);
+    }
+    .verify-box .tick {
+      color: #fff; font-size: 12px; line-height: 1; opacity: 0; transform: scale(0.7);
+      transition: opacity .15s ease, transform .15s ease;
+    }
+    .verify-check.checked .verify-box .tick { opacity: 1; transform: scale(1); }
+    .verify-text { flex: 1; display: flex; flex-direction: column; gap: 3px; }
+    .verify-headline { font-size: 13.5px; color: var(--ink0); font-weight: 500; letter-spacing: -0.01em; }
+    .verify-sub { font-size: 11.5px; color: var(--ink3); font-style: italic; line-height: 1.5; }
+
+    .info {
+      background: var(--accent-bg);
+      border: 1px solid var(--accent-mid);
+      border-radius: 9px; padding: 13px 16px;
+      font-size: 12px; color: var(--ink2); line-height: 1.55;
+      margin-top: 12px;
+    }
+
   }
 }

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -1087,7 +1087,6 @@ fn ScrContacts() -> Element {
     let ab_gen = use_context::<crate::app::AddressBookGen>();
     let mut search = use_signal(String::new);
 
-    let mut menu_selection = use_context::<Signal<menu::MenuSelection>>();
     let mut import_contact_form = use_context::<Signal<crate::app::login::ImportContact>>();
     let mut share_contact_form = use_context::<Signal<crate::app::login::ShareContact>>();
     let mut share_pending = use_context::<Signal<crate::app::login::SharePending>>();
@@ -1095,7 +1094,9 @@ fn ScrContacts() -> Element {
     let actions = use_coroutine_handle::<crate::app::NodeAction>();
 
     let on_import = move |_| {
-        menu_selection.write().close_settings();
+        // Leave Settings open underneath — the modal renders inside
+        // div.fm-app (app.rs) and is now styled in that scope, so it
+        // overlays the Contacts panel instead of dropping to the inbox.
         import_contact_form.write().0 = true;
     };
     let on_share = move |_| {
@@ -1113,7 +1114,6 @@ fn ScrContacts() -> Element {
                 share_text,
             }),
         });
-        menu_selection.write().close_settings();
         share_contact_form.write().0 = true;
     };
 

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -308,12 +308,12 @@ test.describe("Live node E2E", () => {
         .locator('input[placeholder="e.g. Alice (work)"]')
         .fill(ALIAS_T2_BOB);
       // Tick the "I verified these six words" checkbox so the contact
-      // is stored verified. `verify_on_send` defaults to true, so an
-      // unverified import silently rejects the send (toast: "Recipient
-      // is not verified") and bob never receives — root cause of the
-      // harness-only failure tracked in #105. Checkbox renders only
-      // after the import-time Get on bob's inbox returns vk + ek (#249).
-      // Allow 30s for the GetResponse on the iso harness.
+      // is stored verified. `verify_on_send` defaults to false, but we
+      // verify here so the send path is exercised independent of the
+      // privacy default — and so verified-only recipients still accept.
+      // Checkbox renders only after the import-time Get on bob's inbox
+      // returns vk + ek (#249). Allow 30s for the GetResponse on the
+      // iso harness.
       const verifyCheck = aliceApp.locator('[data-testid="fm-verify-check"]');
       await verifyCheck.waitFor({ timeout: 30_000 });
       await verifyCheck.click();
@@ -517,8 +517,8 @@ test.describe("Live node E2E", () => {
       await aliceApp
         .locator('input[placeholder="e.g. Alice (work)"]')
         .fill(ALIAS_T3_BOB);
-      // verify_on_send defaults true; tick checkbox so import is verified
-      // (#105 root cause: silent send rejection on unverified contact).
+      // verify_on_send defaults false; tick checkbox anyway so import is
+      // verified and the send path works regardless of the privacy default.
       const aliceVerify = aliceApp.locator('[data-testid="fm-verify-check"]');
       await aliceVerify.waitFor({ timeout: 30_000 });
       await aliceVerify.click();

--- a/ui/tests/repro-106-107.spec.ts
+++ b/ui/tests/repro-106-107.spec.ts
@@ -99,10 +99,10 @@ async function importContact(app: FrameLocator, card: string, label: string) {
     .locator('input[placeholder="e.g. Alice (work)"]')
     .fill(label);
   // Tick the "I verified these six words" checkbox so the imported
-  // contact is marked verified — `verify_on_send` defaults to true so
-  // an unverified import would silently drop the send (the compose
-  // veil stays up and no toast surfaces). The checkbox only renders
-  // once `fingerprint_words` resolves from the card; wait for it.
+  // contact is marked verified. `verify_on_send` defaults to false, but
+  // we verify here anyway so the flow is robust regardless of the
+  // privacy default. The checkbox only renders once `fingerprint_words`
+  // resolves from the card; wait for it.
   const verifyCheck = app.locator('[data-testid="fm-verify-check"]');
   await verifyCheck.waitFor({ timeout: 15_000 });
   await verifyCheck.click();


### PR DESCRIPTION
## What

Three related fixes to the Import / Share contact modals reachable from **Settings → Contacts** (the `.fm-app` scope).

### 1. Modals rendered unstyled in the inbox view
The modal markup uses `.field` / `.input` / `.textarea` / `.verify-words*` / `.token-block` / `.verify-check*` classes that only existed under `login.css` `@scope (.fm-pre)`. The Settings → Contacts render site lives under `@scope (.fm-app)`, where only `.veil` / `.modal-*` were mirrored — so labels rendered inline-left of inputs and the textarea overlapped its label.

**Fix:** mirror the missing form-field / verify / token rules into `settings.css`'s `.fm-app` block.

| Before | After |
|--------|-------|
| Labels collide with inputs, textarea overlaps label | Labels above full-width inputs, fingerprint grid + token block styled |

### 2. Opening a modal dropped to the inbox
`on_import` / `on_share` called `close_settings()` before opening the modal (from #97, predating the `.fm-app` modal CSS). Background reverted Settings → inbox. Removed it — modal now overlays the Contacts panel.

### 3. `verify_on_send` defaulted on
"Require known key to send" now defaults **off**. It was blocking sends to any not-yet-verified contact out of the box.

## Verification
- `cargo test -p mail-local-state` — 28/28 pass (default-flip assertion updated)
- UI wasm builds (`example-data,no-sync`)
- Manually drove the offline build: Import + Share modals styled correctly and overlay Settings; Privacy toggle confirmed off by default

Playwright spec comments + `docs/qa/manual-test-inventory.md` updated for the new default (specs still tick verify explicitly, so behavior unchanged).