### PR TITLE
fix(toast): spawn_forever for auto-dismiss timer (#290)

### DIFF
--- a/ui/src/toast.rs
+++ b/ui/src/toast.rs
@@ -123,10 +123,20 @@ pub(crate) fn push_toast(message: impl Into<String>, level: ToastLevel) -> Toast
 
     // Spawn a TTL timer. It captures the id and only removes *this* toast,
     // so a newer toast that happens to sit at the same index is never cleared.
+    //
+    // spawn_forever, not spawn (#290): the "Sent" toast is pushed from the
+    // compose component, whose send handler then navigates away and unmounts
+    // it. A bare spawn() ties the TTL future to that scope and cancels it on
+    // unmount, so the toast never auto-dismissed and stuck on screen forever.
+    // spawn_forever detaches the timer so it outlives the pushing component.
+    //
+    // The queue Signal is Copy and captured by value, so the detached task
+    // mutates it directly instead of re-reading use_context (which would read
+    // the wrong scope's context outside the component tree).
     let ttl = level.ttl_ms();
-    spawn(async move {
+    let _task = dioxus_core::spawn_forever(async move {
         gloo_timers::future::TimeoutFuture::new(ttl).await;
-        dismiss_toast(id);
+        queue.write().retain(|t| t.id != id);
     });
 
     id

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -311,18 +311,14 @@ test.describe("Send returns to inbox view (regression: spawn_forever)", () => {
 // a handler that also navigates must use spawn_forever / a navigation-stable
 // scope for the timer.)
 //
-// EXPECTED (once #290 is fixed): the 'Sent' toast disappears on its own after
-// its TTL. TODAY it sticks, so this is test.fail() and flips to a hard
-// failure once the timer survives navigation.
+// #290 FIXED: toast.rs::push_toast now starts the TTL timer with
+// dioxus_core::spawn_forever, so it survives the compose sheet unmounting on
+// navigate-away. The 'Sent' toast auto-dismisses after its TTL. This guards
+// the fix — it fails if the timer is ever re-tied to a component scope.
 test.describe("'Sent' toast auto-dismisses after send (#290)", () => {
   test("the success toast disappears on its own after its TTL", async ({
     page,
   }) => {
-    // #290 is an OPEN bug: the navigate-away cancels the toast's TTL timer so
-    // it never auto-dismisses. This reproduces it, so it's expected-to-fail
-    // until #290 is fixed.
-    test.fail(true, "reproduces open bug #290 ('Sent' toast never auto-dismisses)");
-
     await page.goto("/");
     await waitForApp(page);
     await selectIdentity(page, "address1");


### PR DESCRIPTION
## Summary

Fixes #290 — the green "Sent" confirmation toast never auto-dismissed; it stuck on screen indefinitely after sending.

**Root cause (same class as #286/#289):** `toast.rs::push_toast` started the TTL auto-dismiss timer with a bare `spawn()`, which is component-scoped. The "Sent" toast is pushed from the compose component, whose send handler then navigates away (`at_new_msg()`) and unmounts it — cancelling the in-flight TTL future the instant it was created. So the timer never fired and the bubble persisted.

## Fix

`dioxus_core::spawn_forever` for the TTL timer, so it outlives the pushing component. The queue `Signal` is `Copy`, captured by value and mutated directly in the detached task rather than re-reading `use_context` (which would resolve the wrong scope outside the component tree).

## Verification

- `cargo test -p freenet-email-ui --lib` → 184/184 green (toast unit tests unaffected).
- Playwright guard `#290 'Sent' toast auto-dismisses after send` flipped from `test.fail` → green; confirmed locally against the offline dev server (toast gone 4.1s after send, well within the 6s assertion window).

Closes #290.
