### PR TITLE
feat(ui): font-size scaling + quoted-reply body (#275, #274B)

### DIFF
--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -86,7 +86,7 @@ manual gap by adding a test, flip status to `auto` and link the test.
 | Multi-recipient (To: alice, bob, charlie) | manual | Compose, type comma-separated aliases, confirm 3 fingerprint badges, send, confirm 3 inboxes receive |
 | Auto-sign appends signature once (idempotent on resend) | manual | Settings → Auto-sign on, set signature, send, inspect Sent body for sig; Resend, confirm not duplicated |
 | Forward prefills blank recipient + Fwd: subject + quoted body | auto | offline: `Forward prefills blank recipient + Fwd: subject + quoted body` |
-| Reply prefills recipient + Re: subject | auto | offline: `Reply prefills recipient + Re: subject` |
+| Reply prefills recipient + Re: subject + quoted body (#274B) | auto | offline: `Reply prefills recipient + Re: subject` (asserts quoted body since #274B). |
 | Resend prefills identical recipient/subject/body | auto | offline: `Resend prefills identical recipient/subject/body` |
 | Reply from Archive folder | manual | Archive a message, open it from Archive, click Reply, confirm prefill |
 | Empty body / no recipient → submit blocked or warns | manual | Compose, leave fields blank, click Send, observe behavior |
@@ -141,6 +141,7 @@ add/remove protocol.
 | Appearance: theme switch (data-theme attr) | manual | Settings → Appearance, change theme, confirm `.fm-app[data-theme]` reflects |
 | Appearance: density (data-density attr) | manual | Change density, confirm `.fm-app[data-density]` reflects + row heights change |
 | Appearance: serif_subjects toggle | manual | Toggle, confirm subjects flip font |
+| Appearance: font-size scaling (#275) | manual | Settings → Appearance, change Font size (small / default / large / larger). Confirm `.fm-app[data-font-size]` attr matches; entire UI scales uniformly via CSS `zoom`. Reload → choice persists. |
 | Advanced: custom relay URL takes effect on reload | manual | Set custom_relay + URL, reload, WS connects to that URL |
 | Settings round-trip across reload | manual | Set value, reload, value persists |
 | AFT tier picker dispatches ModifySettings (#85) | auto | iso: `recipient tier change before first send; sender mints at new tier (#221, #180 AFT_CAP_RAISED row)` (re-enabled in #223). |

--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -371,6 +371,18 @@ pub enum Density {
     Compact,
 }
 
+/// UI font-size preference. Scales every text element uniformly via
+/// CSS `zoom` on the app root (#275).
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FontSize {
+    Small,
+    #[default]
+    Default,
+    Large,
+    Larger,
+}
+
 /// Appearance settings (global, not per-identity).
 #[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
 pub struct AppearanceSettings {
@@ -381,6 +393,8 @@ pub struct AppearanceSettings {
     /// Render subject lines in the serif display face.
     #[serde(default = "default_true")]
     pub serif_subjects: bool,
+    #[serde(default)]
+    pub font_size: FontSize,
 }
 
 impl Default for AppearanceSettings {
@@ -389,6 +403,7 @@ impl Default for AppearanceSettings {
             theme: Theme::default(),
             density: Density::default(),
             serif_subjects: true,
+            font_size: FontSize::default(),
         }
     }
 }
@@ -1140,6 +1155,7 @@ mod boundary_tests {
                 theme: Theme::Dark,
                 density: Density::Compact,
                 serif_subjects: false,
+                font_size: FontSize::Large,
             },
             inbox: InboxSettings {
                 drafts_in_inbox: true,

--- a/ui/public/vendor/css/components/main.css
+++ b/ui/public/vendor/css/components/main.css
@@ -8,3 +8,11 @@
 
   }
 }
+
+/* Font-size scaling (#275). `zoom` scales every descendant uniformly
+   including the absolute-px font-size declarations across components.
+   Supported in Chromium, Safari, and Firefox 126+. */
+.fm-app[data-font-size="small"]   { zoom: 0.88; }
+.fm-app[data-font-size="default"] { zoom: 1; }
+.fm-app[data-font-size="large"]   { zoom: 1.15; }
+.fm-app[data-font-size="larger"]  { zoom: 1.30; }

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1153,18 +1153,6 @@ mod menu {
             }
         }
 
-        pub fn open_compose_with(&mut self, to: String, subject: String) {
-            self.new_msg = true;
-            self.email = None;
-            self.sent_id = None;
-            self.compose_prefill = Some(ComposePrefill {
-                to,
-                subject,
-                body: String::new(),
-                draft_id: None,
-            });
-        }
-
         pub fn open_draft(&mut self, prefill: ComposePrefill) {
             self.new_msg = true;
             self.email = None;
@@ -1347,6 +1335,12 @@ fn UserInbox() -> Element {
         ::mail_local_state::Density::Comfortable => "comfortable",
         ::mail_local_state::Density::Compact => "compact",
     };
+    let font_size_attr = match appearance.font_size {
+        ::mail_local_state::FontSize::Small => "small",
+        ::mail_local_state::FontSize::Default => "default",
+        ::mail_local_state::FontSize::Large => "large",
+        ::mail_local_state::FontSize::Larger => "larger",
+    };
     let serif_class = if appearance.serif_subjects {
         " serif-subjects"
     } else {
@@ -1363,6 +1357,7 @@ fn UserInbox() -> Element {
             "data-testid": testid::FM_APP,
             "data-theme": theme_attr,
             "data-density": density_attr,
+            "data-font-size": font_size_attr,
             Topbar {}
             div { class: "main",
                 Sidebar {}
@@ -2105,6 +2100,7 @@ fn OpenArchivedMessage(msg_id: u64, msg: mail_local_state::ArchivedMessage) -> E
     let content = msg.content.clone();
     let reply_to = from.clone();
     let reply_subj = format!("Re: {title}");
+    let reply_body = quote_body(&content);
     let time_full = chrono::DateTime::from_timestamp_millis(msg.archived_at)
         .map(format_time_full)
         .unwrap_or_default();
@@ -2138,7 +2134,12 @@ fn OpenArchivedMessage(msg_id: u64, msg: mail_local_state::ArchivedMessage) -> E
                     class: "btn btn-primary",
                     "data-testid": testid::FM_ARCHIVE_REPLY,
                     onclick: move |_| {
-                        menu_selection.write().open_compose_with(reply_to.to_string(), reply_subj.clone());
+                        menu_selection.write().open_draft(menu::ComposePrefill {
+                            to: reply_to.to_string(),
+                            subject: reply_subj.clone(),
+                            body: reply_body.clone(),
+                            draft_id: None,
+                        });
                     },
                     "Reply"
                 }
@@ -2211,11 +2212,11 @@ fn OpenSentMessage(msg: mail_local_state::SentMessage) -> Element {
         mail_local_state::DeliveryState::Failed => "failed",
     };
 
-    // Reply: same recipient, "Re: <subject>".
+    // Reply: same recipient, "Re: <subject>", original quoted.
     let reply_prefill = menu::ComposePrefill {
         to: to.clone(),
         subject: format!("Re: {subject}"),
-        body: String::new(),
+        body: quote_body(&body),
         draft_id: None,
     };
     // Forward: blank recipient, "Fwd: <subject>", body quoted.
@@ -2368,6 +2369,7 @@ fn OpenMessage(msg: Message) -> Element {
     let id = msg.id;
     let reply_to = from.clone();
     let reply_subj = format!("Re: {}", title);
+    let reply_body = quote_body(&content);
     let time_full = format_time_full(msg.time);
     // Subscribe to address-book mutations so the verification badge
     // updates immediately when the user imports the sender's contact
@@ -2482,7 +2484,12 @@ fn OpenMessage(msg: Message) -> Element {
                     class: "btn btn-primary",
                     "data-testid": testid::FM_REPLY,
                     onclick: move |_| {
-                        menu_selection.write().open_compose_with(reply_to.to_string(), reply_subj.clone());
+                        menu_selection.write().open_draft(menu::ComposePrefill {
+                            to: reply_to.to_string(),
+                            subject: reply_subj.clone(),
+                            body: reply_body.clone(),
+                            draft_id: None,
+                        });
                     },
                     "Reply"
                 }

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -16,7 +16,7 @@ use dioxus::prelude::*;
 #[cfg(any(all(target_family = "wasm", feature = "use-node"), test))]
 use mail_local_state::IdentityAftPrefs;
 use mail_local_state::{
-    Density, GlobalSettings, IdentityPrivacyPrefs, IdentitySettings, InboxSettings,
+    Density, FontSize, GlobalSettings, IdentityPrivacyPrefs, IdentitySettings, InboxSettings,
     PermissionDecision, Theme,
 };
 
@@ -1373,6 +1373,12 @@ fn ScrAppearance() -> Element {
         Density::Comfortable => "comfortable",
         Density::Compact => "compact",
     };
+    let font_size_value = match g.appearance.font_size {
+        FontSize::Small => "small",
+        FontSize::Default => "default",
+        FontSize::Large => "large",
+        FontSize::Larger => "larger",
+    };
 
     let g_theme = g.clone();
     let on_theme = move |ev: Event<FormData>| {
@@ -1397,6 +1403,17 @@ fn ScrAppearance() -> Element {
     let on_serif = move |_| {
         let mut next = g_serif.clone();
         next.appearance.serif_subjects = !next.appearance.serif_subjects;
+        local_state::persist_global_settings(next);
+    };
+    let g_font_size = g.clone();
+    let on_font_size = move |ev: Event<FormData>| {
+        let mut next = g_font_size.clone();
+        next.appearance.font_size = match ev.value().as_str() {
+            "small" => FontSize::Small,
+            "large" => FontSize::Large,
+            "larger" => FontSize::Larger,
+            _ => FontSize::Default,
+        };
         local_state::persist_global_settings(next);
     };
     rsx! {
@@ -1427,6 +1444,21 @@ fn ScrAppearance() -> Element {
                             onchange: on_density,
                             option { value: "compact", "compact" }
                             option { value: "comfortable", "comfortable" }
+                        }
+                    },
+                }
+                SettingRow {
+                    label: "Font size",
+                    help: "Scales every text element uniformly. Use Large/Larger for high-DPI screens or low vision.",
+                    control: rsx! {
+                        select {
+                            class: "fm-select",
+                            value: "{font_size_value}",
+                            onchange: on_font_size,
+                            option { value: "small", "small" }
+                            option { value: "default", "default" }
+                            option { value: "large", "large" }
+                            option { value: "larger", "larger" }
                         }
                     },
                 }

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -980,7 +980,8 @@ test.describe("Sent folder (#47b)", () => {
     await expect(sheet.locator('input[placeholder="subject"]')).toHaveValue(
       "Re: original",
     );
-    await expect(sheet.locator("textarea.sheet-textarea")).toHaveValue("");
+    // #274B: reply now quotes the original body (each line prefixed with "> ").
+    await expect(sheet.locator("textarea.sheet-textarea")).toHaveValue("> hello");
   });
 
   test("Forward prefills blank recipient + Fwd: subject + quoted body", async ({


### PR DESCRIPTION
## Summary

Two small UX wins bundled.

### #275 — Font-size control
- Settings → Appearance → Font size (small / default / large / larger).
- Applied via `data-font-size` attr on `.fm-app` root + CSS `zoom` on the same element. Uniform scale across every component without rewriting the px-based stylesheet.
- New `FontSize` enum in `AppearanceSettings` with `#[serde(default)]` so older serialized state loads.
- Persistence reuses the existing `persist_global_settings` path (delegate write under `use-node`).

### #274B — Quoted reply body
- Inbox detail, Archive detail, and Sent detail reply callsites now switch from the bespoke `open_compose_with` helper to `open_draft` with a `ComposePrefill` carrying `quote_body(&content)`.
- Drops the now-unused `open_compose_with` method.
- `#274A` (multi-recipient) is still open — bigger surface (parser + N AFT burns + partial failure UX). Out of scope here.

## Manual demo

- `cargo make dev-example` → first identity → Settings → Appearance. Select large/larger, watch UI scale; revert default to confirm zoom reverts.
- Open a message, click Reply, confirm the body textarea pre-fills with `> <line>` for each line of the original.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p mail-local-state` — `round_trip_global_settings` updated for new field.
- [x] `cargo test --workspace --lib` — 28 boundary tests pass.
- [x] Playwright `Reply prefills recipient + Re: subject` (chromium) — now asserts quoted body, passes locally.
- [x] Visual: `data-font-size="larger"` → `getComputedStyle(.fm-app).zoom === "1.3"`.

## QA inventory

- Added: `Appearance: font-size scaling (#275)` (manual).
- Updated: `Reply prefills recipient + Re: subject + quoted body (#274B)` — auto test now covers quoted body.