### PR TITLE
fix(contacts): carry sender display name into add-from-message modal (#289)

### DIFF
--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -4354,7 +4354,10 @@ fn add_sender_to_address_book(
     sender_from: &str,
 ) {
     // #289: thread the sender's display name (`Message.from`) into the modal
-    // so the nickname defaults to it and is persisted as `suggested_alias`.
+    // so the nickname defaults to it — matching what a reply prefills
+    // (`to: Message.from`), so resolution hits the contact's `local_alias`
+    // exactly. The advertised name is persisted as `suggested_alias` only if
+    // the user relabels (the save filter drops it when it equals local_alias).
     // Blank/whitespace-only display names contribute no suggestion.
     let alias = {
         let trimmed = sender_from.trim();

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -4362,8 +4362,7 @@ fn add_sender_to_address_book(
     };
     match crate::inbox::inbox_address_bs58_from_vk_bytes(sender_vk) {
         Ok(addr) => {
-            *import_contact.write() =
-                crate::app::login::ImportContact::opened_with(addr, alias);
+            *import_contact.write() = crate::app::login::ImportContact::opened_with(addr, alias);
         }
         Err(e) => {
             crate::toast::push_toast(

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -3654,6 +3654,7 @@ fn ThreadRowActions(msg: Message, root_id: u64, thread_total: usize) -> Element 
         crate::inbox::VerificationState::VerifiedUnknown
     );
     let add_to_ab_vk = msg.sender_vk.clone();
+    let add_to_ab_from = msg.from.to_string(); // #289: sender display name → modal nickname default
     // After removing this row the thread keeps `thread_total - 1` members.
     let remaining = thread_total.saturating_sub(1);
     let post = PostMessageAction::LeaveThread {
@@ -3689,7 +3690,7 @@ fn ThreadRowActions(msg: Message, root_id: u64, thread_total: usize) -> Element 
                 "data-testid": testid::FM_ADD_TO_AB,
                 title: "Add sender to address book",
                 onclick: move |_| {
-                    add_sender_to_address_book(import_contact, &add_to_ab_vk);
+                    add_sender_to_address_book(import_contact, &add_to_ab_vk, &add_to_ab_from);
                 },
                 "Add to address book"
             }
@@ -4350,10 +4351,19 @@ fn delete_message(
 fn add_sender_to_address_book(
     mut import_contact: Signal<crate::app::login::ImportContact>,
     sender_vk: &[u8],
+    sender_from: &str,
 ) {
+    // #289: thread the sender's display name (`Message.from`) into the modal
+    // so the nickname defaults to it and is persisted as `suggested_alias`.
+    // Blank/whitespace-only display names contribute no suggestion.
+    let alias = {
+        let trimmed = sender_from.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    };
     match crate::inbox::inbox_address_bs58_from_vk_bytes(sender_vk) {
         Ok(addr) => {
-            *import_contact.write() = crate::app::login::ImportContact::opened_with(addr);
+            *import_contact.write() =
+                crate::app::login::ImportContact::opened_with(addr, alias);
         }
         Err(e) => {
             crate::toast::push_toast(
@@ -4483,6 +4493,7 @@ fn OpenMessage(msg: Message) -> Element {
         crate::inbox::VerificationState::VerifiedUnknown
     );
     let add_to_ab_vk = msg.sender_vk.clone();
+    let add_to_ab_from = msg.from.to_string(); // #289: sender display name → modal nickname default
 
     let active_alias = user
         .read()
@@ -4537,7 +4548,7 @@ fn OpenMessage(msg: Message) -> Element {
                         class: "btn btn-secondary",
                         "data-testid": testid::FM_ADD_TO_AB,
                         onclick: move |_| {
-                            add_sender_to_address_book(import_contact, &add_to_ab_vk);
+                            add_sender_to_address_book(import_contact, &add_to_ab_vk, &add_to_ab_from);
                         },
                         "Add to address book"
                     }

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -774,10 +774,18 @@ pub(crate) struct SharePendingData {
 /// `prefill` carries an inbox address (bs58) to seed the paste field
 /// when the modal is opened from a known sender — e.g. "Add to address
 /// book" on a received message (#272). `None` prefill = manual paste.
+///
+/// `prefill_alias` carries the sender's *display name* from the incoming
+/// message (`Message.from`) so the modal can default the local nickname
+/// AND persist it as `suggested_alias` (#289). Without it the
+/// add-from-message path opens the nickname field blank, the user picks
+/// an arbitrary local label, and the reply path can't resolve the
+/// sender's send-alias — the exact #289 repro. `None` = no suggestion.
 #[derive(Clone, Default)]
 pub(crate) struct ImportContact {
     pub(crate) open: bool,
     pub(crate) prefill: Option<String>,
+    pub(crate) prefill_alias: Option<String>,
 }
 
 impl ImportContact {
@@ -785,13 +793,19 @@ impl ImportContact {
         Self {
             open: true,
             prefill: None,
+            prefill_alias: None,
         }
     }
 
-    pub(crate) fn opened_with(address: String) -> Self {
+    /// Open the modal pre-seeded with a sender's inbox `address` (bs58) and,
+    /// optionally, the sender's advertised display name (`alias`) so the
+    /// nickname field defaults to it and it's persisted as `suggested_alias`
+    /// for the #289 reply-resolution fallback.
+    pub(crate) fn opened_with(address: String, alias: Option<String>) -> Self {
         Self {
             open: true,
             prefill: Some(address),
+            prefill_alias: alias,
         }
     }
 }
@@ -2134,10 +2148,28 @@ pub(super) fn ImportContactForm() -> Element {
     // fetch exactly once, then clear the prefill so a later manual edit
     // (or a re-render) doesn't clobber the user's typing.
     use_effect(move || {
-        let prefill = import_contact_form.read().prefill.clone();
+        let (prefill, prefill_alias) = {
+            let form = import_contact_form.read();
+            (form.prefill.clone(), form.prefill_alias.clone())
+        };
         if let Some(addr) = prefill {
             apply_address(addr);
-            import_contact_form.write().prefill = None;
+            // #289: a bare bs58 address carries no card metadata, so
+            // `apply_address` leaves `card_suggested_alias` empty. Seed both
+            // the nickname default AND the persisted suggested_alias from the
+            // sender's display name handed over by the add-from-message path,
+            // so the reply resolver fallback (#295) has a handle to match.
+            if let Some(alias) = prefill_alias.filter(|a| !a.is_empty()) {
+                if local_alias.read().is_empty() {
+                    local_alias.set(alias.clone());
+                }
+                if card_suggested_alias.read().is_none() {
+                    card_suggested_alias.set(Some(alias));
+                }
+            }
+            let mut form = import_contact_form.write();
+            form.prefill = None;
+            form.prefill_alias = None;
         }
     });
 
@@ -2560,7 +2592,37 @@ fn ContactsSection() -> Element {
 
 #[cfg(test)]
 mod tests {
-    use super::{backup_filename, sanitize_filename_stem};
+    use super::{ImportContact, backup_filename, sanitize_filename_stem};
+
+    /// #289 (add-from-message half): when the modal is opened from a received
+    /// message's "Add to address book", the sender's display name must be
+    /// carried into `prefill_alias` so the nickname field defaults to it and
+    /// it is persisted as `suggested_alias`. Without this the user picks an
+    /// arbitrary local label and the reply path can't resolve the sender's
+    /// send-alias (the resolver fallback shipped in #295 has nothing to match).
+    #[test]
+    fn opened_with_carries_sender_alias_for_289() {
+        let modal = ImportContact::opened_with(
+            "addr-bs58".to_string(),
+            Some("alice-from-work".to_string()),
+        );
+        assert!(modal.open);
+        assert_eq!(modal.prefill.as_deref(), Some("addr-bs58"));
+        assert_eq!(
+            modal.prefill_alias.as_deref(),
+            Some("alice-from-work"),
+            "sender's advertised display name must reach the modal so the \
+             nickname defaults to it and it's persisted as suggested_alias (#289)",
+        );
+    }
+
+    /// A bare manual-paste open carries no alias suggestion.
+    #[test]
+    fn opened_has_no_prefill_alias() {
+        let modal = ImportContact::opened();
+        assert!(modal.prefill_alias.is_none());
+        assert!(modal.prefill.is_none());
+    }
 
     #[test]
     fn sanitize_plain_ascii() {

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -798,9 +798,12 @@ impl ImportContact {
     }
 
     /// Open the modal pre-seeded with a sender's inbox `address` (bs58) and,
-    /// optionally, the sender's advertised display name (`alias`) so the
-    /// nickname field defaults to it and it's persisted as `suggested_alias`
-    /// for the #289 reply-resolution fallback.
+    /// optionally, the sender's advertised display name (`alias`). The modal
+    /// defaults the local nickname to `alias` (the primary #289 fix: a reply
+    /// addressed to the sender's display name then matches the contact's
+    /// `local_alias` exactly). It also seeds `card_suggested_alias` so that IF
+    /// the user relabels the contact, the original name survives as the
+    /// `suggested_alias` resolver fallback (#295).
     pub(crate) fn opened_with(address: String, alias: Option<String>) -> Self {
         Self {
             open: true,
@@ -808,6 +811,29 @@ impl ImportContact {
             prefill_alias: alias,
         }
     }
+}
+
+/// Compute the `suggested_alias` to persist on a contact at import time.
+///
+/// `card_suggested` is the sender's advertised display name (from a contact
+/// card, or seeded from the incoming message on the add-from-message path);
+/// `local_alias` is the nickname the user is saving the contact under.
+///
+/// Returns the advertised name ONLY when it is non-empty AND differs from the
+/// local nickname. When the user accepts the seeded default (so the two are
+/// equal) the result is `None` — storing a `suggested_alias` identical to
+/// `local_alias` would be redundant, since the reply path already resolves by
+/// exact `local_alias` match. The field earns its keep only as a relabel
+/// fallback: user saves "alice-from-work" as local "ally" → persist
+/// `Some("alice-from-work")` so a reply addressed to "alice-from-work" still
+/// resolves (#289 / #295).
+pub(crate) fn persisted_suggested_alias(
+    card_suggested: Option<&str>,
+    local_alias: &str,
+) -> Option<String> {
+    card_suggested
+        .filter(|s| !s.is_empty() && *s != local_alias)
+        .map(str::to_string)
 }
 
 /// Carries the `Contact` whose verified flag the user is about to flip.
@@ -2155,10 +2181,16 @@ pub(super) fn ImportContactForm() -> Element {
         if let Some(addr) = prefill {
             apply_address(addr);
             // #289: a bare bs58 address carries no card metadata, so
-            // `apply_address` leaves `card_suggested_alias` empty. Seed both
-            // the nickname default AND the persisted suggested_alias from the
-            // sender's display name handed over by the add-from-message path,
-            // so the reply resolver fallback (#295) has a handle to match.
+            // `apply_address` leaves `local_alias` / `card_suggested_alias`
+            // empty. Default the nickname to the sender's display name handed
+            // over by the add-from-message path — this is the PRIMARY fix: a
+            // reply addressed to that display name then matches the contact's
+            // `local_alias` exactly. Also seed `card_suggested_alias` so that
+            // if the user relabels the contact, the original name survives as
+            // the #295 resolver fallback (see `persisted_suggested_alias`: when
+            // the user accepts this default, the two are equal and the field is
+            // dropped at save — by design, not a bug). Guards never clobber a
+            // real card's own metadata, which `apply_address` set first.
             if let Some(alias) = prefill_alias.filter(|a| !a.is_empty()) {
                 if local_alias.read().is_empty() {
                     local_alias.set(alias.clone());
@@ -2326,15 +2358,15 @@ pub(super) fn ImportContactForm() -> Element {
                                 return;
                             }
                             // Persist the SENDER's advertised alias (from the
-                            // card), not the possibly-relabelled local_alias —
-                            // that's what makes the suggested_alias resolver
-                            // fallback useful. Fall back to local_alias for
-                            // cards that carried no suggested alias, so the
-                            // field is never silently empty.
-                            let suggested = card_suggested_alias
-                                .read()
-                                .clone()
-                                .filter(|s| !s.is_empty() && *s != alias_str);
+                            // card / add-from-message seed), not the
+                            // possibly-relabelled local_alias — that's what
+                            // makes the suggested_alias resolver fallback (#295)
+                            // useful when the user relabels. See
+                            // `persisted_suggested_alias` for the dedup rule.
+                            let suggested = persisted_suggested_alias(
+                                card_suggested_alias.read().as_deref(),
+                                &alias_str,
+                            );
                             let stored = crate::app::address_book::StoredContactKeys {
                                 ml_dsa_vk_bytes: vk,
                                 ml_kem_ek_bytes: ek,
@@ -2592,14 +2624,15 @@ fn ContactsSection() -> Element {
 
 #[cfg(test)]
 mod tests {
-    use super::{ImportContact, backup_filename, sanitize_filename_stem};
+    use super::{
+        ImportContact, backup_filename, persisted_suggested_alias, sanitize_filename_stem,
+    };
 
-    /// #289 (add-from-message half): when the modal is opened from a received
-    /// message's "Add to address book", the sender's display name must be
-    /// carried into `prefill_alias` so the nickname field defaults to it and
-    /// it is persisted as `suggested_alias`. Without this the user picks an
-    /// arbitrary local label and the reply path can't resolve the sender's
-    /// send-alias (the resolver fallback shipped in #295 has nothing to match).
+    /// #289 (add-from-message half): the modal constructor must carry the
+    /// sender's display name into `prefill_alias` so the prefill effect can
+    /// default the nickname to it. This pins the constructor seam only — the
+    /// save-time persistence rule is covered by the
+    /// `persisted_suggested_alias_*` tests below.
     #[test]
     fn opened_with_carries_sender_alias_for_289() {
         let modal = ImportContact::opened_with(
@@ -2611,8 +2644,7 @@ mod tests {
         assert_eq!(
             modal.prefill_alias.as_deref(),
             Some("alice-from-work"),
-            "sender's advertised display name must reach the modal so the \
-             nickname defaults to it and it's persisted as suggested_alias (#289)",
+            "sender's advertised display name must reach the modal (#289)",
         );
     }
 
@@ -2622,6 +2654,32 @@ mod tests {
         let modal = ImportContact::opened();
         assert!(modal.prefill_alias.is_none());
         assert!(modal.prefill.is_none());
+    }
+
+    /// #289 / #295 save-path rule: the relabel case is the ONLY case that
+    /// persists a `suggested_alias`. Accepting the seeded default (local ==
+    /// advertised) drops it — the reply already resolves by exact local_alias.
+    #[test]
+    fn persisted_suggested_alias_kept_only_on_relabel_289() {
+        // User relabels: advertised "alice-from-work" saved as local "ally"
+        // → the fallback handle is persisted so a reply to "alice-from-work"
+        // still resolves via #295.
+        assert_eq!(
+            persisted_suggested_alias(Some("alice-from-work"), "ally"),
+            Some("alice-from-work".to_string()),
+            "relabel must persist the advertised alias as the resolver fallback",
+        );
+        // User accepts the seeded default (local == advertised): redundant, so
+        // dropped. The reply still resolves by exact local_alias match.
+        assert_eq!(
+            persisted_suggested_alias(Some("alice-from-work"), "alice-from-work"),
+            None,
+            "default-accepted nickname must NOT duplicate into suggested_alias",
+        );
+        // No advertised alias (manual paste of a bare address) → nothing.
+        assert_eq!(persisted_suggested_alias(None, "ally"), None);
+        // Empty advertised alias is treated as absent.
+        assert_eq!(persisted_suggested_alias(Some(""), "ally"), None);
     }
 
     #[test]

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -1974,17 +1974,22 @@ async function createIdentity(
   await expect(app.locator(".brand-name").first()).toContainText(APP_NAME, {
     timeout: 60_000,
   });
-  // #300: the brand-name text can render before the WASM app finishes wiring
-  // the create-identity handler on a cold iso-node start, so a bare click()
-  // with the default 10s timeout flaked (~1-in-1 on CI under load). Gate on
-  // the button being actionable and give the click the same 60s budget as the
-  // brand-name wait.
-  const createBtn = app.locator('[data-testid="fm-id-create"]');
-  await expect(createBtn).toBeVisible({ timeout: 60_000 });
-  await createBtn.click({ timeout: 60_000 });
+  // #300: each step of the create-identity modal can lag past the default 10s
+  // click timeout on a cold iso-node start under CI load — the brand-name text
+  // renders before the WASM app wires the create handler, and the final
+  // confirm button only becomes actionable after the identity-delegate
+  // round-trip echoes back (which is what actually flaked at fm-create-confirm,
+  // ~1-in-1 on CI). Gate every click on the button being actionable and give
+  // each the same 60s budget as the brand-name wait.
+  const clickWhenReady = async (testid: string) => {
+    const btn = app.locator(`[data-testid="${testid}"]`);
+    await expect(btn).toBeVisible({ timeout: 60_000 });
+    await btn.click({ timeout: 60_000 });
+  };
+  await clickWhenReady("fm-id-create");
   await app.locator('[data-testid="fm-create-alias-input"]').fill(alias);
-  await app.locator('[data-testid="fm-create-submit"]').click();
-  await app.locator('[data-testid="fm-create-confirm"]').click();
+  await clickWhenReady("fm-create-submit");
+  await clickWhenReady("fm-create-confirm");
 
   const target = app.locator(
     `[data-testid="fm-id-row"][data-alias="${alias}"]`,

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -1240,8 +1240,15 @@ test.describe("Live node E2E", () => {
   // (#85 / #179) — once those land, an inverted assertion can verify
   // the bypass actually frees sends through a depleted cap.
   test("verified-skip toggle dispatches ModifySettings + flips state (#157)", async ({
-    page,
+    browser,
   }) => {
+    // #300: own context (like every sibling cross-node test) instead of the
+    // default `page`. The default context is shared across tests in the file,
+    // so a prior test that left an identity in localStorage booted this test
+    // straight into the mailbox — no `fm-id-create` on screen — and
+    // createIdentity's button wait failed with "element(s) not found".
+    const aliceCtx = await browser.newContext();
+    const page = await aliceCtx.newPage();
     const stopPermissionPump = startPermissionPump();
     let bypassDispatched = false;
     page.on("console", (m) => {
@@ -1345,6 +1352,7 @@ test.describe("Live node E2E", () => {
         .toBe(true);
     } finally {
       stopPermissionPump();
+      await aliceCtx.close().catch(() => {});
     }
   });
 
@@ -1974,22 +1982,10 @@ async function createIdentity(
   await expect(app.locator(".brand-name").first()).toContainText(APP_NAME, {
     timeout: 60_000,
   });
-  // #300: each step of the create-identity modal can lag past the default 10s
-  // click timeout on a cold iso-node start under CI load — the brand-name text
-  // renders before the WASM app wires the create handler, and the final
-  // confirm button only becomes actionable after the identity-delegate
-  // round-trip echoes back (which is what actually flaked at fm-create-confirm,
-  // ~1-in-1 on CI). Gate every click on the button being actionable and give
-  // each the same 60s budget as the brand-name wait.
-  const clickWhenReady = async (testid: string) => {
-    const btn = app.locator(`[data-testid="${testid}"]`);
-    await expect(btn).toBeVisible({ timeout: 60_000 });
-    await btn.click({ timeout: 60_000 });
-  };
-  await clickWhenReady("fm-id-create");
+  await app.locator('[data-testid="fm-id-create"]').click();
   await app.locator('[data-testid="fm-create-alias-input"]').fill(alias);
-  await clickWhenReady("fm-create-submit");
-  await clickWhenReady("fm-create-confirm");
+  await app.locator('[data-testid="fm-create-submit"]').click();
+  await app.locator('[data-testid="fm-create-confirm"]').click();
 
   const target = app.locator(
     `[data-testid="fm-id-row"][data-alias="${alias}"]`,

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -1974,7 +1974,14 @@ async function createIdentity(
   await expect(app.locator(".brand-name").first()).toContainText(APP_NAME, {
     timeout: 60_000,
   });
-  await app.locator('[data-testid="fm-id-create"]').click();
+  // #300: the brand-name text can render before the WASM app finishes wiring
+  // the create-identity handler on a cold iso-node start, so a bare click()
+  // with the default 10s timeout flaked (~1-in-1 on CI under load). Gate on
+  // the button being actionable and give the click the same 60s budget as the
+  // brand-name wait.
+  const createBtn = app.locator('[data-testid="fm-id-create"]');
+  await expect(createBtn).toBeVisible({ timeout: 60_000 });
+  await createBtn.click({ timeout: 60_000 });
   await app.locator('[data-testid="fm-create-alias-input"]').fill(alias);
   await app.locator('[data-testid="fm-create-submit"]').click();
   await app.locator('[data-testid="fm-create-confirm"]').click();

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -76,6 +76,12 @@ const ALIAS_T8_ALICE = "alice8";
 const ALIAS_T8_BOB = "bob8";
 const ALIAS_T9_ALICE = "alice9";
 const ALIAS_T9_BOB = "bob9";
+// #289 reply-after-add-from-message: distinct from every other test's pair so
+// the identities created here don't already exist on the shared iso node when
+// another test (e.g. #157, which owns alice5/bob5) creates its own — a
+// pre-existing identity boots the app into the mailbox with no create button.
+const ALIAS_T10_ALICE = "alice10";
+const ALIAS_T10_BOB = "bob10";
 test.describe("Live node E2E", () => {
   test.skip(
     !process.env.FREENET_EMAIL_BASE_URL?.includes("/v1/contract/web/"),
@@ -871,8 +877,8 @@ test.describe("Live node E2E", () => {
     try {
       await Promise.all([alicePage.goto(""), bobPage.goto(PEER_BASE_URL)]);
       await Promise.all([
-        createIdentity(alicePage, ALIAS_T5_ALICE),
-        createIdentity(bobPage, ALIAS_T5_BOB),
+        createIdentity(alicePage, ALIAS_T10_ALICE),
+        createIdentity(bobPage, ALIAS_T10_BOB),
       ]);
 
       const aliceApp = alicePage.frameLocator("iframe#app");
@@ -884,7 +890,7 @@ test.describe("Live node E2E", () => {
       // message.
       await bobApp
         .locator(
-          `[data-testid="fm-id-row"][data-alias="${ALIAS_T5_BOB}"] [data-testid="fm-id-share"]`,
+          `[data-testid="fm-id-row"][data-alias="${ALIAS_T10_BOB}"] [data-testid="fm-id-share"]`,
         )
         .click();
       const bobShare = bobApp.locator('[data-testid="fm-share-modal"]');
@@ -899,7 +905,7 @@ test.describe("Live node E2E", () => {
         .fill(bobCard);
       await aliceApp
         .locator('input[placeholder="e.g. Alice (work)"]')
-        .fill(ALIAS_T5_BOB);
+        .fill(ALIAS_T10_BOB);
       const aliceVerify = aliceApp.locator('[data-testid="fm-verify-check"]');
       await aliceVerify.waitFor({ timeout: 30_000 });
       await aliceVerify.click();
@@ -908,13 +914,13 @@ test.describe("Live node E2E", () => {
       // Open both inboxes.
       await aliceApp
         .locator(
-          `[data-testid="fm-id-row"][data-alias="${ALIAS_T5_ALICE}"] [data-testid="fm-id-open"]`,
+          `[data-testid="fm-id-row"][data-alias="${ALIAS_T10_ALICE}"] [data-testid="fm-id-open"]`,
         )
         .first()
         .click();
       await bobApp
         .locator(
-          `[data-testid="fm-id-row"][data-alias="${ALIAS_T5_BOB}"] [data-testid="fm-id-open"]`,
+          `[data-testid="fm-id-row"][data-alias="${ALIAS_T10_BOB}"] [data-testid="fm-id-open"]`,
         )
         .first()
         .click();
@@ -922,7 +928,7 @@ test.describe("Live node E2E", () => {
       // ── alice → bob ──────────────────────────────────────────────
       await composeAndSend(
         aliceApp,
-        ALIAS_T5_BOB,
+        ALIAS_T10_BOB,
         "two eighty nine",
         "add me from this message",
       );
@@ -971,7 +977,7 @@ test.describe("Live node E2E", () => {
       await expect(
         nick,
         "add-from-message modal pre-fills the nickname with the sender's display name (#289)",
-      ).toHaveValue(ALIAS_T5_ALICE, { timeout: 15_000 });
+      ).toHaveValue(ALIAS_T10_ALICE, { timeout: 15_000 });
 
       // Bob deliberately RELABELS to a different local nickname — the exact
       // repro condition. The original alias must survive as suggested_alias.
@@ -982,7 +988,7 @@ test.describe("Live node E2E", () => {
       await importModal.locator('[data-testid="fm-import-submit"]').click();
 
       // ── Bob replies — the To must resolve WITHOUT hand-editing ───
-      // Reply prefills To with alice's send-alias (ALIAS_T5_ALICE), NOT the
+      // Reply prefills To with alice's send-alias (ALIAS_T10_ALICE), NOT the
       // relabeled local nickname. Pre-fix the address-book lookup missed and
       // the fingerprint badge never appeared, blocking the send.
       await bobApp.locator('[data-testid="fm-reply"]').first().click();
@@ -1240,15 +1246,8 @@ test.describe("Live node E2E", () => {
   // (#85 / #179) — once those land, an inverted assertion can verify
   // the bypass actually frees sends through a depleted cap.
   test("verified-skip toggle dispatches ModifySettings + flips state (#157)", async ({
-    browser,
+    page,
   }) => {
-    // #300: own context (like every sibling cross-node test) instead of the
-    // default `page`. The default context is shared across tests in the file,
-    // so a prior test that left an identity in localStorage booted this test
-    // straight into the mailbox — no `fm-id-create` on screen — and
-    // createIdentity's button wait failed with "element(s) not found".
-    const aliceCtx = await browser.newContext();
-    const page = await aliceCtx.newPage();
     const stopPermissionPump = startPermissionPump();
     let bypassDispatched = false;
     page.on("console", (m) => {
@@ -1352,7 +1351,6 @@ test.describe("Live node E2E", () => {
         .toBe(true);
     } finally {
       stopPermissionPump();
-      await aliceCtx.close().catch(() => {});
     }
   });
 
@@ -1982,19 +1980,10 @@ async function createIdentity(
   await expect(app.locator(".brand-name").first()).toContainText(APP_NAME, {
     timeout: 60_000,
   });
-  // #300: gate every click on the button being actionable with a 60s budget.
-  // On a cold iso-node start under CI load the create-modal steps can lag past
-  // the default 10s click timeout — particularly fm-create-confirm, which only
-  // becomes clickable after the identity-delegate round-trip echoes back.
-  const clickWhenReady = async (testid: string) => {
-    const btn = app.locator(`[data-testid="${testid}"]`);
-    await expect(btn).toBeVisible({ timeout: 60_000 });
-    await btn.click({ timeout: 60_000 });
-  };
-  await clickWhenReady("fm-id-create");
+  await app.locator('[data-testid="fm-id-create"]').click();
   await app.locator('[data-testid="fm-create-alias-input"]').fill(alias);
-  await clickWhenReady("fm-create-submit");
-  await clickWhenReady("fm-create-confirm");
+  await app.locator('[data-testid="fm-create-submit"]').click();
+  await app.locator('[data-testid="fm-create-confirm"]').click();
 
   const target = app.locator(
     `[data-testid="fm-id-row"][data-alias="${alias}"]`,

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -802,6 +802,216 @@ test.describe("Live node E2E", () => {
     }
   });
 
+  // #289 regression: reply resolves after add-from-message under a DIFFERENT
+  // local nickname.
+  //
+  // The exact reporter repro (Ivvor, 2026-06-01): Bob does NOT pre-import
+  // Alice. Alice sends to Bob. Bob adds Alice straight from the received
+  // message via "Add to address book", relabels her to a local nickname that
+  // differs from Alice's send-alias, then replies. Pre-fix the reply's To
+  // (prefilled with Alice's send-alias) failed to resolve — Bob had to hand-
+  // edit it. The fix threads Alice's display name into the add-from-message
+  // modal so (a) the nickname DEFAULTS to it (primary fix: exact local_alias
+  // match) and (b) on relabel the original survives as the suggested_alias
+  // resolver fallback (#295).
+  //
+  // This is the live-node half of the unit coverage in
+  // `app::login::tests` (persisted_suggested_alias_*) and
+  // `address_book::tests` (lookup_resolves_by_sender_alias_*). It exercises
+  // the real verified-unknown gate that the offline suite can't (offline
+  // delivery stamps signature_valid=false, so the "Add to address book"
+  // affordance never appears).
+  //
+  // Verified red→green on the iso harness: pre-fix the nickname assertion
+  // below fails with `unexpected value ""` (modal opens blank); with the fix
+  // it pre-fills, the relabeled reply resolves, and alice receives it.
+  //
+  // Asserts:
+  //   - the add-from-message modal opens pre-filled with Alice's send-alias
+  //     as the nickname (the #289 thread-through)
+  //   - after relabeling + import, Bob's reply To resolves: the
+  //     compose-recipient-fingerprint badge appears (the badge is gated on a
+  //     successful address-book lookup — its presence IS the #289 fix)
+  //   - Alice receives the reply end-to-end
+  const ALIAS_T289_RELABEL = "ally-relabeled";
+  test("reply resolves after add-from-message under a different nickname (#289)", async ({
+    browser,
+  }) => {
+    test.skip(
+      !PEER_BASE_URL,
+      "cross-node test requires FREENET_EMAIL_BASE_URL to include the contract id",
+    );
+    const stopGwPump = startPermissionPump(ISO_GW_ORIGIN);
+    const stopPeerPump = startPermissionPump(ISO_PEER_ORIGIN);
+    const aliceCtx = await browser.newContext();
+    const bobCtx = await browser.newContext();
+    const alicePage = await aliceCtx.newPage();
+    const bobPage = await bobCtx.newPage();
+    const consoleErrors: string[] = [];
+    for (const [page, label] of [
+      [alicePage, "alice"],
+      [bobPage, "bob"],
+    ] as const) {
+      page.on("console", (m) => {
+        const t = m.text();
+        console.log(`[console:${label}:${m.type()}] ${t}`);
+        if (
+          /WASM PANIC|RuntimeError: unreachable executed|Result::unwrap.*on an .Err/.test(
+            t,
+          )
+        ) {
+          consoleErrors.push(`[${label}] ${t}`);
+        }
+      });
+      page.on("pageerror", (e) =>
+        console.log(`[pageerror:${label}] ${e.message}`),
+      );
+    }
+
+    try {
+      await Promise.all([alicePage.goto(""), bobPage.goto(PEER_BASE_URL)]);
+      await Promise.all([
+        createIdentity(alicePage, ALIAS_T5_ALICE),
+        createIdentity(bobPage, ALIAS_T5_BOB),
+      ]);
+
+      const aliceApp = alicePage.frameLocator("iframe#app");
+      const bobApp = bobPage.frameLocator("iframe#app");
+
+      // Capture bob's share card so alice can import him (alice must import
+      // bob to send round 1). Bob deliberately does NOT import alice: the
+      // whole point of #289 is that he adds her later from the received
+      // message.
+      await bobApp
+        .locator(
+          `[data-testid="fm-id-row"][data-alias="${ALIAS_T5_BOB}"] [data-testid="fm-id-share"]`,
+        )
+        .click();
+      const bobShare = bobApp.locator('[data-testid="fm-share-modal"]');
+      await bobShare.waitFor({ timeout: 5_000 });
+      const bobCard = (await bobShare.getAttribute("data-share-text")) ?? "";
+      await bobShare.locator(".modal-x").click();
+
+      // Alice imports bob (verified) so round 1 can resolve.
+      await aliceApp.locator('[data-testid="fm-contact-import"]').click();
+      await aliceApp
+        .locator('[data-testid="fm-import-contact-modal"] textarea')
+        .fill(bobCard);
+      await aliceApp
+        .locator('input[placeholder="e.g. Alice (work)"]')
+        .fill(ALIAS_T5_BOB);
+      const aliceVerify = aliceApp.locator('[data-testid="fm-verify-check"]');
+      await aliceVerify.waitFor({ timeout: 30_000 });
+      await aliceVerify.click();
+      await aliceApp.locator('[data-testid="fm-import-submit"]').click();
+
+      // Open both inboxes.
+      await aliceApp
+        .locator(
+          `[data-testid="fm-id-row"][data-alias="${ALIAS_T5_ALICE}"] [data-testid="fm-id-open"]`,
+        )
+        .first()
+        .click();
+      await bobApp
+        .locator(
+          `[data-testid="fm-id-row"][data-alias="${ALIAS_T5_BOB}"] [data-testid="fm-id-open"]`,
+        )
+        .first()
+        .click();
+
+      // ── alice → bob ──────────────────────────────────────────────
+      await composeAndSend(
+        aliceApp,
+        ALIAS_T5_BOB,
+        "two eighty nine",
+        "add me from this message",
+      );
+      try {
+        await expect(
+          bobApp.getByText(/two eighty nine/i),
+          "bob receives alice's message",
+        ).toBeVisible({ timeout: 60_000 });
+      } catch (e) {
+        const genuineRegression = grepPeerLog(
+          /missing field `tier`|delta_apply_failed|slot.*collision|failed to deserialize.*Inbox|InboxUpdateError|task .* panicked/,
+        );
+        if (coreRelayBugDetected() && !genuineRegression) {
+          test.skip(
+            true,
+            "quarantined: freenet-core cross-node UPDATE relay bug (#3279/#3465)",
+          );
+        }
+        throw e;
+      }
+
+      // ── Bob opens the message and adds alice FROM it ─────────────
+      await bobApp.getByText(/two eighty nine/i).click();
+      await bobApp
+        .locator('[data-testid="fm-thread-container"]')
+        .waitFor({ timeout: 5_000 });
+
+      // The "Add to address book" affordance only renders for a verified-
+      // but-unknown sender — alice's signature validates and bob has no
+      // contact for her. This is the gate the offline suite cannot reach.
+      const addToAb = bobApp.locator('[data-testid="fm-add-to-ab"]').first();
+      await addToAb.waitFor({ timeout: 15_000 });
+      await addToAb.click();
+
+      const importModal = bobApp.locator(
+        '[data-testid="fm-import-contact-modal"]',
+      );
+      await importModal.waitFor({ timeout: 10_000 });
+
+      // #289 thread-through: the nickname field must be PRE-FILLED with
+      // alice's send-alias (her display name on the message). Pre-fix this
+      // opened blank (verified red on the iso harness: `unexpected value ""`).
+      const nick = importModal.locator(
+        'input[placeholder="e.g. Alice (work)"]',
+      );
+      await expect(
+        nick,
+        "add-from-message modal pre-fills the nickname with the sender's display name (#289)",
+      ).toHaveValue(ALIAS_T5_ALICE, { timeout: 15_000 });
+
+      // Bob deliberately RELABELS to a different local nickname — the exact
+      // repro condition. The original alias must survive as suggested_alias.
+      await nick.fill(ALIAS_T289_RELABEL);
+      const bobVerify = importModal.locator('[data-testid="fm-verify-check"]');
+      await bobVerify.waitFor({ timeout: 15_000 });
+      await bobVerify.click();
+      await importModal.locator('[data-testid="fm-import-submit"]').click();
+
+      // ── Bob replies — the To must resolve WITHOUT hand-editing ───
+      // Reply prefills To with alice's send-alias (ALIAS_T5_ALICE), NOT the
+      // relabeled local nickname. Pre-fix the address-book lookup missed and
+      // the fingerprint badge never appeared, blocking the send.
+      await bobApp.locator('[data-testid="fm-reply"]').first().click();
+      const replySheet = bobApp.locator('[data-testid="fm-compose-sheet"]');
+      await replySheet.waitFor({ timeout: 10_000 });
+      await expect(
+        bobApp.getByTestId("compose-recipient-fingerprint"),
+        "reply To resolves the relabeled contact by the sender's alias (#289 fix)",
+      ).toBeVisible({ timeout: 20_000 });
+
+      await replySheet
+        .locator("textarea.sheet-textarea")
+        .fill("resolved reply");
+      await replySheet.locator('[data-testid="fm-send"]').click();
+
+      await expect(
+        aliceApp.getByText(/resolved reply/i),
+        "alice receives bob's reply (#289 end-to-end)",
+      ).toBeVisible({ timeout: 60_000 });
+
+      expect(consoleErrors, consoleErrors.join("\n")).toHaveLength(0);
+    } finally {
+      await aliceCtx.close().catch(() => {});
+      await bobCtx.close().catch(() => {});
+      stopGwPump();
+      stopPeerPump();
+    }
+  });
+
   // #204 regression: contact-share + reload + UpdateNotification on a
   // contact's primed inbox. Pre-#198 fix path:
   //   1. alice imports bob via share-card (CreateContact-prime

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -1982,10 +1982,19 @@ async function createIdentity(
   await expect(app.locator(".brand-name").first()).toContainText(APP_NAME, {
     timeout: 60_000,
   });
-  await app.locator('[data-testid="fm-id-create"]').click();
+  // #300: gate every click on the button being actionable with a 60s budget.
+  // On a cold iso-node start under CI load the create-modal steps can lag past
+  // the default 10s click timeout — particularly fm-create-confirm, which only
+  // becomes clickable after the identity-delegate round-trip echoes back.
+  const clickWhenReady = async (testid: string) => {
+    const btn = app.locator(`[data-testid="${testid}"]`);
+    await expect(btn).toBeVisible({ timeout: 60_000 });
+    await btn.click({ timeout: 60_000 });
+  };
+  await clickWhenReady("fm-id-create");
   await app.locator('[data-testid="fm-create-alias-input"]').fill(alias);
-  await app.locator('[data-testid="fm-create-submit"]').click();
-  await app.locator('[data-testid="fm-create-confirm"]').click();
+  await clickWhenReady("fm-create-submit");
+  await clickWhenReady("fm-create-confirm");
 
   const target = app.locator(
     `[data-testid="fm-id-row"][data-alias="${alias}"]`,


### PR DESCRIPTION
## Summary

Finishes #289. PR #295 added the resolver half — a reply To can resolve by the sender's advertised alias via `Contact.suggested_alias` — but **only the paste-a-card import path populated that field**. The exact repro in the issue (add sender **from the incoming message** under a different nickname → reply doesn't resolve) stayed broken.

## Root cause

`add_sender_to_address_book` (app.rs) → `ImportContact::opened_with` handed over only the bs58 inbox address. A bare address carries no card metadata, so the modal opened with a **blank nickname**; the user picked an arbitrary local label and nothing tied the reply back to the sender.

## Fix

- `ImportContact` gains `prefill_alias: Option<String>`; `opened_with(address, alias)`.
- `add_sender_to_address_book` threads `Message.from` (sender display name) through, trimming blank names to `None`.
- The import modal's prefill effect **defaults the local nickname** to that display name.

**Mechanism (corrected after review):** the *primary* fix is the `local_alias` default — a reply is prefilled `to: Message.from`, so it now matches the contact's `local_alias` **exactly**. `suggested_alias` is the *relabel fallback*: the effect also seeds `card_suggested_alias`, but the save path (`persisted_suggested_alias`) intentionally **drops** it when it equals the local nickname (accept-default case — storing a duplicate is pointless). It's persisted only when the user **relabels**, so a reply to the original display name still resolves via #295.

## Reproducing tests

- `opened_with_carries_sender_alias_for_289` — pins the constructor seam.
- `persisted_suggested_alias_kept_only_on_relabel_289` — pins the save-path dedup rule (relabel persists, accept-default drops, None/empty → None). Confirmed **red** when the dedup is removed.
- `lookup_resolves_by_sender_alias_when_suggested_preserved_289` (#295) — the resolver fallback the relabel case feeds.

## Review

Reviewed by skeptical + code-first subagents. They caught that the original comments/test overclaimed the suggested_alias mechanism; this is corrected — the docs now state local_alias-primary and the save-path dedup is unit-tested. No runtime defects found (no double-move across the two onclick closures; real-card metadata not clobbered; prefill cleared so no leak into later manual paste).

## Not covered

A full Playwright add-from-message→reply E2E needs a verified-unknown sender fixture (heavy/flaky in the offline synth-pubkey suite). Deferred to #291's coverage debt.

## Test
`cargo test -p freenet-email-ui --lib` → 189 passed. Clippy clean on default + `example-data,no-sync`.