### PR TITLE
feat(ui): global threading on/off toggle in Appearance settings

### DIFF
--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -85,6 +85,7 @@ standalone). All rows below are `auto`.
 | Behavior | Status | Test / recipe |
 |---|---|---|
 | Inbox list collapses a back-and-forth into one row with a count badge; standalone rows stay separate | auto | offline (`threads.spec.ts`): `collapses a back-and-forth into one row with a count badge, standalone rows stay separate` |
+| Global threading on/off toggle (Settings → Appearance → Conversations, `FM_THREADING_ENABLED_TOGGLE`). On (default): inbox groups threads. Off: flat one-row-per-message list (no `+N` sender suffix, no count badge); thread-view picker becomes inert. Persists across sessions via `GlobalSettings.inbox.threading_enabled` (`#[serde(default = "default_true")]`). | manual | offline (`cargo make dev-example`): open address1 inbox → "Re: Lunch tomorrow?" shows "Mary +1" + badge "3". Settings → Appearance → toggle "Group messages into threads" off → back to mailbox → expect 5 flat rows, no badge. Gated in `app.rs` via `threads::group_flat` vs `group_into_threads`. |
 | Clicking a thread group opens the threaded detail container | auto | offline (`threads.spec.ts`): `clicking the thread group opens the threaded detail container` |
 | Nested view default-expands the last (leaf) message; collapsed nodes expand on click | auto | offline (`threads.spec.ts`): `default-expands the last message of the branch; collapsed nodes expand on click` |
 | Nested view "in reply to" quote chip toggles the quoted excerpt | auto | offline (`threads.spec.ts`): `the 'in reply to' quote chip toggles` |

--- a/modules/mail-local-state/src/lib.rs
+++ b/modules/mail-local-state/src/lib.rs
@@ -445,7 +445,7 @@ impl Default for AppearanceSettings {
 /// Quarantine folder (with its own sidebar entry + count badge) instead of
 /// the inbox. Defaulting it off keeps first-run UX friendly; users who want
 /// strict quarantine flip the toggle in Settings > Inbox.
-#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Default)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone)]
 pub struct InboxSettings {
     /// Show drafts inline in the inbox list rather than only in the
     /// Drafts folder.
@@ -453,11 +453,32 @@ pub struct InboxSettings {
     /// Move messages from senders not in the verified address book into a
     /// dedicated Quarantine folder instead of the inbox.
     pub quarantine_unknown: bool,
+    /// Master switch for conversation threading (#270). When `true`
+    /// (default), the inbox collapses back-and-forth messages into one row
+    /// per thread and the detail pane renders the `thread_view` style. When
+    /// `false`, the inbox shows a flat one-row-per-message list and threads
+    /// don't group. Toggled globally in Settings → Appearance; the
+    /// `thread_view` picker below only matters while this is on.
+    /// `#[serde(default = "default_true")]` so older persisted state (which
+    /// predates this field) loads with threading ON, preserving #270 behavior.
+    #[serde(default = "default_true")]
+    pub threading_enabled: bool,
     /// How a collapsed thread expands in the detail pane (#270): the
     /// indentation-tree `Nested` view (default) or the power-user `Compact`
     /// accordion. `#[serde(default)]` so older state loads as `Nested`.
     #[serde(default)]
     pub thread_view: ThreadView,
+}
+
+impl Default for InboxSettings {
+    fn default() -> Self {
+        Self {
+            drafts_in_inbox: false,
+            quarantine_unknown: false,
+            threading_enabled: true,
+            thread_view: ThreadView::default(),
+        }
+    }
 }
 
 /// Threaded-detail rendering style (#270). Selected in Settings → Inbox.
@@ -1245,6 +1266,7 @@ mod boundary_tests {
             inbox: InboxSettings {
                 drafts_in_inbox: true,
                 quarantine_unknown: false,
+                threading_enabled: false,
                 thread_view: ThreadView::Compact,
             },
             advanced: AdvancedSettings {

--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -41,6 +41,7 @@
   "fmThreadContainer": "fm-thread-container",
   "fmThreadGroup": "fm-thread-group",
   "fmThreadViewSelect": "fm-thread-view-select",
+  "fmThreadingEnabledToggle": "fm-threading-enabled-toggle",
   "fmStorybook": "fm-storybook",
   "fmToast": "fm-toast",
   "fmActionCreate": "fm-action-create",

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1261,6 +1261,23 @@ pub(crate) mod threads {
             .collect()
     }
 
+    /// Flat fallback when threading is disabled (Settings → Appearance,
+    /// `threading_enabled = false`). Each message becomes its own
+    /// single-member `ThreadGroup`, so the inbox renders one row per
+    /// message with no grouping and no count badge. Mirrors the
+    /// finalize step of `group_into_threads` for a 1-message bucket.
+    pub(crate) fn group_flat(msgs: &[Message]) -> Vec<ThreadGroup> {
+        msgs.iter()
+            .map(|m| ThreadGroup {
+                key: format!("flat:{}", m.id),
+                messages: vec![m.clone()],
+                root_id: m.id,
+                unread_count: usize::from(!m.read),
+                count: 1,
+            })
+            .collect()
+    }
+
     /// Deterministic display order for the grouped inbox list (#270; the
     /// #137/#233 determinism class).
     ///
@@ -2977,7 +2994,17 @@ fn MessageList() -> Element {
                         // newest member descending so the list stays "newest
                         // conversation on top". A single-message thread renders
                         // like an ordinary row (count badge suppressed).
-                        let mut groups = threads::group_into_threads(&visible);
+                        // When threading is disabled globally (Settings →
+                        // Appearance), fall back to a flat one-row-per-message
+                        // list via `group_flat` — `sort_cmp_group` still orders
+                        // newest-first.
+                        let threading_on =
+                            crate::local_state::global_settings().inbox.threading_enabled;
+                        let mut groups = if threading_on {
+                            threads::group_into_threads(&visible)
+                        } else {
+                            threads::group_flat(&visible)
+                        };
                         groups.sort_by(threads::sort_cmp_group);
                         groups.into_iter().map(move |group| {
                             // Newest member drives the row's sender / time /

--- a/ui/src/app/settings.rs
+++ b/ui/src/app/settings.rs
@@ -305,7 +305,7 @@ fn SettingRow(
 }
 
 #[component]
-fn Toggle(on: bool, ontoggle: EventHandler<()>) -> Element {
+fn Toggle(on: bool, ontoggle: EventHandler<()>, testid: Option<String>) -> Element {
     let cls = if on { "fm-toggle on" } else { "fm-toggle" };
     rsx! {
         button {
@@ -313,6 +313,7 @@ fn Toggle(on: bool, ontoggle: EventHandler<()>) -> Element {
             r#type: "button",
             role: "switch",
             "aria-checked": "{on}",
+            "data-testid": testid,
             onclick: move |_| ontoggle.call(()),
         }
     }
@@ -1398,6 +1399,7 @@ fn ScrContacts() -> Element {
 fn ScrAppearance() -> Element {
     let g = use_global_settings();
     let serif_subjects = g.appearance.serif_subjects;
+    let threading_enabled = g.inbox.threading_enabled;
     let theme_value = match g.appearance.theme {
         Theme::System => "auto",
         Theme::Light => "light",
@@ -1437,6 +1439,12 @@ fn ScrAppearance() -> Element {
     let on_serif = move |_| {
         let mut next = g_serif.clone();
         next.appearance.serif_subjects = !next.appearance.serif_subjects;
+        local_state::persist_global_settings(next);
+    };
+    let g_threading = g.clone();
+    let on_threading = move |_| {
+        let mut next = g_threading.clone();
+        next.inbox.threading_enabled = !next.inbox.threading_enabled;
         local_state::persist_global_settings(next);
     };
     let g_font_size = g.clone();
@@ -1500,6 +1508,19 @@ fn ScrAppearance() -> Element {
                     label: "Subjects in serif",
                     help: "Off: subjects render in DM Sans like the rest of the UI.",
                     control: rsx! { Toggle { on: serif_subjects, ontoggle: on_serif } },
+                }
+            }
+            Card { title: "Conversations",
+                SettingRow {
+                    label: "Group messages into threads",
+                    help: "On: collapse back-and-forth messages into one inbox row per conversation. Off: a flat list, one row per message. Pick Nested vs Compact under Settings → Inbox.",
+                    control: rsx! {
+                        Toggle {
+                            testid: testid::FM_THREADING_ENABLED_TOGGLE.to_string(),
+                            on: threading_enabled,
+                            ontoggle: on_threading,
+                        }
+                    },
                 }
             }
         }

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -81,6 +81,10 @@ pub(crate) const FM_THREAD_CONTAINER: &str = "fm-thread-container";
 pub(crate) const FM_THREAD_GROUP: &str = "fm-thread-group";
 /// The Settings → Inbox thread-view `<select>` (Nested / Compact).
 pub(crate) const FM_THREAD_VIEW_SELECT: &str = "fm-thread-view-select";
+/// The Settings → Appearance master threading on/off toggle. When off the
+/// inbox renders flat (one row per message) and the thread-view select is
+/// inert.
+pub(crate) const FM_THREADING_ENABLED_TOGGLE: &str = "fm-threading-enabled-toggle";
 /// The in-app storybook host wrapper (`example-data` builds only, gated on a
 /// `?story=` query param). Wraps a single thread component rendered from a
 /// hand-built `ThreadGroup` so the views can be screenshotted in isolation.
@@ -196,6 +200,10 @@ mod tests {
             ("fmThreadContainer", super::FM_THREAD_CONTAINER),
             ("fmThreadGroup", super::FM_THREAD_GROUP),
             ("fmThreadViewSelect", super::FM_THREAD_VIEW_SELECT),
+            (
+                "fmThreadingEnabledToggle",
+                super::FM_THREADING_ENABLED_TOGGLE,
+            ),
             ("fmStorybook", super::FM_STORYBOOK),
             ("fmToast", super::FM_TOAST),
             ("fmActionCreate", super::FM_ACTION_CREATE),


### PR DESCRIPTION
## Summary

#270 shipped conversation threading with a Nested/Compact picker (Settings → Inbox), but there was no way to **disable threading entirely**. This adds a master on/off switch in **Settings → Appearance → Conversations** ("Group messages into threads").

When **off**, the inbox renders a flat one-row-per-message list (no `+N` sender suffix, no count badge) and the existing Inbox→Conversations Nested/Compact picker becomes inert. When **on** (default), behavior is unchanged from #270.

## Changes

- **mail-local-state**: `InboxSettings` gains `threading_enabled: bool`, default `true` via `#[serde(default = "default_true")]` + explicit `Default` impl — pre-existing persisted state loads with threading ON, preserving #270 behavior.
- **app.rs**: new `threads::group_flat` (one `ThreadGroup` per message) gated against `group_into_threads` on `inbox.threading_enabled` at the inbox-list render site.
- **settings.rs**: new "Conversations" card in `ScrAppearance` with the toggle; `Toggle` component gains an optional `testid` prop.
- **testid**: `FM_THREADING_ENABLED_TOGGLE` (rust const + JSON mirror + pair test).
- Existing Inbox→Conversations Nested/Compact picker left in place (as requested).

## Verification

Driven live offline (`example-data,no-sync`) via Playwright:
- Threading ON: seeded "Re: Lunch tomorrow?" shows "Mary +1" + count badge "3" (1 collapsed row).
- Toggle off → back to mailbox → 5 flat rows, no badge, thread expanded into its members.

176 ui + 31 local-state tests pass; testid mirror (`json_matches_rust_consts`) + clippy clean.