### PR TITLE
fix(persistence): spawn_forever for local-state delegate writes (#286)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,26 @@ target for production publishes: `publish-email`, `publish-production`,
 and `scripts/release.sh`. The first publish takes ~30s to propagate
 before the gateway URL resolves.
 
+> **⚠️ Port collision — never test-publish onto a running `freenet network` node.**
+> `freenet local`/`fdev` both default to **port 7509**. If a long-running
+> `freenet network` node already owns 7509 (some dev machines run one under
+> launchd), then `cargo make publish-email-test` / `publish-all` will publish
+> the **test-key contract onto the real network** and drive your manual QA
+> against the wrong node. Before any test publish:
+> 1. `ps aux | grep "[f]reenet network"` — if one is up, 7509 is the real net.
+> 2. Start a dedicated sandbox on a free port and target it, e.g.
+>    `freenet local --ws-api-port 7600`, then publish/QA against 7600.
+> 3. `publish-email-test`/`publish-all` run `update-published-contract`, which
+>    **overwrites** `published-contract/contract-id.txt` + `webapp.parameters`
+>    with the TEST id, clobbering the committed **prod** snapshot. After QA:
+>    `git checkout -- published-contract/contract-id.txt published-contract/webapp.parameters`.
+>    **Never commit that diff** — the committed snapshot is the prod-key id.
+>
+> (`WEB_CONTAINER_CONTRACT_ID` is embedded from `contract-id.txt` at build
+> time but is **diagnostic-only** — logged in `ui/src/lib.rs`, never used for a
+> contract op — so a wrong embedded id is cosmetic console noise, not a
+> functional break.)
+
 ### Testing
 
 ```bash

--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -145,7 +145,7 @@ standalone). All rows below are `auto`.
 | Discard removes the draft | auto | offline: `Discard removes the draft` |
 | Send removes the draft | auto | offline: `Send removes the draft` |
 | Sent doesn't leak into Drafts, in-session (#107) | auto | offline: `Send removes the draft` (in-session only — does NOT reload). `repro-106-107.spec.ts` asserts the *draft persists*, not sent-vs-draft routing, and contains no reload. |
-| Sent stays in Sent / out of Drafts **across reload** | auto | iso: `sent message stays in Sent (not Drafts) across reload (#286)` — sends, reloads, asserts Sent row survives + Drafts count empty. |
+| Sent stays in Sent / out of Drafts **across reload** | auto | iso: `sent message stays in Sent (not Drafts) across reload (#286)` — sends, reloads, asserts Sent row survives + Drafts count empty. Fixed by `spawn_forever` on the SaveSent delegate write (#286). |
 | Draft folder count badge | auto | offline: `draft folder count badge reflects pending drafts` |
 | Long typing burst → debounced delegate save | manual | Type 200+ chars rapidly, wait 1s, reload, confirm draft state |
 
@@ -166,7 +166,7 @@ standalone). All rows below are `auto`.
 |---|---|---|
 | Archive moves Inbox row to Archive folder | auto | offline: `Archive moves message from Inbox to Archive folder` |
 | Delete from Inbox does NOT create Archive entry (in-session) | auto | offline: `Delete from Inbox does not produce an Archive entry` (in-session only — no reload) |
-| Deleted message stays deleted **across reload** | auto | iso: `deleted message stays deleted across reload (#286)` — bob receives, deletes, reloads, asserts still gone (no resurrection from contract re-fetch). Carries the same-host core-relay quarantine. |
+| Deleted message stays deleted **across reload** | auto | iso: `deleted message stays deleted across reload (#286)` — bob receives, deletes, reloads, asserts still gone (no resurrection from contract re-fetch). Carries the same-host core-relay quarantine. Fixed by `spawn_forever` on the DeleteMessage delegate write (#286). |
 | Archive count badge | auto | offline: `Archive count badge reflects archived rows` |
 | Delete on archived row removes from Archive | auto | offline: `Delete on archived row removes it from Archive too` |
 | True unarchive (move back to Inbox) | blocked | Issue #60 — contract OwnerInsert not yet wired; UI button hidden |

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -3414,7 +3414,12 @@ fn ThreadDetail(group: crate::app::threads::ThreadGroup) -> Element {
                     let mut client_clone = client.clone();
                     let alias_for_send = alias.clone();
                     let mid = m.id;
-                    spawn(async move {
+                    // spawn_forever: opening a message then immediately
+                    // navigating away (archive/delete/back) unmounts this
+                    // view; a bare spawn() would cancel the MarkRead delegate
+                    // write, so the message resurfaced as unread on reload
+                    // (#286 read-state variant).
+                    let _task = dioxus_core::spawn_forever(async move {
                         if let Err(e) = crate::local_state::mark_read(
                             &mut client_clone,
                             alias_for_send,
@@ -3910,7 +3915,12 @@ fn OpenArchivedMessage(msg_id: u64, msg: mail_local_state::ArchivedMessage) -> E
                             {
                                 let mut c = client.clone();
                                 let a = delete_alias.clone();
-                                spawn(async move {
+                                // spawn_forever: at_inbox_list() below
+                                // navigates away and unmounts this view, which
+                                // would cancel a bare spawn() before the
+                                // DeleteMessage delegate write committed —
+                                // message returns after reload (#286).
+                                let _task = dioxus_core::spawn_forever(async move {
                                     if let Err(e) = crate::local_state::delete_message(
                                         &mut c, a, msg_id,
                                     )
@@ -4159,7 +4169,11 @@ fn archive_message(
             let mut c = client.clone();
             let a = alias.to_string();
             let ar = archived.clone();
-            spawn(async move {
+            // spawn_forever: the caller runs post.apply() right after this,
+            // navigating away and unmounting the view. A bare spawn() would
+            // cancel the ArchiveMessage delegate write on unmount, so the
+            // archived message bounced back to the Inbox after reload (#286).
+            let _task = dioxus_core::spawn_forever(async move {
                 if let Err(e) = crate::local_state::archive_message(&mut c, a, id, ar).await {
                     crate::log::local_state_failure("archive message", e);
                 }
@@ -4196,7 +4210,12 @@ fn delete_message(
         {
             let mut c = client.clone();
             let a = alias.to_string();
-            spawn(async move {
+            // spawn_forever: the caller runs post.apply() right after this,
+            // which navigates away and unmounts the message view. A bare
+            // spawn() would cancel the DeleteMessage delegate write on
+            // unmount, so the deletion never committed to the node and the
+            // message returned after reload (#286).
+            let _task = dioxus_core::spawn_forever(async move {
                 if let Err(e) = crate::local_state::delete_message(&mut c, a, id).await {
                     crate::log::error(format!("delete_message failed: {e}"), None);
                 }
@@ -4281,7 +4300,11 @@ fn OpenMessage(msg: Message) -> Element {
             {
                 let mut client_clone = client.clone();
                 let alias_for_send = alias.clone();
-                spawn(async move {
+                // spawn_forever: same as the group-open path — navigating
+                // away right after opening unmounts this view and a bare
+                // spawn() would cancel the MarkRead write, resurfacing the
+                // message as unread on reload (#286 read-state variant).
+                let _task = dioxus_core::spawn_forever(async move {
                     if let Err(e) = crate::local_state::mark_read(
                         &mut client_clone,
                         alias_for_send,
@@ -4633,7 +4656,12 @@ fn ComposeSheet() -> Element {
         {
             let mut client_clone = client.clone();
             let alias = alias_for_delete.clone();
-            spawn(async move {
+            // spawn_forever: delete_draft_now fires on Send, which navigates
+            // away and unmounts this component. A bare spawn() would cancel
+            // the DeleteDraft delegate write on unmount, leaving the draft
+            // persisted on the node — it then reappears (and the sent message
+            // re-derives as a Draft) after reload (#286).
+            let _task = dioxus_core::spawn_forever(async move {
                 if let Err(e) = crate::local_state::delete_draft(&mut client_clone, alias, id).await
                 {
                     crate::log::local_state_failure("delete draft", e);
@@ -4887,7 +4915,13 @@ fn ComposeSheet() -> Element {
                 let mut client_clone = client.clone();
                 let alias_async = sender_alias.clone();
                 let id_async = sent_id.clone();
-                spawn(async move {
+                // spawn_forever, not spawn: the send handler navigates away
+                // (at_new_msg() below) and unmounts this compose component.
+                // spawn() ties the task to this scope and cancels it on
+                // unmount, so the SaveSent delegate write never reached the
+                // wire — the message persisted only in the in-session
+                // snapshot and re-derived as a Draft after reload (#286).
+                let _task = dioxus_core::spawn_forever(async move {
                     if let Err(e) = crate::local_state::save_sent(
                         &mut client_clone,
                         alias_async,

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -1379,11 +1379,9 @@ test.describe("Live node E2E", () => {
   test("sent message stays in Sent (not Drafts) across reload (#286)", async ({
     browser,
   }) => {
-    // #286 is an OPEN bug: sent messages revert to Drafts on reload. This
-    // test reproduces it, so it is expected-to-fail until #286 is fixed.
-    // Playwright flips it back to a hard failure the moment it starts
-    // passing — i.e. when the bug is fixed and this guard becomes stale.
-    test.fail(true, "reproduces open bug #286 (sent reverts on reload)");
+    // #286 FIXED (spawn_forever for the SaveSent delegate write, app.rs):
+    // the sent row now persists across reload instead of re-deriving as a
+    // Draft. This guards the fix — it fails if the regression returns.
     test.skip(
       !PEER_BASE_URL,
       "requires FREENET_EMAIL_BASE_URL to include the contract id",
@@ -1512,11 +1510,9 @@ test.describe("Live node E2E", () => {
   test("deleted message stays deleted across reload (#286)", async ({
     browser,
   }) => {
-    // #286 is an OPEN bug: deleted messages return on reload. This test
-    // reproduces it, so it is expected-to-fail until #286 is fixed.
-    // Playwright flips it back to a hard failure the moment it starts
-    // passing — i.e. when the bug is fixed and this guard becomes stale.
-    test.fail(true, "reproduces open bug #286 (deleted returns on reload)");
+    // #286 FIXED (spawn_forever for the DeleteMessage delegate write,
+    // app.rs): the deletion now commits durably instead of being cancelled
+    // on unmount. This guards the fix — it fails if the regression returns.
     test.skip(
       !PEER_BASE_URL,
       "requires FREENET_EMAIL_BASE_URL to include the contract id",


### PR DESCRIPTION
## Summary

Fixes #286 — sent messages re-derived as **Drafts** after reload (and deleted/archived/read state reverting), even though prior tombstone work (#265, #113, #106/#107) was in place.

**Root cause — different layer than every prior persistence fix.** Those fixes were all *tombstone bookkeeping*: in-session guards (`OPTIMISTIC_SENT`, `DELETED_MESSAGES`, …) so a stale delegate echo couldn't clobber an optimistic local mutation. They assumed the delegate **write itself landed**.

It didn't. The six folder-state writes (`save_sent`, `delete_message`, `archive_message`, `mark_read`, `delete_draft`) were dispatched via component-scoped `spawn()`, then the handler **navigated away** (`at_new_msg()` / `post.apply()` / `at_inbox_list()`), unmounting the component and **cancelling the in-flight write before it reached the `mail-local-state` delegate**. So nothing persisted — reload re-derived Sent→Draft regardless of tombstone correctness. Same unmount-cancellation class already fixed once for the AFT send future (`app.rs:4816`).

## Fix

Convert the six persistence-write dispatches from `spawn(...)` to `dioxus_core::spawn_forever(...)` so the write outlives the unmounting component. Each site carries an explanatory comment citing #286.

Deliberately **left bare `spawn` on**:
- `save_draft` autosave (debounce-cancellable via `autosave_token`; must lose the race to the explicit `delete_draft` on Send).
- top-level `DELAYED_ACTIONS` queue runner (app-root scope, doesn't unmount per-navigation).

Audited all spawn sites near `local_state` writes — all 6 critical paths now `spawn_forever`, the 2 remaining bare-spawns are intentional.

## Verification

- **Unit:** `cargo test -p freenet-email-ui --lib local_state` → 18/18 green, incl. `compose_send_then_reload_keeps_sent_and_drops_draft` + the full #265 tombstone suite.
- **Iso 2-node harness** (`test-e2e-real-node`, send enabled): flipped both #286 guards from `test.fail` → green. 8 passed / 1 skipped / 0 failed.
  - ✓ sent message stays in Sent (not Drafts) across reload (#286)
  - ✓ deleted message stays deleted across reload (#286)
- **Manual** on the iso node, real browser: create identity → self-send → reload → **Sent=1, Drafts empty, message intact**.

## Also in this PR

`docs(agents)`: warn against test-publishing onto a running `freenet network` node (port-7509 collision corrupts QA + the committed snapshot). Lesson from QA-ing this fix.

Closes #286.
