### PR TITLE
feat(ui): build the Quarantine folder + count badge

### DIFF
--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -72,7 +72,7 @@ manual gap by adding a test, flip status to `auto` and link the test.
 | Detail header full timestamp | auto | offline: `detail header shows full timestamp` |
 | Detail verified badge (verif-known / verif-unknown / unverified) | auto | offline: `detail header shows verified badge for incoming message` |
 | Search filter | manual | Send 3 messages with distinct subjects, type substring in sidebar Search, only matching rows visible |
-| Quarantine unknown sender (privacy pref) | manual | Toggle in Settings → Privacy, send from unknown, confirm row hidden / quarantined |
+| Quarantine unknown sender | manual | Toggle in Settings → Inbox, send from unknown sender, confirm a Quarantine folder appears with a count badge and the row lands there (not Inbox); verified senders stay in Inbox |
 | Hide unsigned (privacy pref) | manual | Toggle, deliver pre-#51 message, confirm hidden |
 
 ### Compose / send
@@ -136,7 +136,7 @@ add/remove protocol.
 | Identity privacy: verify_on_send toggle | manual | Settings → Privacy, toggle, send to unverified contact, confirm send proceeds vs blocks |
 | Identity privacy: hide_unsigned toggle | manual | Toggle, observe Inbox |
 | Inbox: drafts_in_inbox toggle | manual | Settings → Inbox, toggle, observe Drafts surface in Inbox folder |
-| Inbox: quarantine_unknown toggle | manual | Toggle, observe Inbox filters unknown senders |
+| Inbox: quarantine_unknown toggle | manual | Settings → Inbox, toggle on → Quarantine folder + badge appear in sidebar, unknown-sender rows move there; toggle off → folder disappears, rows return to Inbox |
 | Auto-sign + signature persists | manual | Set, send, reload, send again, confirm sig still appended |
 | Appearance: theme switch (data-theme attr) | manual | Settings → Appearance, change theme, confirm `.fm-app[data-theme]` reflects |
 | Appearance: density (data-density attr) | manual | Change density, confirm `.fm-app[data-density]` reflects + row heights change |

--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -395,17 +395,18 @@ impl Default for AppearanceSettings {
 
 /// Inbox-folder settings (global). Govern UI grouping / quarantine behavior.
 ///
-/// Both fields default to `false`. `quarantine_unknown=true` would silently
-/// hide every unsigned/legacy inbound message until the user verifies the
-/// sender, which is hostile for first-run UX; users who want strict
-/// quarantine flip the toggle in Settings > Inbox.
+/// Both fields default to `false`. `quarantine_unknown=true` diverts every
+/// message from a sender not in the verified address book into a dedicated
+/// Quarantine folder (with its own sidebar entry + count badge) instead of
+/// the inbox. Defaulting it off keeps first-run UX friendly; users who want
+/// strict quarantine flip the toggle in Settings > Inbox.
 #[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Default)]
 pub struct InboxSettings {
     /// Show drafts inline in the inbox list rather than only in the
     /// Drafts folder.
     pub drafts_in_inbox: bool,
-    /// Move messages from senders not in the address book into a
-    /// quarantine folder instead of the inbox.
+    /// Move messages from senders not in the verified address book into a
+    /// dedicated Quarantine folder instead of the inbox.
     pub quarantine_unknown: bool,
 }
 

--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -10,6 +10,7 @@
   "fmDraftCard": "fm-draft-card",
   "fmSentCard": "fm-sent-card",
   "fmArchiveCard": "fm-archive-card",
+  "fmQuarantineCard": "fm-quarantine-card",
   "fmDetailTime": "fm-detail-time",
   "fmDetailFingerprint": "fm-detail-fingerprint",
   "fmDetailVerif": "fm-detail-verif",

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1043,6 +1043,7 @@ mod menu {
     pub(super) enum Folder {
         #[default]
         Inbox,
+        Quarantine,
         Sent,
         Drafts,
         Archive,
@@ -1052,6 +1053,7 @@ mod menu {
         pub fn label(self) -> &'static str {
             match self {
                 Folder::Inbox => "Inbox",
+                Folder::Quarantine => "Quarantine",
                 Folder::Sent => "Sent",
                 Folder::Drafts => "Drafts",
                 Folder::Archive => "Archive",
@@ -1061,6 +1063,7 @@ mod menu {
         pub fn icon(self) -> &'static str {
             match self {
                 Folder::Inbox => "▤",
+                Folder::Quarantine => "⚠",
                 Folder::Sent => "↗",
                 Folder::Drafts => "✎",
                 Folder::Archive => "▦",
@@ -1250,9 +1253,38 @@ thread_local! {
     static DELAYED_ACTIONS: RefCell<Vec<LocalBoxFuture<'static, ()>>> = RefCell::new(Vec::new());
 }
 
+/// True when `m`'s sender is in the address book AND verified. Drives the
+/// Inbox/Quarantine split: when `quarantine_unknown` is on, only senders for
+/// which this returns true stay in the Inbox; everyone else (including
+/// signature-less rows) lands in Quarantine. Empty sender-vk never counts as
+/// known.
+fn is_sender_verified(m: &Message) -> bool {
+    if m.sender_vk.is_empty() {
+        return false;
+    }
+    matches!(
+        address_book::contact_by_vk(&m.sender_vk),
+        Some(c) if c.verified
+    )
+}
+
 fn folder_count(emails: &[Message], folder: menu::Folder, alias: &str) -> usize {
+    // Only split Inbox/Quarantine counts when the user opted in; otherwise the
+    // Quarantine folder is hidden and every row is an Inbox row.
+    let quarantine_on = crate::local_state::global_settings()
+        .inbox
+        .quarantine_unknown;
     match folder {
-        menu::Folder::Inbox => emails.iter().filter(|m| !m.read).count(),
+        menu::Folder::Inbox => emails
+            .iter()
+            .filter(|m| !m.read)
+            .filter(|m| !quarantine_on || is_sender_verified(m))
+            .count(),
+        menu::Folder::Quarantine => emails
+            .iter()
+            .filter(|m| !m.read)
+            .filter(|m| quarantine_on && !is_sender_verified(m))
+            .count(),
         menu::Folder::Drafts => crate::local_state::drafts_for(alias).len(),
         menu::Folder::Sent => crate::local_state::sent_for(alias).len(),
         menu::Folder::Archive => crate::local_state::archived_for(alias).len(),
@@ -1430,7 +1462,27 @@ fn Sidebar() -> Element {
             div { class: "sect-label", "Folders" }
             div { class: "nav",
                 {
-                    [menu::Folder::Inbox, menu::Folder::Sent, menu::Folder::Drafts, menu::Folder::Archive]
+                    // Quarantine only appears once the user opts in via
+                    // Settings > Inbox; until then there's no quarantine concept
+                    // so an empty folder would just confuse.
+                    let quarantine_on = crate::local_state::global_settings().inbox.quarantine_unknown;
+                    let folders: Vec<menu::Folder> = if quarantine_on {
+                        vec![
+                            menu::Folder::Inbox,
+                            menu::Folder::Quarantine,
+                            menu::Folder::Sent,
+                            menu::Folder::Drafts,
+                            menu::Folder::Archive,
+                        ]
+                    } else {
+                        vec![
+                            menu::Folder::Inbox,
+                            menu::Folder::Sent,
+                            menu::Folder::Drafts,
+                            menu::Folder::Archive,
+                        ]
+                    };
+                    folders
                         .into_iter()
                         .map(|f| {
                             let cls = if f == active { "nav-item active" } else { "nav-item" };
@@ -1576,7 +1628,11 @@ fn MessageList() -> Element {
         .unwrap_or_default();
     let inbox_settings = crate::local_state::global_settings().inbox;
     let privacy_prefs = crate::local_state::identity_settings_for(&active_alias).privacy;
-    let visible: Vec<Message> = if matches!(folder, menu::Folder::Inbox) {
+    // Inbox and Quarantine share every filter except the verified-sender
+    // split, so build the common candidate set once and partition by
+    // `is_sender_verified` only when the user opted into quarantine.
+    let visible: Vec<Message> = if matches!(folder, menu::Folder::Inbox | menu::Folder::Quarantine)
+    {
         let mut v: Vec<Message> = emails
             .iter()
             // Hide archived/deleted rows. In offline mode the populate loop
@@ -1595,21 +1651,19 @@ fn MessageList() -> Element {
                 }
                 m.signature_valid && !m.sender_vk.is_empty()
             })
-            // GlobalSettings.inbox.quarantine_unknown: when set, hide rows
-            // from senders not in the verified address book. Until a
-            // dedicated Quarantine folder ships, "hide" is the safe
-            // interpretation — visible drops, count drops, no surface.
+            // GlobalSettings.inbox.quarantine_unknown split: when off, every
+            // surviving row is an Inbox row (Quarantine folder is hidden).
+            // When on, verified senders stay in Inbox and everyone else is
+            // diverted to Quarantine.
             .filter(|m| {
                 if !inbox_settings.quarantine_unknown {
-                    return true;
+                    return matches!(folder, menu::Folder::Inbox);
                 }
-                if m.sender_vk.is_empty() {
-                    return false;
+                if matches!(folder, menu::Folder::Quarantine) {
+                    !is_sender_verified(m)
+                } else {
+                    is_sender_verified(m)
                 }
-                matches!(
-                    address_book::contact_by_vk(&m.sender_vk),
-                    Some(c) if c.verified
-                )
             })
             .cloned()
             .collect();
@@ -1840,7 +1894,13 @@ fn MessageList() -> Element {
                         }
                     }
                     {
-                        visible.into_iter().map(|email| {
+                        let in_quarantine = matches!(folder, menu::Folder::Quarantine);
+                        let card_testid = if in_quarantine {
+                            testid::FM_QUARANTINE_CARD
+                        } else {
+                            testid::FM_MSG_CARD
+                        };
+                        visible.into_iter().map(move |email| {
                             let id = email.id;
                             let mut classes = String::from("msg-card");
                             if !email.read { classes.push_str(" unread"); }
@@ -1853,11 +1913,14 @@ fn MessageList() -> Element {
                                 article {
                                     class: "{classes}",
                                     id: "email-inbox-accessor-{id}",
-                                    "data-testid": testid::FM_MSG_CARD,
+                                    "data-testid": "{card_testid}",
                                     "data-msg-id": "{id}",
                                     onclick: move |_| { menu_selection.write().open_email(id); },
                                     div { class: "msg-row1",
                                         span { class: "msg-sender", "{from}" }
+                                        if in_quarantine {
+                                            span { class: "badge badge-failed", "unverified" }
+                                        }
                                         span {
                                             class: "msg-time",
                                             "data-testid": testid::FM_MSG_TIME,
@@ -1890,15 +1953,22 @@ fn DetailPanel() -> Element {
     let selected = selected_id.and_then(|id| emails.iter().find(|m| m.id == id).cloned());
     let _local_gen = crate::local_state::GENERATION();
 
-    if matches!(folder, menu::Folder::Inbox) {
+    // Quarantine rows are ordinary inbox Messages keyed by id, so they open
+    // through the same OpenMessage path as the Inbox.
+    if matches!(folder, menu::Folder::Inbox | menu::Folder::Quarantine) {
         if let Some(msg) = selected {
             rsx! { OpenMessage { msg } }
         } else {
+            let hint = if matches!(folder, menu::Folder::Quarantine) {
+                "Select a quarantined message"
+            } else {
+                "Select a message"
+            };
             rsx! {
                 section { class: "detail-col",
                     div { class: "empty",
                         div { class: "empty-glyph", "✉" }
-                        div { class: "empty-hint", "Select a message" }
+                        div { class: "empty-hint", "{hint}" }
                     }
                 }
             }
@@ -3295,6 +3365,43 @@ mod kept_to_message_tests {
             msg.verification_state(),
             VerificationState::Unverified
         ));
+    }
+}
+
+#[cfg(test)]
+mod quarantine_tests {
+    use super::{Message, is_sender_verified};
+    use chrono::Utc;
+    use std::borrow::Cow;
+
+    fn msg_with_vk(vk: Vec<u8>) -> Message {
+        Message {
+            id: 0,
+            from: Cow::Borrowed("someone"),
+            title: Cow::Borrowed("hi"),
+            content: Cow::Borrowed("body"),
+            read: false,
+            time: Utc::now(),
+            sender_vk: vk,
+            signature_valid: true,
+            assignment_hash: [0u8; 32],
+        }
+    }
+
+    /// An empty sender-vk (legacy / unsigned) is never a known sender, so it
+    /// is diverted to Quarantine when the toggle is on. This is the case the
+    /// offline example messages exercise — they all carry an empty vk.
+    #[test]
+    fn empty_vk_is_unverified() {
+        assert!(!is_sender_verified(&msg_with_vk(Vec::new())));
+    }
+
+    /// A vk that isn't in the (empty, in this test) address book is unknown,
+    /// so even a cryptographically-valid signature lands in Quarantine until
+    /// the user verifies the contact.
+    #[test]
+    fn unknown_vk_is_unverified() {
+        assert!(!is_sender_verified(&msg_with_vk(vec![1, 2, 3, 4])));
     }
 }
 

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -576,7 +576,7 @@ fn ScrPrivacy() -> Element {
                 }
                 SettingRow {
                     label: "Hide unsigned messages",
-                    help: "Move messages with no ML-DSA signature directly to a quarantine folder.",
+                    help: "Drop messages with no valid ML-DSA signature from the list entirely. For unknown-but-signed senders, use Quarantine in Inbox settings instead.",
                     control: rsx! { Toggle { on: hide_unsigned, ontoggle: on_hide_unsigned } },
                 }
             }

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -30,6 +30,7 @@ pub(crate) const FM_MSG_TIME: &str = "fm-msg-time";
 pub(crate) const FM_DRAFT_CARD: &str = "fm-draft-card";
 pub(crate) const FM_SENT_CARD: &str = "fm-sent-card";
 pub(crate) const FM_ARCHIVE_CARD: &str = "fm-archive-card";
+pub(crate) const FM_QUARANTINE_CARD: &str = "fm-quarantine-card";
 
 // Detail header
 pub(crate) const FM_DETAIL_TIME: &str = "fm-detail-time";
@@ -144,6 +145,7 @@ mod tests {
             ("fmDraftCard", super::FM_DRAFT_CARD),
             ("fmSentCard", super::FM_SENT_CARD),
             ("fmArchiveCard", super::FM_ARCHIVE_CARD),
+            ("fmQuarantineCard", super::FM_QUARANTINE_CARD),
             ("fmDetailTime", super::FM_DETAIL_TIME),
             ("fmDetailFingerprint", super::FM_DETAIL_FINGERPRINT),
             ("fmDetailVerif", super::FM_DETAIL_VERIF),

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -149,6 +149,58 @@ test.describe("Inbox view", () => {
   });
 });
 
+test.describe("Quarantine folder", () => {
+  // Helper: open Settings → Inbox and flip the quarantine toggle.
+  async function toggleQuarantine(page: Page) {
+    await page.locator('[data-testid="fm-settings-btn"]').click();
+    await page
+      .locator('[data-testid="fm-settings-shell"]')
+      .waitFor({ timeout: 5_000 });
+    await page.locator('[data-testid="fm-settings-nav-item"][data-screen="inbox"]').click();
+    // The quarantine row owns the only "unknown keys" label on this screen.
+    const row = page
+      .locator(".fm-row-set", { hasText: "Hold messages with unknown keys" });
+    await row.locator('[role="switch"]').click();
+    // Back out to the mailbox.
+    await page.locator('[data-testid="fm-settings-back"]').click();
+    await page.locator('[data-testid="fm-app"]').waitFor({ timeout: 5_000 });
+  }
+
+  test("hidden until enabled, then diverts unknown senders with a badge", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    // Off by default: no Quarantine folder in the sidebar, and the example
+    // (unknown-sender) messages all live in the Inbox.
+    await expect(
+      page.locator('[data-testid="fm-folder-quarantine"]'),
+    ).toHaveCount(0);
+    await expect(page.getByText("Lunch tomorrow?")).toBeVisible();
+
+    await toggleQuarantine(page);
+
+    // Quarantine folder now appears with a count badge (2 unread of the 3
+    // seeded example messages — "Your weekly digest" is pre-read).
+    const quarantineBtn = page.locator('[data-testid="fm-folder-quarantine"]');
+    await expect(quarantineBtn).toBeVisible();
+    await expect(quarantineBtn.locator(".count")).toHaveText("2");
+
+    // Inbox is now empty — every example sender is unknown.
+    await page.locator('[data-testid="fm-folder-inbox"]').click();
+    await expect(page.getByText("Lunch tomorrow?")).toHaveCount(0);
+
+    // The diverted rows render in Quarantine with an `unverified` badge.
+    await quarantineBtn.click();
+    const cards = page.locator('[data-testid="fm-quarantine-card"]');
+    await expect(cards).toHaveCount(3);
+    await expect(page.getByText("Lunch tomorrow?")).toBeVisible();
+    await expect(cards.first().locator(".badge")).toContainText("unverified");
+  });
+});
+
 test.describe("Compose and logout", () => {
   test("compose sheet renders and log out returns to identity list", async ({
     page,


### PR DESCRIPTION
## What

The `quarantine_unknown` toggle previously only **hid** messages from senders not in the verified address book — no folder, no surface. The Settings copy promised a "Quarantine folder ... count badge" that never existed.

This wires up the real folder.

## Changes

- **`Folder::Quarantine`** (⚠) appears in the sidebar **only when the toggle is on**, with the existing per-folder count badge (unread count).
- **`is_sender_verified()`** — shared predicate that partitions the inbox candidate set: verified senders stay in Inbox, everyone else (including unsigned / empty-vk rows) is diverted to Quarantine. Toggle off → every row is an Inbox row, folder hidden.
- Quarantine rows reuse the Inbox `OpenMessage` detail path and carry an `unverified` badge so the diversion reason is visible.
- Settings help text now matches reality; the `hide_unsigned` row no longer falsely claims it moves messages to a quarantine folder (it drops them).
- `folder_count` excludes quarantined rows from the Inbox unread count when the toggle is on.

Verifying a quarantined sender in the address book moves their messages back to the Inbox automatically (live re-eval of `is_sender_verified`).

## Tests

- `quarantine_tests` unit module pins the empty-vk and unknown-vk cases.
- Playwright test: toggle-off (hidden) → toggle-on (folder + badge "2" + Inbox empties + 3 quarantine cards with the `unverified` badge).
- Full offline suite: **114 passed / 0 failed** (16 skipped — firefox/webkit not installed locally).
- `cargo clippy` clean; testid drift-guard + `mail-local-state` tests pass.

## QA inventory

Updated the two stale rows describing the old hide-only behavior.