### PR TITLE
feat(ui): add sender to contacts from mail (#272) + send-side AFT bypass for verified contacts (#273)

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -175,7 +175,7 @@ pub(crate) fn app() -> Element {
     // These context providers are still here so both subtrees share the
     // same signal instances.
     use_context_provider(|| Signal::new(login::ImportBackup(false)));
-    use_context_provider(|| Signal::new(login::ImportContact(false)));
+    use_context_provider(|| Signal::new(login::ImportContact::default()));
     use_context_provider(|| Signal::new(login::ShareContact(false)));
     use_context_provider(|| Signal::new(login::SharePending::default()));
 
@@ -1383,7 +1383,7 @@ fn UserInbox() -> Element {
             if share_contact.read().0 {
                 login::ShareContactModal {}
             }
-            if import_contact.read().0 {
+            if import_contact.read().open {
                 login::ImportContactForm {}
             }
         }
@@ -2279,6 +2279,7 @@ fn OpenMessage(msg: Message) -> Element {
     let mut inbox = use_context::<Signal<InboxView>>();
     let inbox_data = use_context::<InboxesData>();
     let user = use_context::<Signal<User>>();
+    let mut import_contact = use_context::<Signal<crate::app::login::ImportContact>>();
     let email_id = [msg.id];
 
     let result = inbox
@@ -2373,6 +2374,7 @@ fn OpenMessage(msg: Message) -> Element {
         verification,
         crate::inbox::VerificationState::VerifiedUnknown
     );
+    let add_to_ab_vk = msg.sender_vk.clone();
 
     let archive_client = client.clone();
     let archive_inbox_data = inbox_data;
@@ -2426,15 +2428,24 @@ fn OpenMessage(msg: Message) -> Element {
                         class: "btn btn-secondary",
                         "data-testid": testid::FM_ADD_TO_AB,
                         onclick: move |_| {
-                            // Stub: opens the existing address-book import
-                            // modal. Pre-filling it with this sender's VK
-                            // is a follow-up — the affordance is wired now
-                            // so the verified-unknown flow has a path
-                            // (#51).
-                            crate::toast::push_toast(
-                                "Open the address book to add this sender",
-                                crate::toast::ToastLevel::Info,
-                            );
+                            // #272: derive the sender's bs58 inbox address
+                            // from the message's `sender_vk` and open the
+                            // import modal pre-seeded with it. The modal's
+                            // effect runs the same parse + `FetchContactKeys`
+                            // it would for a manual paste, so the contact's
+                            // ML-KEM ek + tier policy are pulled live.
+                            match crate::inbox::inbox_address_bs58_from_vk_bytes(&add_to_ab_vk) {
+                                Ok(addr) => {
+                                    *import_contact.write() =
+                                        crate::app::login::ImportContact::opened_with(addr);
+                                }
+                                Err(e) => {
+                                    crate::toast::push_toast(
+                                        format!("Could not derive sender address: {e}"),
+                                        crate::toast::ToastLevel::Error,
+                                    );
+                                }
+                            }
                         },
                         "Add to address book"
                     }

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -770,7 +770,31 @@ pub(crate) struct SharePendingData {
     pub(crate) share_text: String,
 }
 
-pub(crate) struct ImportContact(pub(crate) bool);
+/// Controls the Import-contact modal. `open` toggles visibility;
+/// `prefill` carries an inbox address (bs58) to seed the paste field
+/// when the modal is opened from a known sender — e.g. "Add to address
+/// book" on a received message (#272). `None` prefill = manual paste.
+#[derive(Clone, Default)]
+pub(crate) struct ImportContact {
+    pub(crate) open: bool,
+    pub(crate) prefill: Option<String>,
+}
+
+impl ImportContact {
+    pub(crate) fn opened() -> Self {
+        Self {
+            open: true,
+            prefill: None,
+        }
+    }
+
+    pub(crate) fn opened_with(address: String) -> Self {
+        Self {
+            open: true,
+            prefill: Some(address),
+        }
+    }
+}
 
 /// Carries the `Contact` whose verified flag the user is about to flip.
 /// `None` while the modal is closed; populated by the row-level Verify
@@ -835,7 +859,7 @@ pub(super) fn IdentifiersList() -> Element {
             if share_contact.read().0 {
                 ShareContactModal {}
             }
-            if import_contact.read().0 {
+            if import_contact.read().open {
                 ImportContactForm {}
             }
         }
@@ -1990,8 +2014,11 @@ pub(super) fn ImportContactForm() -> Element {
         }
     });
 
-    let on_paste_change = move |evt: dioxus::prelude::Event<dioxus::html::FormData>| {
-        let text = evt.value().clone();
+    // Parse a pasted (or prefilled) inbox-address blob and kick off the
+    // key fetch. Factored out of the textarea handler so the #272
+    // "Add to address book" prefill path can reuse the exact same parse +
+    // fetch logic without synthesising a DOM event.
+    let mut apply_address = move |text: String| {
         paste_text.set(text.clone());
         error_msg.set(String::new());
         fingerprint_words.set(None);
@@ -2093,6 +2120,19 @@ pub(super) fn ImportContactForm() -> Element {
         }
     };
 
+    // #272: when the modal is opened from "Add to address book" on a
+    // received message, the sender's inbox address is handed over via
+    // `ImportContact.prefill`. Seed the paste field and trigger the key
+    // fetch exactly once, then clear the prefill so a later manual edit
+    // (or a re-render) doesn't clobber the user's typing.
+    use_effect(move || {
+        let prefill = import_contact_form.read().prefill.clone();
+        if let Some(addr) = prefill {
+            apply_address(addr);
+            import_contact_form.write().prefill = None;
+        }
+    });
+
     // Soft warning when the sender included a verify phrase but the user
     // hasn't ticked the box. Verified-only inboxes (settings.rs:1434)
     // will reject sends until the user ticks it once they've matched the
@@ -2109,7 +2149,7 @@ pub(super) fn ImportContactForm() -> Element {
         if let Some(addr) = pending_address.read().clone() {
             crate::api::contact_import::cancel(&addr);
         }
-        import_contact_form.write().0 = false;
+        *import_contact_form.write() = ImportContact::default();
         error_msg.set(String::new());
     };
     let verify_check_class = if *verified.read() {
@@ -2125,7 +2165,7 @@ pub(super) fn ImportContactForm() -> Element {
                 if let Some(addr) = pending_address.read().clone() {
                     crate::api::contact_import::cancel(&addr);
                 }
-                import_contact_form.write().0 = false;
+                *import_contact_form.write() = ImportContact::default();
                 error_msg.set(String::new());
             },
             div { class: "modal",
@@ -2146,7 +2186,9 @@ pub(super) fn ImportContactForm() -> Element {
                             placeholder: "e.g. EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr",
                             rows: "3",
                             value: "{paste_text}",
-                            oninput: on_paste_change,
+                            oninput: move |evt: dioxus::prelude::Event<dioxus::html::FormData>| {
+                                apply_address(evt.value());
+                            },
                         }
                     }
                     if *fetching.read() {
@@ -2261,7 +2303,7 @@ pub(super) fn ImportContactForm() -> Element {
                             if let Some(addr) = pending_address.read().clone() {
                                 crate::api::contact_import::cancel(&addr);
                             }
-                            import_contact_form.write().0 = false;
+                            *import_contact_form.write() = ImportContact::default();
                             paste_text.set(String::new());
                             local_alias.set(String::new());
                             description.set(String::new());
@@ -2400,7 +2442,7 @@ fn ContactsSection() -> Element {
             button {
                 class: "btn btn-secondary",
                 "data-testid": testid::FM_CONTACT_IMPORT,
-                onclick: move |_| { import_contact_form.write().0 = true; },
+                onclick: move |_| { *import_contact_form.write() = ImportContact::opened(); },
                 "+ Import contact"
             }
         }

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -1097,7 +1097,7 @@ fn ScrContacts() -> Element {
         // Leave Settings open underneath — the modal renders inside
         // div.fm-app (app.rs) and is now styled in that scope, so it
         // overlays the Contacts panel instead of dropping to the inbox.
-        import_contact_form.write().0 = true;
+        *import_contact_form.write() = crate::app::login::ImportContact::opened();
     };
     let on_share = move |_| {
         let Some(active) = user.read().logged_id().cloned() else {

--- a/ui/src/contact_tier_cache.rs
+++ b/ui/src/contact_tier_cache.rs
@@ -13,7 +13,7 @@
 //!
 //! Cache is in-memory only: a reload re-primes via `set_aliases` →
 //! Get-with-subscribe for every contact.
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::{LazyLock, RwLock};
 
 use chrono::{DateTime, Utc};
@@ -21,14 +21,31 @@ use freenet_aft_interface::Tier;
 use freenet_email_inbox::InboxSettings;
 use freenet_stdlib::prelude::ContractKey;
 
-/// Minimum policy fields the sender needs from the recipient's live
-/// `InboxSettings`. Skips `verified_senders` / `allow_verified_skip_token`
-/// — those affect the bypass path which goes through the contract's own
-/// state read, not the sender.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Policy fields the sender needs from the recipient's live
+/// `InboxSettings`. Besides the tier/max-age the sender mints against,
+/// this now mirrors the verified-sender bypass state (#273): when the
+/// recipient has `allow_verified_skip_token` on and the sender's ML-DSA
+/// VK is in `verified_senders`, the sender skips minting an AFT token
+/// entirely. The sender can only safely skip when it has *observed* the
+/// recipient's live settings — a cache miss falls back to minting a
+/// token, so a stale/absent observation never silently drops a message.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecipientPolicy {
     pub minimum_tier: Tier,
     pub max_age_secs: u64,
+    pub allow_verified_skip_token: bool,
+    pub verified_senders: BTreeSet<Vec<u8>>,
+}
+
+impl RecipientPolicy {
+    /// Whether a sender holding `sender_vk` may skip the AFT token for
+    /// this recipient: the recipient must have the bypass enabled and
+    /// have whitelisted this exact VK on-chain.
+    pub fn allows_token_skip_for(&self, sender_vk: &[u8]) -> bool {
+        self.allow_verified_skip_token
+            && !sender_vk.is_empty()
+            && self.verified_senders.contains(sender_vk)
+    }
 }
 
 /// Internal cache entry: `RecipientPolicy` plus the `last_update`
@@ -36,7 +53,7 @@ pub struct RecipientPolicy {
 /// (`record_with_last_update` ignores incoming snapshots whose
 /// `last_update` is older than what we already have, mirroring the
 /// contract-level last-write-wins in `Inbox::merge`).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct CacheEntry {
     policy: RecipientPolicy,
     last_update: DateTime<Utc>,
@@ -62,24 +79,33 @@ pub fn record_with_last_update(
         policy: RecipientPolicy {
             minimum_tier: settings.minimum_tier,
             max_age_secs: settings.max_age_secs,
+            allow_verified_skip_token: settings.allow_verified_skip_token,
+            verified_senders: settings.verified_senders.clone(),
         },
         last_update,
     };
     let mut guard = CACHE.write().expect("contact tier cache poisoned");
-    let existing = guard.get(&key).copied();
+    let existing = guard.get(&key).cloned();
     match existing {
-        Some(prev) if prev.last_update > entry.last_update => {
+        Some(ref prev) if prev.last_update > entry.last_update => {
             // Stale; ignore.
             return;
         }
         _ => {}
     }
     let prev_policy = existing.map(|e| e.policy);
+    let changed = prev_policy.as_ref() != Some(&entry.policy);
+    let (tier, max_age, bypass, n_verified) = (
+        entry.policy.minimum_tier,
+        entry.policy.max_age_secs,
+        entry.policy.allow_verified_skip_token,
+        entry.policy.verified_senders.len(),
+    );
     guard.insert(key, entry);
-    if prev_policy != Some(entry.policy) {
+    if changed {
         crate::log::info(format!(
-            "contact tier cache: recorded {key} tier={:?} max_age_secs={} (#221)",
-            entry.policy.minimum_tier, entry.policy.max_age_secs
+            "contact tier cache: recorded {key} tier={tier:?} max_age_secs={max_age} \
+             allow_verified_skip_token={bypass} verified_senders={n_verified} (#221/#273)"
         ));
     }
 }
@@ -100,7 +126,7 @@ pub fn lookup(key: &ContractKey) -> Option<RecipientPolicy> {
         .read()
         .expect("contact tier cache poisoned")
         .get(key)
-        .map(|e| e.policy)
+        .map(|e| e.policy.clone())
 }
 
 #[cfg(test)]
@@ -130,6 +156,42 @@ mod tests {
             verified_senders: BTreeSet::new(),
             private: Vec::new(),
         }
+    }
+
+    fn settings_bypass(verified: &[&[u8]]) -> InboxSettings {
+        InboxSettings {
+            minimum_tier: Tier::Min1,
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
+            allow_verified_skip_token: true,
+            verified_senders: verified.iter().map(|v| v.to_vec()).collect(),
+            private: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn bypass_fields_round_trip_and_gate_skip() {
+        let key = dummy_key(4);
+        record(key, &settings_bypass(&[b"vk-alice"]));
+        let p = lookup(&key).expect("cache hit");
+        assert!(p.allow_verified_skip_token);
+        // Whitelisted VK may skip.
+        assert!(p.allows_token_skip_for(b"vk-alice"));
+        // Non-whitelisted VK may not.
+        assert!(!p.allows_token_skip_for(b"vk-bob"));
+        // Empty VK never skips (matches the contract's `!sender_vk.is_empty()`).
+        assert!(!p.allows_token_skip_for(b""));
+    }
+
+    #[test]
+    fn bypass_off_never_skips_even_if_whitelisted() {
+        let key = dummy_key(5);
+        // minimum_tier path with bypass OFF but a populated set should
+        // still refuse to skip — `allow_verified_skip_token` is the master.
+        let mut s = settings_bypass(&[b"vk-alice"]);
+        s.allow_verified_skip_token = false;
+        record(key, &s);
+        let p = lookup(&key).expect("cache hit");
+        assert!(!p.allows_token_skip_for(b"vk-alice"));
     }
 
     // NOTE: these tests share a process-global `CACHE` (LazyLock). Each

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -180,6 +180,24 @@ pub(crate) fn verify_message_signature(
     MlDsaVerifier::verify(&vk, ciphertext, &sig).is_ok()
 }
 
+/// Derive the bs58 inbox-contract address for a sender from their raw
+/// ML-DSA-65 verifying-key bytes (as carried on a received message's
+/// `sender_vk`). Used by the #272 "Add to address book" flow to seed the
+/// import modal — the address is enough to trigger the live
+/// `FetchContactKeys` Get that pulls the rest of the contact's keys.
+///
+/// Derives against the sender's embedded `INBOX_CODE_HASH`; a received
+/// message carries no recipient-side hash, and the import fetch resolves
+/// the real keys regardless.
+pub(crate) fn inbox_address_bs58_from_vk_bytes(sender_vk: &[u8]) -> Result<String, DynError> {
+    let encoded_vk: EncodedVerifyingKey<MlDsa65> = sender_vk
+        .try_into()
+        .map_err(|_| "sender VK wrong length")?;
+    let vk = MlDsaVerifyingKey::<MlDsa65>::decode(&encoded_vk);
+    let key = inbox_key_for(&vk)?;
+    Ok(key.id().encode())
+}
+
 thread_local! {
     static PENDING_INBOXES_UPDATE: RefCell<HashMap<InboxContract, Vec<PendingOutgoing>>> = RefCell::new(HashMap::new());
     static INBOX_TO_ID: RefCell<HashMap<InboxContract, Identity>> =
@@ -554,9 +572,37 @@ impl DecryptedMessage {
         // the sender's `INBOX_CODE_HASH` for own-identity sends and
         // for contacts imported before the field shipped.
         let code_hash = recipient_inbox_wasm_hash.unwrap_or(INBOX_CODE_HASH);
+        let params: freenet_stdlib::prelude::Parameters = InboxParams {
+            pub_key: inbox_pub_key_bytes.clone(),
+        }
+        .try_into()
+        .map_err(|e| format!("{e}"))?;
+        let inbox_key = ContractKey::from_params(code_hash, params).map_err(|e| format!("{e}"))?;
+
+        // #273: verified-sender bypass. When the recipient has the bypass
+        // enabled on-chain AND has whitelisted our ML-DSA VK in
+        // `verified_senders`, we may deliver this message without minting
+        // an AFT token. We only take this path when we have *observed* the
+        // recipient's live `InboxSettings` (cache hit) — a miss falls
+        // through to the normal token mint so a stale/absent observation
+        // can never silently drop the message at the recipient's contract.
+        let sender_vk = from.ml_dsa_vk_bytes();
+        let can_skip_token = crate::contact_tier_cache::lookup(&inbox_key)
+            .is_some_and(|p| p.allows_token_skip_for(&sender_vk));
+        if can_skip_token {
+            crate::log::info(format!(
+                "send.start_sending: verified-sender bypass active, skipping AFT token \
+                 from=`{}` inbox_key={inbox_key} (#273)",
+                from.alias()
+            ));
+            return self
+                .finish_sending_bypass(client, inbox_key, hash, from)
+                .await;
+        }
+
         let delegate_key = AftRecords::assign_token(
             client,
-            inbox_pub_key_bytes.clone(),
+            inbox_pub_key_bytes,
             recipient_required_tier,
             recipient_max_age_secs,
             recipient_inbox_wasm_hash,
@@ -564,12 +610,6 @@ impl DecryptedMessage {
             hash,
         )
         .await?;
-        let params = InboxParams {
-            pub_key: inbox_pub_key_bytes,
-        }
-        .try_into()
-        .map_err(|e| format!("{e}"))?;
-        let inbox_key = ContractKey::from_params(code_hash, params).map_err(|e| format!("{e}"))?;
         crate::log::info(format!(
             "send.start_sending: token requested, awaiting AFT delegate response from=`{}` inbox_key={inbox_key} (release-visible diagnostic for #174)",
             from.alias()
@@ -586,6 +626,47 @@ impl DecryptedMessage {
                 });
         });
         let _ = recipient_ek; // ek is used inside to_stored via pending queue
+        Ok(())
+    }
+
+    /// #273 verified-sender bypass send path. Used when `start_sending`
+    /// determined (from the recipient's observed `InboxSettings`) that
+    /// this sender may deliver without an AFT token. Builds a placeholder
+    /// `TokenAssignment` — the recipient's inbox contract skips all
+    /// token-assignment validation for verified senders
+    /// (`add_message`/`verify_token_policy` short-circuit on the
+    /// `verified_senders` allow-list, see `contracts/inbox/src/lib.rs`),
+    /// so only the `assignment_hash` is load-bearing: it must equal the
+    /// real message hash because the inbox keys + dedupes messages by it.
+    ///
+    /// The delta is sent as a bare `UpdateData::Delta` — there is no AFT
+    /// allocation record to bundle as `RelatedStateAndDelta`, and the
+    /// contract never fetches one for a bypassed message.
+    async fn finish_sending_bypass(
+        self,
+        client: &mut WebApiRequestClient,
+        inbox_key: ContractKey,
+        hash: TokenAssignmentHash,
+        from: &Identity,
+    ) -> Result<(), DynError> {
+        let placeholder = TokenAssignment {
+            tier: Tier::Min1,
+            time_slot: Utc::now(),
+            generator: Vec::new(),
+            signature: Vec::new(),
+            assignment_hash: hash,
+            token_record: *inbox_key.id(),
+        };
+        let stored = self.to_stored(placeholder, from)?;
+        let delta = UpdateInbox::AddMessages {
+            messages: vec![stored],
+        };
+        let delta_bytes = serde_json::to_vec(&delta)?;
+        let request = ContractRequest::Update {
+            key: inbox_key,
+            data: UpdateData::Delta(delta_bytes.into()),
+        };
+        client.send(request.into()).await?;
         Ok(())
     }
 

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -190,9 +190,8 @@ pub(crate) fn verify_message_signature(
 /// message carries no recipient-side hash, and the import fetch resolves
 /// the real keys regardless.
 pub(crate) fn inbox_address_bs58_from_vk_bytes(sender_vk: &[u8]) -> Result<String, DynError> {
-    let encoded_vk: EncodedVerifyingKey<MlDsa65> = sender_vk
-        .try_into()
-        .map_err(|_| "sender VK wrong length")?;
+    let encoded_vk: EncodedVerifyingKey<MlDsa65> =
+        sender_vk.try_into().map_err(|_| "sender VK wrong length")?;
     let vk = MlDsaVerifyingKey::<MlDsa65>::decode(&encoded_vk);
     let key = inbox_key_for(&vk)?;
     Ok(key.id().encode())

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -1117,7 +1117,9 @@ test.describe("Live node E2E", () => {
         }
         if (
           label === "alice" &&
-          /contact tier cache: recorded .+ tier=Min1 .+ \(#221\)/.test(t)
+          /contact tier cache: recorded .+ tier=Min1 .+ \(#221(?:\/#273)?\)/.test(
+            t,
+          )
         ) {
           cacheRecordedMin1 = true;
         }


### PR DESCRIPTION
## Summary

- **#272 — Add sender to contacts from a received mail.** The "Add to address book" action on a received message now derives the sender's bs58 inbox address from `sender_vk` (`inbox::inbox_address_bs58_from_vk_bytes`) and opens the import modal pre-seeded with it. The modal runs the same parse + `FetchContactKeys` it would for a manual paste, so the contact's ML-KEM ek + tier policy are pulled live. `ImportContact` context extended from `(bool)` → `{ open, prefill: Option<String> }`.
- **#273 — Send-side AFT bypass for verified contacts.** Recipient-side management (toggle + `verified_senders` sync on create/delete/verify) already shipped in #150/#157; the missing piece was the sender actually skipping the token. `start_sending` now consults the contact-tier cache: on a hit where the recipient has `allow_verified_skip_token` on **and** the sender's ML-DSA VK is in their `verified_senders`, it skips `assign_token` and sends a bare `AddMessages` delta via `finish_sending_bypass` (placeholder token assignment carrying the real message hash for inbox dedup). **Fetch-first by cache:** a cache miss falls back to minting a token, so a stale/absent observation can never silently drop a message at the recipient's contract.

## Design notes

- The contact-tier cache (`RecipientPolicy`) now mirrors the recipient's bypass state, fed automatically from observed `InboxSettings` on GetResponse / UpdateNotification / ModifySettings. New `RecipientPolicy::allows_token_skip_for(vk)` gates the skip (master toggle + whitelist membership + non-empty VK, matching the contract).
- Contract path verified sound: the inbox contract's `verify_token_policy` / `add_message` short-circuit on the `verified_senders` allow-list, and the `AddMessages` arm skips the `missing_related` AFT-record fetch for bypass messages — so a bare-Delta bypass send isn't stalled waiting for a token record. A valid ML-DSA signature over the content is still required.

## Test plan

- [x] `cargo build` UI wasm — default (`use-node`) **and** offline (`example-data,no-sync`)
- [x] `cargo test -p freenet-email-ui` — 162 passed (incl. 3 new `contact_tier_cache` bypass tests)
- [x] inbox contract tests (`--features contract`) — 35 passed (existing verified-bypass accept/reject tests)
- [x] `cargo clippy` UI wasm — clean
- [x] `cargo make test-ui-playwright` — 114 passed / 16 skipped (incl. #158 import-modal regression tests, confirming the `ImportContact` struct change is safe)
- [ ] Manual two-identity flow against a local node: receive → "Add to address book" → verify → enable bypass → send without burning a token (not run — needs a real node + two identities; offline example-data can't produce a `VerifiedUnknown` sender)

Closes #272
Closes #273