### PR TITLE
fix(contacts): resolve To by sender's advertised alias (#289)

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -955,7 +955,15 @@ mod identity_management {
         let stored = crate::app::address_book::StoredContactKeys {
             ml_dsa_vk_bytes: contact.ml_dsa_vk_bytes.clone(),
             ml_kem_ek_bytes: contact.ml_kem_ek_bytes.clone(),
-            suggested_alias: Some(contact.local_alias.to_string()),
+            // Persist the sender's advertised alias carried on the contact
+            // (the suggested_alias resolver fallback depends on it). Falls
+            // back to local_alias only when the card had none, matching the
+            // import-form submit path.
+            suggested_alias: contact
+                .suggested_alias
+                .as_deref()
+                .map(str::to_string)
+                .or_else(|| Some(contact.local_alias.to_string())),
             verified: contact.verified,
             required_tier: contact.required_tier,
             max_age_secs: contact.max_age_secs,

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -845,6 +845,7 @@ impl User {
         #[cfg(not(feature = "use-node"))]
         let _ = address_book::insert_contact(address_book::Contact {
             local_alias: "alice-example".into(),
+            suggested_alias: None,
             description: "Example contact for offline testing".into(),
             ml_dsa_vk_bytes: vec![0xAA; 1952],
             ml_kem_ek_bytes: vec![0xBB; 1184],

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -143,6 +143,13 @@ pub fn identity_inbox_address(identity: &Identity) -> Result<String, String> {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Contact {
     pub local_alias: Rc<str>,
+    /// The alias the sender chose for themselves on their shared card
+    /// (`ContactCard.suggested_alias`). Retained so the To field can
+    /// still resolve the contact when the importer relabelled them with
+    /// a different `local_alias` but types the name the *sender*
+    /// advertised. `None` for cards with no suggested alias or contacts
+    /// imported before this field shipped.
+    pub suggested_alias: Option<Rc<str>>,
     pub description: String,
     pub ml_dsa_vk_bytes: Vec<u8>,
     pub ml_kem_ek_bytes: Vec<u8>,
@@ -303,9 +310,16 @@ pub fn remove_contact(alias: &str) {
 }
 
 /// Resolve an alias to a `Recipient`.  Walks both own identities and contacts.
+///
+/// Matching order: first the exact `local_alias` HashMap key, then — only
+/// on a miss — a scan for a contact whose sender-advertised
+/// `suggested_alias` equals `alias`. The fallback lets a user who
+/// relabelled a contact on import still address them by the name the
+/// sender shared. Exact local-alias matches always win, so relabelling
+/// is never shadowed by someone else's suggested alias.
 pub fn lookup(alias: &str) -> Option<Recipient> {
-    ADDRESS_BOOK.with(|ab| {
-        ab.borrow().get(alias).map(|entry| match entry {
+    fn entry_to_recipient(entry: &Entry) -> Recipient {
+        match entry {
             Entry::Own(id) => {
                 let ml_dsa_vk_bytes = id.ml_dsa_vk_bytes();
                 let ml_kem_ek_bytes = id.ml_kem_ek_bytes();
@@ -336,6 +350,23 @@ pub fn lookup(alias: &str) -> Option<Recipient> {
                     inbox_wasm_hash: c.inbox_wasm_hash.clone(),
                 }
             }
+        }
+    }
+
+    ADDRESS_BOOK.with(|ab| {
+        let ab = ab.borrow();
+        // Exact local-alias / own-identity-alias match wins.
+        if let Some(entry) = ab.get(alias) {
+            return Some(entry_to_recipient(entry));
+        }
+        // Fallback: a contact whose sender-advertised suggested_alias
+        // matches. Only contacts carry a suggested_alias, so this never
+        // collides with an own identity.
+        ab.values().find_map(|entry| match entry {
+            Entry::Contact(c) if c.suggested_alias.as_deref() == Some(alias) => {
+                Some(entry_to_recipient(entry))
+            }
+            _ => None,
         })
     })
 }
@@ -588,6 +619,7 @@ impl StoredContactKeys {
     pub fn into_contact(self, local_alias: Rc<str>, description: String) -> Contact {
         Contact {
             local_alias,
+            suggested_alias: self.suggested_alias.map(Rc::from),
             description,
             ml_dsa_vk_bytes: self.ml_dsa_vk_bytes,
             ml_kem_ek_bytes: self.ml_kem_ek_bytes,
@@ -765,6 +797,7 @@ mod tests {
     fn make_contact(alias: &str, vk: u8, ek: u8) -> Contact {
         Contact {
             local_alias: alias.into(),
+            suggested_alias: None,
             description: String::new(),
             ml_dsa_vk_bytes: vec![vk; 1952],
             ml_kem_ek_bytes: vec![ek; 1184],
@@ -783,6 +816,64 @@ mod tests {
         let err =
             insert_contact(make_contact("bob", 3, 2)).expect_err("different VK should be rejected");
         assert!(err.contains("different contact"), "got: {err}");
+    }
+
+    fn make_contact_suggested(local: &str, suggested: Option<&str>, vk: u8, ek: u8) -> Contact {
+        Contact {
+            suggested_alias: suggested.map(Rc::from),
+            ..make_contact(local, vk, ek)
+        }
+    }
+
+    #[test]
+    fn lookup_resolves_by_local_alias() {
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        insert_contact(make_contact_suggested("7511", Some("test7511"), 1, 2)).unwrap();
+        let r = lookup("7511").expect("exact local alias resolves");
+        assert_eq!(&*r.local_alias, "7511");
+        assert!(!r.is_own);
+    }
+
+    #[test]
+    fn lookup_falls_back_to_suggested_alias() {
+        // The user relabelled the contact "7511" but types the name the
+        // sender advertised ("test7511"). The fallback must still resolve.
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        insert_contact(make_contact_suggested("7511", Some("test7511"), 1, 2)).unwrap();
+        let r = lookup("test7511").expect("suggested alias resolves on local-alias miss");
+        assert_eq!(
+            &*r.local_alias, "7511",
+            "resolved recipient keeps the local alias, not the suggested one"
+        );
+    }
+
+    #[test]
+    fn lookup_exact_local_alias_wins_over_suggested() {
+        // If one contact's local_alias equals another contact's
+        // suggested_alias, the exact local-alias match must win.
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        insert_contact(make_contact_suggested("shared", Some("other"), 1, 2)).unwrap();
+        insert_contact(make_contact_suggested("real", Some("shared"), 3, 4)).unwrap();
+        let r = lookup("shared").expect("resolves");
+        assert_eq!(
+            &*r.local_alias, "shared",
+            "exact local-alias match must win over a suggested-alias collision"
+        );
+    }
+
+    #[test]
+    fn lookup_unknown_alias_returns_none() {
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        insert_contact(make_contact_suggested("7511", Some("test7511"), 1, 2)).unwrap();
+        assert!(lookup("nobody").is_none());
+    }
+
+    #[test]
+    fn lookup_no_suggested_alias_is_local_only() {
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        insert_contact(make_contact_suggested("7511", None, 1, 2)).unwrap();
+        assert!(lookup("7511").is_some());
+        assert!(lookup("anything-else").is_none());
     }
 
     #[test]
@@ -970,6 +1061,7 @@ mod tests {
 
         let contact = Contact {
             local_alias: "bob".into(),
+            suggested_alias: None,
             description: String::new(),
             ml_dsa_vk_bytes: vk_bytes.clone(),
             ml_kem_ek_bytes: vec![0u8; 1184],
@@ -998,6 +1090,7 @@ mod tests {
         let vk_a_bytes = MlDsaKeypair::verifying_key(&sk_a).encode().to_vec();
         insert_contact(Contact {
             local_alias: "alice".into(),
+            suggested_alias: None,
             description: String::new(),
             ml_dsa_vk_bytes: vk_a_bytes,
             ml_kem_ek_bytes: vec![0u8; 1184],
@@ -1033,6 +1126,7 @@ mod tests {
 
         insert_contact(Contact {
             local_alias: "alice".into(),
+            suggested_alias: None,
             description: String::new(),
             ml_dsa_vk_bytes: vk_bytes.clone(),
             ml_kem_ek_bytes: vec![0xCC; 1184],
@@ -1102,6 +1196,7 @@ mod tests {
         let vk_bytes = MlDsaKeypair::verifying_key(&sk).encode().to_vec();
         insert_contact(Contact {
             local_alias: "ally".into(),
+            suggested_alias: None,
             description: String::new(),
             ml_dsa_vk_bytes: vk_bytes,
             ml_kem_ek_bytes: vec![0u8; 1184],
@@ -1125,5 +1220,39 @@ mod tests {
             "the contact resolves under its local label; #289 is purely an \
              addressing-handle mismatch, not a missing contact",
         );
+    }
+
+    #[test]
+    fn lookup_resolves_by_sender_alias_when_suggested_preserved_289() {
+        use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+
+        // Same scenario as the miss test above, but the import preserved
+        // the sender's advertised alias ("alice-from-work") as
+        // suggested_alias even though the user relabelled locally to "ally".
+        // This is the #289 fix: the reply To resolves by the sender's
+        // alias via the suggested_alias fallback.
+        let sk = MlDsa65::from_seed(&[42u8; 32].into());
+        let vk_bytes = MlDsaKeypair::verifying_key(&sk).encode().to_vec();
+        insert_contact(Contact {
+            local_alias: "ally".into(),
+            suggested_alias: Some("alice-from-work".into()),
+            description: String::new(),
+            ml_dsa_vk_bytes: vk_bytes,
+            ml_kem_ek_bytes: vec![0u8; 1184],
+            required_tier: Tier::Day1,
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
+            verified: true,
+            inbox_wasm_hash: None,
+        })
+        .unwrap();
+
+        let r = lookup("alice-from-work")
+            .expect("sender alias resolves via suggested_alias fallback (#289)");
+        assert_eq!(
+            &*r.local_alias, "ally",
+            "resolved recipient keeps the user's local label",
+        );
+        assert!(lookup("ally").is_some(), "local label still resolves too");
     }
 }

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -1955,6 +1955,11 @@ pub(super) fn ImportContactForm() -> Element {
 
     let mut paste_text = use_signal(String::new);
     let mut local_alias = use_signal(String::new);
+    // The alias the sender advertised on their card, captured at decode
+    // time and preserved even if the user relabels `local_alias` before
+    // import — so the To field can still resolve by the sender's name
+    // (address_book::lookup suggested_alias fallback).
+    let mut card_suggested_alias: Signal<Option<String>> = use_signal(|| None);
     let mut description = use_signal(String::new);
     let mut verified = use_signal(|| false);
     let mut error_msg = use_signal(String::new);
@@ -2044,6 +2049,9 @@ pub(super) fn ImportContactForm() -> Element {
 
         match crate::app::address_book::ContactCard::decode(addr_input) {
             Ok(card) => {
+                // Preserve the sender's advertised alias regardless of
+                // whether the user keeps or overrides it as local_alias.
+                card_suggested_alias.set(card.suggested_alias.clone());
                 if local_alias.read().is_empty()
                     && let Some(ref s) = card.suggested_alias
                 {
@@ -2285,10 +2293,20 @@ pub(super) fn ImportContactForm() -> Element {
                                 error_msg.set("That address belongs to one of your own identities.".into());
                                 return;
                             }
+                            // Persist the SENDER's advertised alias (from the
+                            // card), not the possibly-relabelled local_alias —
+                            // that's what makes the suggested_alias resolver
+                            // fallback useful. Fall back to local_alias for
+                            // cards that carried no suggested alias, so the
+                            // field is never silently empty.
+                            let suggested = card_suggested_alias
+                                .read()
+                                .clone()
+                                .filter(|s| !s.is_empty() && *s != alias_str);
                             let stored = crate::app::address_book::StoredContactKeys {
                                 ml_dsa_vk_bytes: vk,
                                 ml_kem_ek_bytes: ek,
-                                suggested_alias: Some(alias_str.clone()),
+                                suggested_alias: suggested,
                                 verified: *verified.read(),
                                 required_tier: tier,
                                 max_age_secs: max_age,
@@ -2306,6 +2324,7 @@ pub(super) fn ImportContactForm() -> Element {
                             *import_contact_form.write() = ImportContact::default();
                             paste_text.set(String::new());
                             local_alias.set(String::new());
+                            card_suggested_alias.set(None);
                             description.set(String::new());
                             verified.set(false);
                             fingerprint_words.set(None);


### PR DESCRIPTION
## Summary

Fixes the contact-resolution half of #289 — reply/compose To field fails to resolve when the recipient imported a contact card but relabelled it with a different local nickname than the alias the sender advertised.

**Scenario (from the issue, repro'd by Ivvor):** A sends to B. B has no contact for A, adds A from the incoming card but picks a *different* local nickname. B types A's original name in To → "Not in address book," even though A is a contact. B has to hand-edit To to match their own local label.

**Root cause:** the address book is keyed solely by `local_alias`, and `lookup` did an exact-key match. The sender's advertised alias (`ContactCard.suggested_alias`) was:
1. dropped from `Contact` in `into_contact` (though `StoredContactKeys` already persisted it), and
2. overwritten with the relabelled `local_alias` at import-submit + in `create_contact_api_call`.

So the name the sender shared became un-typeable the moment the user relabelled.

## Fix

- `Contact` retains `suggested_alias` (the sender's card alias).
- Import form captures the card's `suggested_alias` into a dedicated signal so it survives the user overriding `local_alias`, and persists it (only when it differs from the local label).
- `address_book::lookup` falls back to a `suggested_alias` scan on an exact-local-alias miss. **Exact local-alias matches always win**, so relabelling is never shadowed by someone else's suggested alias.
- `create_contact_api_call` persists the contact's actual `suggested_alias` instead of hardcoding `local_alias`.

Resolved recipients always keep the user's chosen `local_alias` — the suggested alias is only an additional lookup handle, never surfaced as the label.

## Scope

This is the **resolver** half of #289. The issue also mentions auto-resolving the reply path by the sender's ML-DSA VK / inbox key (resolve-by-key, no typing) — left as a follow-up; this PR makes both the local label and the sender's advertised alias resolve as typed strings.

## Tests

6 new `address_book` resolver cases:
- resolve by local alias / by suggested alias / exact-wins-over-suggested / unknown→none / no-suggested→local-only
- `lookup_resolves_by_sender_alias_when_suggested_preserved_289` — the #289 positive case, alongside the existing `lookup_misses_when_contact_imported_under_different_nickname_289` characterization (still valid: a contact with no stored suggested alias still misses).

184/184 ui lib tests green, clippy clean.

Refs #289.
