### PR TITLE
fix(inbox/aft): #249 followups — #256 #254 #255 #260

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -2738,48 +2738,61 @@ pub(crate) async fn node_comms(
                 let awaiting_inbox = inbox_management::AWAITING_MIGRATION_ACK
                     .with(|a| take_awaiting_ack(&mut a.borrow_mut(), &contract_key));
                 if let Some(alias) = awaiting_inbox {
-                    if let Err(e) =
-                        identity_management::clear_pending_migration_api_call(&mut client, &alias)
-                            .await
+                    // #260: the migration PUT is durably on the network now —
+                    // clear the persistent marker. Only surface the success
+                    // toast if the clear lands; if it fails the marker stays
+                    // set (re-attempted next session), so a "migrated"
+                    // toast would over-promise.
+                    match identity_management::clear_pending_migration_api_call(&mut client, &alias)
+                        .await
                     {
-                        crate::log::error(
-                            format!(
-                                "inbox migration: clear pending marker for `{alias}` failed: {e} (#260)"
-                            ),
-                            None,
-                        );
+                        Ok(()) => {
+                            crate::toast::push_toast(
+                                format!(
+                                    "Inbox `{alias}` migrated to the new contract id after webapp upgrade."
+                                ),
+                                crate::toast::ToastLevel::Info,
+                            );
+                        }
+                        Err(e) => {
+                            crate::log::error(
+                                format!(
+                                    "inbox migration: clear pending marker for `{alias}` failed: {e} — will retry next session (#260)"
+                                ),
+                                None,
+                            );
+                        }
                     }
-                    crate::toast::push_toast(
-                        format!(
-                            "Inbox `{alias}` migrated to the new contract id after webapp upgrade."
-                        ),
-                        crate::toast::ToastLevel::Info,
-                    );
                     return;
                 }
 
                 let awaiting_aft = token_record_management::AWAITING_AFT_MIGRATION_ACK
                     .with(|a| take_awaiting_ack(&mut a.borrow_mut(), &contract_key));
                 if let Some(alias) = awaiting_aft {
-                    if let Err(e) = identity_management::clear_pending_aft_migration_api_call(
+                    // #260: same deferred-clear discipline as the inbox branch.
+                    match identity_management::clear_pending_aft_migration_api_call(
                         &mut client,
                         &alias,
                     )
                     .await
                     {
-                        crate::log::error(
-                            format!(
-                                "AFT migration: clear pending marker for `{alias}` failed: {e} (#260)"
-                            ),
-                            None,
-                        );
+                        Ok(()) => {
+                            crate::toast::push_toast(
+                                format!(
+                                    "Token ledger `{alias}` migrated to the new contract id after webapp upgrade."
+                                ),
+                                crate::toast::ToastLevel::Info,
+                            );
+                        }
+                        Err(e) => {
+                            crate::log::error(
+                                format!(
+                                    "AFT migration: clear pending marker for `{alias}` failed: {e} — will retry next session (#260)"
+                                ),
+                                None,
+                            );
+                        }
                     }
-                    crate::toast::push_toast(
-                        format!(
-                            "Token ledger `{alias}` migrated to the new contract id after webapp upgrade."
-                        ),
-                        crate::toast::ToastLevel::Info,
-                    );
                 }
             }
             HostResponse::DelegateResponse { key, values } => {

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -176,6 +176,20 @@ impl From<WebApiRequestClient> for NodeResponses {
     }
 }
 
+/// #260: pop the awaiting-ack entry whose key matches `acked`, returning its
+/// alias. Shared by the inbox and AFT `PutResponse` handlers — when a
+/// migration re-PUT is acknowledged, this is how the handler finds which
+/// alias's pending-migration marker to clear. Returns `None` if the acked key
+/// isn't a migration we're tracking (the common case: ordinary create PUTs).
+#[cfg(feature = "use-node")]
+fn take_awaiting_ack(
+    awaiting: &mut Vec<(std::rc::Rc<str>, freenet_stdlib::prelude::ContractKey)>,
+    acked: &freenet_stdlib::prelude::ContractKey,
+) -> Option<std::rc::Rc<str>> {
+    let pos = awaiting.iter().position(|(_, k)| k == acked)?;
+    Some(awaiting.remove(pos).0)
+}
+
 #[cfg(feature = "use-node")]
 mod contract_api {
     use freenet_stdlib::{client_api::ContractRequest, prelude::*};
@@ -387,6 +401,18 @@ mod inbox_management {
     thread_local! {
         pub(super) static CREATED_INBOX: RefCell<Vec<(Rc<str>, ContractKey)>> = const { RefCell::new(Vec::new()) };
 
+        /// #260: migration PUTs whose network ACK we are still awaiting.
+        /// `put_migrated_inbox` enqueues the re-PUT and returns immediately
+        /// (the PUT is NOT yet acknowledged). The pending-migration marker
+        /// on the delegate must survive until the `PutResponse` for the new
+        /// key actually lands — otherwise a PUT that enqueues then never
+        /// reaches the network leaves the marker cleared, the hash stamped,
+        /// and the migration silently abandoned forever. Entries are
+        /// `(alias, new_inbox_key)`; the `PutResponse` arm matches on the
+        /// key, clears the pending marker, and removes the entry.
+        pub(super) static AWAITING_MIGRATION_ACK: RefCell<Vec<(Rc<str>, ContractKey)>> =
+            const { RefCell::new(Vec::new()) };
+
         /// #213 inbox migration: maps an OLD inbox `ContractKey` (derived
         /// with a prior `INBOX_CODE_HASH`) to the identity that owns it.
         /// On the corresponding `GetResponse`, the api.rs handler decodes
@@ -415,25 +441,81 @@ mod inbox_management {
     /// state — the signature is over a fixed `STATE_UPDATE` salt and
     /// the identity key is unchanged, so the re-signed state validates
     /// identically.
+    /// #254: decide which ML-KEM ek a migration re-PUT should advertise.
+    ///
+    /// The migration writer re-PUTs a prior inbox state under the current
+    /// code hash. It must NOT silently overwrite an ek already published on
+    /// chain — a user who re-keyed from backup between the original PUT and
+    /// the migration would otherwise have the migration clobber the
+    /// chain-advertised ek with a stale/new local one, breaking senders who
+    /// imported the on-chain ek.
+    ///
+    /// - on-chain ek empty (pre-#249 legacy state) → stamp the local ek
+    ///   (the migration's whole point).
+    /// - on-chain ek present and equal to local → use it (no surprise).
+    /// - on-chain ek present and DIFFERENT from local → preserve the
+    ///   on-chain ek and surface the divergence so the user can confirm an
+    ///   intended rotation (re-keying is a separate explicit action).
+    #[derive(Debug, PartialEq, Eq)]
+    pub(super) enum OwnerEkChoice {
+        /// Legacy state had no ek; stamp the local identity ek.
+        StampLocal,
+        /// On-chain ek matches local; reuse it.
+        UseOnChain,
+        /// On-chain ek diverges from local; preserve on-chain and warn.
+        PreserveOnChainDiverged,
+    }
+
+    pub(super) fn select_owner_ek(on_chain_ek: &[u8], local_ek: &[u8]) -> OwnerEkChoice {
+        if on_chain_ek.is_empty() {
+            OwnerEkChoice::StampLocal
+        } else if on_chain_ek == local_ek {
+            OwnerEkChoice::UseOnChain
+        } else {
+            OwnerEkChoice::PreserveOnChainDiverged
+        }
+    }
+
     pub(super) async fn put_migrated_inbox(
         client: &mut WebApiRequestClient,
         identity: &crate::app::Identity,
         parsed: freenet_email_inbox::Inbox,
-    ) -> Result<(), DynError> {
+    ) -> Result<ContractKey, DynError> {
         use ml_dsa::signature::Keypair;
         let vk = Keypair::verifying_key(identity.ml_dsa_signing_key.as_ref());
         let params: Parameters = InboxParams {
             pub_key: crate::inbox::inbox_params_pub_key_bytes(&vk),
         }
         .try_into()?;
-        // Use the parsed state's `owner_ek_bytes` if non-empty (already
-        // populated by a prior migration); otherwise stamp the local
-        // identity's ek so the re-PUT under the new code hash carries
-        // it. This is the migration writer's responsibility (#199).
-        let owner_ek_bytes = if parsed.owner_ek_bytes.is_empty() {
-            identity.ml_kem_ek_bytes()
-        } else {
-            parsed.owner_ek_bytes
+        // #254: never silently overwrite an ek already on chain. Prefer the
+        // on-chain ek when present; only stamp the local ek for legacy
+        // (pre-#249) states that carry none. Surface a divergence so a
+        // re-key is a deliberate, user-confirmed action.
+        let local_ek = identity.ml_kem_ek_bytes();
+        let owner_ek_bytes = match select_owner_ek(&parsed.owner_ek_bytes, &local_ek) {
+            OwnerEkChoice::StampLocal => local_ek,
+            OwnerEkChoice::UseOnChain => parsed.owner_ek_bytes,
+            OwnerEkChoice::PreserveOnChainDiverged => {
+                crate::log::error(
+                    format!(
+                        "inbox migration: on-chain ek differs from local for \
+                         identity=`{}` — preserving the on-chain ek. If you \
+                         intended to rotate keys, use Re-key inbox (#254).",
+                        identity.alias()
+                    ),
+                    None,
+                );
+                crate::toast::push_toast(
+                    format!(
+                        "Inbox `{}` advertises a different encryption key than \
+                         this device. Keeping the published key. Re-key the \
+                         inbox if you meant to rotate.",
+                        identity.alias()
+                    ),
+                    crate::toast::ToastLevel::Warning,
+                );
+                parsed.owner_ek_bytes
+            }
         };
         let rebuilt = freenet_email_inbox::Inbox::new(
             identity.ml_dsa_signing_key.as_ref(),
@@ -443,11 +525,14 @@ mod inbox_management {
         );
         let state = rebuilt.serialize()?;
         let new_key = contract_api::create_contract(client, INBOX_CODE, state, &params).await?;
+        // #260: this PUT is only ENQUEUED, not yet acked. The caller records
+        // `(alias, new_key)` in AWAITING_MIGRATION_ACK and defers clearing the
+        // pending-migration marker until the matching `PutResponse` lands.
         crate::log::info(format!(
-            "inbox migration: PUT succeeded new_key={new_key} identity=`{}` (#213)",
+            "inbox migration: PUT enqueued new_key={new_key} identity=`{}` (#213)",
             identity.alias()
         ));
-        Ok(())
+        Ok(new_key)
     }
 
     /// Dispatch a `Get` for `identity`'s inbox under the prior contract
@@ -542,6 +627,36 @@ mod inbox_management {
         });
         Ok(contract_key)
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{OwnerEkChoice, select_owner_ek};
+
+        #[test]
+        fn select_owner_ek_stamps_local_for_legacy_empty_254() {
+            // Pre-#249 state carries no ek → migration stamps the local one.
+            assert_eq!(select_owner_ek(&[], &[1, 2, 3]), OwnerEkChoice::StampLocal,);
+        }
+
+        #[test]
+        fn select_owner_ek_reuses_matching_on_chain_254() {
+            assert_eq!(
+                select_owner_ek(&[9, 9, 9], &[9, 9, 9]),
+                OwnerEkChoice::UseOnChain,
+            );
+        }
+
+        #[test]
+        fn select_owner_ek_preserves_diverged_on_chain_254() {
+            // The bug: previously the migration silently used whichever ek
+            // without flagging that the on-chain ek diverges from local.
+            // A diverged on-chain ek must be preserved AND surfaced.
+            assert_eq!(
+                select_owner_ek(&[1, 2, 3], &[4, 5, 6]),
+                OwnerEkChoice::PreserveOnChainDiverged,
+            );
+        }
+    }
 }
 
 #[cfg(feature = "use-node")]
@@ -560,6 +675,13 @@ mod token_record_management {
 
     thread_local! {
         pub(super) static CREATED_AFT_RECORD: RefCell<Vec<(Rc<str>, ContractKey)>> = const { RefCell::new(Vec::new()) };
+
+        /// #260: AFT-record migration PUTs awaiting their network ACK.
+        /// Mirror of `inbox_management::AWAITING_MIGRATION_ACK` — the pending
+        /// AFT-migration marker is cleared only when the `PutResponse` for
+        /// the new token-record key lands, not when the PUT is enqueued.
+        pub(super) static AWAITING_AFT_MIGRATION_ACK: RefCell<Vec<(Rc<str>, ContractKey)>> =
+            const { RefCell::new(Vec::new()) };
 
         /// #251 improvement 3 AFT migration: maps an OLD AFT-record
         /// `ContractKey` (derived with a prior `TOKEN_RECORD_CODE_HASH`)
@@ -622,17 +744,19 @@ mod token_record_management {
         client: &mut WebApiRequestClient,
         identity: &crate::app::Identity,
         parsed: TokenAllocationRecord,
-    ) -> Result<(), DynError> {
+    ) -> Result<ContractKey, DynError> {
         let vk = Keypair::verifying_key(identity.ml_dsa_signing_key.as_ref());
         let params: Parameters = TokenDelegateParameters::new(&vk).try_into()?;
         let state = parsed.serialized()?;
         let new_key =
             contract_api::create_contract(client, TOKEN_RECORD_CODE, state, &params).await?;
+        // #260: enqueued, not acked — caller records the key and defers the
+        // pending-marker clear to the matching `PutResponse`.
         crate::log::info(format!(
-            "AFT migration: PUT succeeded new_key={new_key} identity=`{}` (#251)",
+            "AFT migration: PUT enqueued new_key={new_key} identity=`{}` (#251)",
             identity.alias()
         ));
-        Ok(())
+        Ok(new_key)
     }
 
     /// Dispatch a `Get` for `identity`'s AFT record under each prior
@@ -2142,53 +2266,47 @@ pub(crate) async fn node_comms(
                                         match serde_json::from_slice::<StoredInbox>(state.as_ref())
                                         {
                                             Ok(parsed) => {
-                                                if let Err(e) =
-                                                    inbox_management::put_migrated_inbox(
-                                                        &mut client,
-                                                        &identity,
-                                                        parsed,
-                                                    )
-                                                    .await
+                                                match inbox_management::put_migrated_inbox(
+                                                    &mut client,
+                                                    &identity,
+                                                    parsed,
+                                                )
+                                                .await
                                                 {
-                                                    crate::log::error(
-                                                        format!(
-                                                            "inbox migration: PUT failed for `{alias_str}`: {e} (#213)"
-                                                        ),
-                                                        None,
-                                                    );
-                                                    inbox_management::MIGRATED_IDENTITIES.with(
-                                                        |s| {
-                                                            s.borrow_mut().remove(&vk_key);
-                                                        },
-                                                    );
-                                                } else {
-                                                    // #251 improvement 5:
-                                                    // clear the persistent
-                                                    // pending-migration marker
-                                                    // now that the PUT
-                                                    // succeeded. Until this
-                                                    // clear lands, subsequent
-                                                    // session restarts would
-                                                    // re-attempt the GET.
-                                                    if let Err(e) = identity_management::clear_pending_migration_api_call(
-                                                        &mut client,
-                                                        &alias_str,
-                                                    )
-                                                    .await
-                                                    {
+                                                    Err(e) => {
                                                         crate::log::error(
                                                             format!(
-                                                                "inbox migration: clear pending marker for `{alias_str}` failed: {e} (#251)"
+                                                                "inbox migration: PUT failed for `{alias_str}`: {e} (#213)"
                                                             ),
                                                             None,
                                                         );
+                                                        inbox_management::MIGRATED_IDENTITIES.with(
+                                                            |s| {
+                                                                s.borrow_mut().remove(&vk_key);
+                                                            },
+                                                        );
                                                     }
-                                                    crate::toast::push_toast(
-                                                        format!(
-                                                            "Inbox `{alias_str}` migrated to the new contract id after webapp upgrade."
-                                                        ),
-                                                        crate::toast::ToastLevel::Info,
-                                                    );
+                                                    Ok(new_key) => {
+                                                        // #260: the PUT is only
+                                                        // ENQUEUED here. Do NOT
+                                                        // clear the pending
+                                                        // marker yet — record
+                                                        // the awaited key and
+                                                        // defer the clear to the
+                                                        // `PutResponse` arm so a
+                                                        // PUT that never lands on
+                                                        // the network re-attempts
+                                                        // next session instead of
+                                                        // being silently
+                                                        // abandoned.
+                                                        inbox_management::AWAITING_MIGRATION_ACK
+                                                            .with(|a| {
+                                                                a.borrow_mut().push((
+                                                                    alias_str.clone().into(),
+                                                                    new_key,
+                                                                ));
+                                                            });
+                                                    }
                                                 }
                                             }
                                             Err(e) => {
@@ -2245,44 +2363,38 @@ pub(crate) async fn node_comms(
                                             state.as_ref()
                                         ) {
                                             Ok(parsed) => {
-                                                if let Err(e) =
-                                                    token_record_management::put_migrated_aft_record(
-                                                        &mut client,
-                                                        &identity,
-                                                        parsed,
-                                                    )
-                                                    .await
+                                                match token_record_management::put_migrated_aft_record(
+                                                    &mut client,
+                                                    &identity,
+                                                    parsed,
+                                                )
+                                                .await
                                                 {
-                                                    crate::log::error(
-                                                        format!(
-                                                            "AFT migration: PUT failed for `{alias_str}`: {e} (#251)"
-                                                        ),
-                                                        None,
-                                                    );
-                                                    token_record_management::MIGRATED_AFT_IDENTITIES
-                                                        .with(|s| {
-                                                            s.borrow_mut().remove(&vk_key);
-                                                        });
-                                                } else {
-                                                    if let Err(e) = identity_management::clear_pending_aft_migration_api_call(
-                                                        &mut client,
-                                                        &alias_str,
-                                                    )
-                                                    .await
-                                                    {
+                                                    Err(e) => {
                                                         crate::log::error(
                                                             format!(
-                                                                "AFT migration: clear pending marker for `{alias_str}` failed: {e} (#251)"
+                                                                "AFT migration: PUT failed for `{alias_str}`: {e} (#251)"
                                                             ),
                                                             None,
                                                         );
+                                                        token_record_management::MIGRATED_AFT_IDENTITIES
+                                                            .with(|s| {
+                                                                s.borrow_mut().remove(&vk_key);
+                                                            });
                                                     }
-                                                    crate::toast::push_toast(
-                                                        format!(
-                                                            "AFT token ledger for `{alias_str}` migrated to the new contract id after webapp upgrade."
-                                                        ),
-                                                        crate::toast::ToastLevel::Info,
-                                                    );
+                                                    Ok(new_key) => {
+                                                        // #260: enqueued only —
+                                                        // defer the pending-marker
+                                                        // clear to the matching
+                                                        // `PutResponse`.
+                                                        token_record_management::AWAITING_AFT_MIGRATION_ACK
+                                                            .with(|a| {
+                                                                a.borrow_mut().push((
+                                                                    alias_str.clone().into(),
+                                                                    new_key,
+                                                                ));
+                                                            });
+                                                    }
                                                 }
                                             }
                                             Err(e) => {
@@ -2615,6 +2727,59 @@ pub(crate) async fn node_comms(
                         )
                         .await;
                     }
+                    return;
+                }
+
+                // #260: a migration re-PUT's ACK has landed. Only now is it
+                // safe to clear the persistent pending-migration marker — the
+                // new state is durably on the network. Until this point the
+                // marker survived so a never-acked PUT re-attempts next
+                // session instead of being silently abandoned.
+                let awaiting_inbox = inbox_management::AWAITING_MIGRATION_ACK
+                    .with(|a| take_awaiting_ack(&mut a.borrow_mut(), &contract_key));
+                if let Some(alias) = awaiting_inbox {
+                    if let Err(e) =
+                        identity_management::clear_pending_migration_api_call(&mut client, &alias)
+                            .await
+                    {
+                        crate::log::error(
+                            format!(
+                                "inbox migration: clear pending marker for `{alias}` failed: {e} (#260)"
+                            ),
+                            None,
+                        );
+                    }
+                    crate::toast::push_toast(
+                        format!(
+                            "Inbox `{alias}` migrated to the new contract id after webapp upgrade."
+                        ),
+                        crate::toast::ToastLevel::Info,
+                    );
+                    return;
+                }
+
+                let awaiting_aft = token_record_management::AWAITING_AFT_MIGRATION_ACK
+                    .with(|a| take_awaiting_ack(&mut a.borrow_mut(), &contract_key));
+                if let Some(alias) = awaiting_aft {
+                    if let Err(e) = identity_management::clear_pending_aft_migration_api_call(
+                        &mut client,
+                        &alias,
+                    )
+                    .await
+                    {
+                        crate::log::error(
+                            format!(
+                                "AFT migration: clear pending marker for `{alias}` failed: {e} (#260)"
+                            ),
+                            None,
+                        );
+                    }
+                    crate::toast::push_toast(
+                        format!(
+                            "Token ledger `{alias}` migrated to the new contract id after webapp upgrade."
+                        ),
+                        crate::toast::ToastLevel::Info,
+                    );
                 }
             }
             HostResponse::DelegateResponse { key, values } => {
@@ -3848,5 +4013,51 @@ impl std::fmt::Display for TryNodeAction {
                 write!(f, "creating AFT delegate")
             }
         }
+    }
+}
+
+#[cfg(all(test, feature = "use-node"))]
+mod awaiting_ack_tests {
+    use std::rc::Rc;
+
+    use freenet_stdlib::prelude::{ContractCode, ContractKey, Parameters};
+
+    use super::take_awaiting_ack;
+
+    fn key(n: u8) -> ContractKey {
+        // Distinct params per n → distinct contract id, so each key is unique.
+        ContractKey::from_params_and_code(Parameters::from(vec![n]), ContractCode::from(vec![0u8]))
+    }
+
+    /// #260: the pending-migration marker must NOT be cleared on PUT enqueue.
+    /// The clear is keyed off the migration PUT's `PutResponse`; until the
+    /// acked key matches an awaiting entry, `take_awaiting_ack` returns None
+    /// and the marker survives — so a never-acked PUT re-attempts next session.
+    #[test]
+    fn awaiting_ack_only_clears_on_matching_key_260() {
+        let mut awaiting: Vec<(Rc<str>, ContractKey)> =
+            vec![(Rc::from("alice"), key(1)), (Rc::from("bob"), key(2))];
+
+        // A PutResponse for an unrelated key (e.g. an ordinary create) must
+        // not consume any awaiting entry — the markers stay pending.
+        assert!(
+            take_awaiting_ack(&mut awaiting, &key(9)).is_none(),
+            "unrelated ack must not clear a pending migration",
+        );
+        assert_eq!(awaiting.len(), 2, "no entry consumed on non-match");
+
+        // The ack for alice's new key clears exactly alice's entry.
+        assert_eq!(
+            take_awaiting_ack(&mut awaiting, &key(1)).as_deref(),
+            Some("alice"),
+        );
+        assert_eq!(awaiting.len(), 1, "exactly one entry consumed");
+        assert_eq!(awaiting[0].0.as_ref(), "bob", "bob still awaits its ack");
+
+        // A duplicate ack for the same (now-removed) key is a no-op.
+        assert!(
+            take_awaiting_ack(&mut awaiting, &key(1)).is_none(),
+            "duplicate ack must not double-clear",
+        );
     }
 }

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -234,6 +234,35 @@ impl Recipient {
 thread_local! {
     /// Single source of truth for alias → entry.  Local aliases are unique.
     static ADDRESS_BOOK: RefCell<HashMap<String, Entry>> = RefCell::new(HashMap::new());
+
+    /// #255: cache of on-chain inbox `ContractInstanceId` → `Recipient`,
+    /// rebuilt lazily from `ADDRESS_BOOK` when stale. `lookup_by_bs58` is on
+    /// the per-keystroke compose-form resolver path; without this it ran an
+    /// ML-DSA-65 decode (~ms-class) + key derivation for every contact on
+    /// every keystroke (O(N) per keystroke). The cache makes lookup O(1).
+    ///
+    /// Keyed by the derived `ContractInstanceId`, which already bakes in each
+    /// contact's per-contact `inbox_wasm_hash` (#251 improvement 4), so the
+    /// cache is hash-aware by construction. It must be REBUILT (not patched)
+    /// on any write, since a contact's hash is a build input to its key.
+    static BS58_LOOKUP_CACHE: RefCell<Option<(
+        u64,
+        HashMap<freenet_stdlib::prelude::ContractInstanceId, Recipient>,
+    )>> = const { RefCell::new(None) };
+
+    /// Generation counter bumped by every `ADDRESS_BOOK` mutator
+    /// (`register_identity`, `insert_contact`, `remove_contact`). The cache
+    /// stores the gen it was built at and rebuilds when it falls behind. Kept
+    /// module-internal rather than piggy-backing on `AddressBookGen` because
+    /// some writers (own-identity register, offline seed) don't bump that
+    /// signal.
+    static ADDRESS_BOOK_GEN: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Bump the address-book generation so the bs58 lookup cache rebuilds on next
+/// access. Called from every `ADDRESS_BOOK` mutator.
+fn bump_address_book_gen() {
+    ADDRESS_BOOK_GEN.with(|g| g.set(g.get().wrapping_add(1)));
 }
 
 /// Ensure an own `Identity` is registered.  Idempotent — a second call for
@@ -245,6 +274,7 @@ pub fn register_identity(identity: &Identity) {
             Entry::Own(Box::new(identity.clone())),
         );
     });
+    bump_address_book_gen();
 }
 
 /// Insert a contact. Errors if:
@@ -255,58 +285,66 @@ pub fn register_identity(identity: &Identity) {
 /// Re-inserting a contact with the same alias and same fingerprint succeeds
 /// (allows overwrite of metadata like description / verified flag).
 pub fn insert_contact(contact: Contact) -> Result<(), String> {
-    ADDRESS_BOOK.with(|ab| {
-        let mut ab = ab.borrow_mut();
-        // Self-import guard: enforced here so any caller path (UI form,
-        // future API, test harness) gets the same protection.
-        for entry in ab.values() {
-            if let Entry::Own(id) = entry
-                && id.ml_dsa_vk_bytes() == contact.ml_dsa_vk_bytes
-                && id.ml_kem_ek_bytes() == contact.ml_kem_ek_bytes
-            {
-                return Err("cannot import your own identity as a contact".into());
-            }
-        }
-        if let Some(existing) = ab.get(contact.local_alias.as_ref()) {
-            match existing {
-                Entry::Own(_) => {
-                    return Err(format!(
-                        "\"{}\" is one of your own identities",
-                        contact.local_alias
-                    ));
+    ADDRESS_BOOK
+        .with(|ab| {
+            let mut ab = ab.borrow_mut();
+            // Self-import guard: enforced here so any caller path (UI form,
+            // future API, test harness) gets the same protection.
+            for entry in ab.values() {
+                if let Entry::Own(id) = entry
+                    && id.ml_dsa_vk_bytes() == contact.ml_dsa_vk_bytes
+                    && id.ml_kem_ek_bytes() == contact.ml_kem_ek_bytes
+                {
+                    return Err("cannot import your own identity as a contact".into());
                 }
-                Entry::Contact(c) => {
-                    // Allow overwrite only when BOTH key halves match;
-                    // otherwise the alias is taken by a different contact
-                    // and the import must be rejected. Comparing only the
-                    // ML-DSA VK would let a card with a substituted ML-KEM
-                    // key silently overwrite the recipient's encryption
-                    // material under an existing trusted alias.
-                    if c.ml_dsa_vk_bytes != contact.ml_dsa_vk_bytes
-                        || c.ml_kem_ek_bytes != contact.ml_kem_ek_bytes
-                    {
+            }
+            if let Some(existing) = ab.get(contact.local_alias.as_ref()) {
+                match existing {
+                    Entry::Own(_) => {
                         return Err(format!(
-                            "alias \"{}\" is already used by a different contact",
+                            "\"{}\" is one of your own identities",
                             contact.local_alias
                         ));
                     }
+                    Entry::Contact(c) => {
+                        // Allow overwrite only when BOTH key halves match;
+                        // otherwise the alias is taken by a different contact
+                        // and the import must be rejected. Comparing only the
+                        // ML-DSA VK would let a card with a substituted ML-KEM
+                        // key silently overwrite the recipient's encryption
+                        // material under an existing trusted alias.
+                        if c.ml_dsa_vk_bytes != contact.ml_dsa_vk_bytes
+                            || c.ml_kem_ek_bytes != contact.ml_kem_ek_bytes
+                        {
+                            return Err(format!(
+                                "alias \"{}\" is already used by a different contact",
+                                contact.local_alias
+                            ));
+                        }
+                    }
                 }
             }
-        }
-        ab.insert(contact.local_alias.to_string(), Entry::Contact(contact));
-        Ok(())
-    })
+            ab.insert(contact.local_alias.to_string(), Entry::Contact(contact));
+            Ok(())
+        })
+        .inspect(|()| bump_address_book_gen())
 }
 
 /// Remove a contact by alias.  No-op if the alias does not exist or is an
 /// own identity (own identities are never removed via this path).
 pub fn remove_contact(alias: &str) {
-    ADDRESS_BOOK.with(|ab| {
+    let removed = ADDRESS_BOOK.with(|ab| {
         let mut ab = ab.borrow_mut();
         if matches!(ab.get(alias), Some(Entry::Contact(_))) {
             ab.remove(alias);
+            true
+        } else {
+            false
         }
     });
+    if removed {
+        bump_address_book_gen();
+    }
 }
 
 /// Resolve an alias to a `Recipient`.  Walks both own identities and contacts.
@@ -376,63 +414,91 @@ pub fn lookup(alias: &str) -> Option<Recipient> {
 /// book — i.e. the user has imported them and (presumably) verified the
 /// fingerprint. Unknown addresses return `None`; the UI surfaces "import
 /// as contact first".
-pub fn lookup_by_bs58(addr: &str) -> Option<Recipient> {
+/// Build the bs58 lookup map from the current `ADDRESS_BOOK` — one ML-DSA
+/// decode + key derivation per entry. Called only on cache miss / staleness.
+fn build_bs58_lookup_map() -> HashMap<freenet_stdlib::prelude::ContractInstanceId, Recipient> {
     use crate::inbox::{INBOX_CODE_HASH, inbox_key_for, inbox_key_for_with_hash};
+    ADDRESS_BOOK.with(|ab| {
+        let mut map = HashMap::new();
+        for entry in ab.borrow().values() {
+            match entry {
+                Entry::Contact(c) => {
+                    let Ok(vk) = vk_from_bytes(&c.ml_dsa_vk_bytes) else {
+                        continue;
+                    };
+                    // #251 improvement 4: derive under the contact's advertised
+                    // hash, not the sender's `INBOX_CODE_HASH`. A cross-version
+                    // contact's id differs from `inbox_key_for(vk)`.
+                    let code_hash = c.inbox_wasm_hash.as_deref().unwrap_or(INBOX_CODE_HASH);
+                    let Ok(key) = inbox_key_for_with_hash(&vk, code_hash) else {
+                        continue;
+                    };
+                    let fingerprint = c.fingerprint();
+                    map.insert(
+                        *key.id(),
+                        Recipient {
+                            local_alias: c.local_alias.clone(),
+                            ml_dsa_vk_bytes: c.ml_dsa_vk_bytes.clone(),
+                            ml_kem_ek_bytes: c.ml_kem_ek_bytes.clone(),
+                            fingerprint,
+                            required_tier: c.required_tier,
+                            max_age_secs: c.max_age_secs,
+                            verified: c.verified,
+                            is_own: false,
+                            inbox_wasm_hash: c.inbox_wasm_hash.clone(),
+                        },
+                    );
+                }
+                Entry::Own(id) => {
+                    let Ok(vk) = vk_from_bytes(&id.ml_dsa_vk_bytes()) else {
+                        continue;
+                    };
+                    let Ok(key) = inbox_key_for(&vk) else {
+                        continue;
+                    };
+                    let ml_dsa_vk_bytes = id.ml_dsa_vk_bytes();
+                    let ml_kem_ek_bytes = id.ml_kem_ek_bytes();
+                    let fingerprint = fingerprint_words(&ml_dsa_vk_bytes, &ml_kem_ek_bytes);
+                    map.insert(
+                        *key.id(),
+                        Recipient {
+                            local_alias: id.alias.clone(),
+                            ml_dsa_vk_bytes,
+                            ml_kem_ek_bytes,
+                            fingerprint,
+                            required_tier: id.required_tier,
+                            max_age_secs: id.max_age_secs,
+                            verified: true,
+                            is_own: true,
+                            inbox_wasm_hash: None,
+                        },
+                    );
+                }
+            }
+        }
+        map
+    })
+}
+
+/// Resolve a bs58 inbox `ContractInstanceId` to a `Recipient`. O(1) after a
+/// one-time per-generation cache build (#255). On the per-keystroke compose
+/// resolver path, so this must not re-decode every contact each call.
+pub fn lookup_by_bs58(addr: &str) -> Option<Recipient> {
     use std::str::FromStr;
     let trimmed = addr.trim();
     let target = freenet_stdlib::prelude::ContractInstanceId::from_str(trimmed).ok()?;
 
-    ADDRESS_BOOK.with(|ab| {
-        ab.borrow().values().find_map(|entry| match entry {
-            Entry::Contact(c) => {
-                let vk = vk_from_bytes(&c.ml_dsa_vk_bytes).ok()?;
-                // #251 improvement 4: address-book lookup must derive the
-                // contact's inbox key under the contact's advertised
-                // hash, not the sender's `INBOX_CODE_HASH`. A
-                // cross-version contact's actual contract id differs
-                // from `inbox_key_for(vk)` once the sender upgrades.
-                let code_hash = c.inbox_wasm_hash.as_deref().unwrap_or(INBOX_CODE_HASH);
-                let key = inbox_key_for_with_hash(&vk, code_hash).ok()?;
-                if *key.id() == target {
-                    let fingerprint = c.fingerprint();
-                    Some(Recipient {
-                        local_alias: c.local_alias.clone(),
-                        ml_dsa_vk_bytes: c.ml_dsa_vk_bytes.clone(),
-                        ml_kem_ek_bytes: c.ml_kem_ek_bytes.clone(),
-                        fingerprint,
-                        required_tier: c.required_tier,
-                        max_age_secs: c.max_age_secs,
-                        verified: c.verified,
-                        is_own: false,
-                        inbox_wasm_hash: c.inbox_wasm_hash.clone(),
-                    })
-                } else {
-                    None
-                }
-            }
-            Entry::Own(id) => {
-                let vk = vk_from_bytes(&id.ml_dsa_vk_bytes()).ok()?;
-                let key = inbox_key_for(&vk).ok()?;
-                if *key.id() == target {
-                    let ml_dsa_vk_bytes = id.ml_dsa_vk_bytes();
-                    let ml_kem_ek_bytes = id.ml_kem_ek_bytes();
-                    let fingerprint = fingerprint_words(&ml_dsa_vk_bytes, &ml_kem_ek_bytes);
-                    Some(Recipient {
-                        local_alias: id.alias.clone(),
-                        ml_dsa_vk_bytes,
-                        ml_kem_ek_bytes,
-                        fingerprint,
-                        required_tier: id.required_tier,
-                        max_age_secs: id.max_age_secs,
-                        verified: true,
-                        is_own: true,
-                        inbox_wasm_hash: None,
-                    })
-                } else {
-                    None
-                }
-            }
-        })
+    let cur_gen = ADDRESS_BOOK_GEN.with(|g| g.get());
+    BS58_LOOKUP_CACHE.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        let needs_rebuild = match cell.as_ref() {
+            Some((cached_gen, _)) => *cached_gen != cur_gen,
+            None => true,
+        };
+        if needs_rebuild {
+            *cell = Some((cur_gen, build_bs58_lookup_map()));
+        }
+        cell.as_ref().and_then(|(_, map)| map.get(&target).cloned())
     })
 }
 
@@ -1143,6 +1209,49 @@ mod tests {
         assert_eq!(by_alias.ml_kem_ek_bytes, by_bs58.ml_kem_ek_bytes);
         assert_eq!(by_alias.fingerprint, by_bs58.fingerprint);
         assert!(by_bs58.verified);
+    }
+
+    /// #255: the lookup cache must rebuild when the address book changes —
+    /// a contact removed after a prior lookup must no longer resolve.
+    #[test]
+    fn lookup_by_bs58_cache_invalidates_on_remove_255() {
+        use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        bump_address_book_gen();
+
+        let sk = MlDsa65::from_seed(&[11u8; 32].into());
+        let vk = MlDsaKeypair::verifying_key(&sk);
+        let vk_bytes = vk.encode().to_vec();
+        let addr = crate::inbox::inbox_key_for(&vk)
+            .expect("inbox_key_for")
+            .id()
+            .encode();
+
+        insert_contact(Contact {
+            local_alias: "bob".into(),
+            suggested_alias: None,
+            description: String::new(),
+            ml_dsa_vk_bytes: vk_bytes,
+            ml_kem_ek_bytes: vec![0xCC; 1184],
+            required_tier: Tier::Day1,
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
+            verified: true,
+            inbox_wasm_hash: None,
+        })
+        .unwrap();
+
+        // Prime the cache.
+        assert!(
+            lookup_by_bs58(&addr).is_some(),
+            "contact resolves before removal",
+        );
+
+        // Removal must invalidate — a stale cache would still return bob.
+        remove_contact("bob");
+        assert!(
+            lookup_by_bs58(&addr).is_none(),
+            "removed contact must not resolve (cache rebuilt) (#255)",
+        );
     }
 
     #[test]

--- a/ui/src/app/address_book.rs
+++ b/ui/src/app/address_book.rs
@@ -740,6 +740,16 @@ pub fn migrate_legacy_identities() {
 mod tests {
     use super::*;
 
+    /// Reset the address book between tests. Bumps the generation so the
+    /// bs58 lookup cache (#255) can't carry a prior test's contacts into
+    /// this one — the test runner reuses threads, so the thread-local cache
+    /// would otherwise persist across tests. A bare `ADDRESS_BOOK.clear()`
+    /// alone leaves the cache stale.
+    fn reset_address_book() {
+        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        bump_address_book_gen();
+    }
+
     #[test]
     fn fingerprint_is_six_bip39_words() {
         let vk = vec![0u8; 1952];
@@ -877,7 +887,7 @@ mod tests {
     #[test]
     fn insert_contact_rejects_alias_with_different_vk() {
         // Use a thread-local scope by clearing first.
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact("bob", 1, 2)).unwrap();
         let err =
             insert_contact(make_contact("bob", 3, 2)).expect_err("different VK should be rejected");
@@ -893,7 +903,7 @@ mod tests {
 
     #[test]
     fn lookup_resolves_by_local_alias() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact_suggested("7511", Some("test7511"), 1, 2)).unwrap();
         let r = lookup("7511").expect("exact local alias resolves");
         assert_eq!(&*r.local_alias, "7511");
@@ -904,7 +914,7 @@ mod tests {
     fn lookup_falls_back_to_suggested_alias() {
         // The user relabelled the contact "7511" but types the name the
         // sender advertised ("test7511"). The fallback must still resolve.
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact_suggested("7511", Some("test7511"), 1, 2)).unwrap();
         let r = lookup("test7511").expect("suggested alias resolves on local-alias miss");
         assert_eq!(
@@ -917,7 +927,7 @@ mod tests {
     fn lookup_exact_local_alias_wins_over_suggested() {
         // If one contact's local_alias equals another contact's
         // suggested_alias, the exact local-alias match must win.
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact_suggested("shared", Some("other"), 1, 2)).unwrap();
         insert_contact(make_contact_suggested("real", Some("shared"), 3, 4)).unwrap();
         let r = lookup("shared").expect("resolves");
@@ -929,14 +939,14 @@ mod tests {
 
     #[test]
     fn lookup_unknown_alias_returns_none() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact_suggested("7511", Some("test7511"), 1, 2)).unwrap();
         assert!(lookup("nobody").is_none());
     }
 
     #[test]
     fn lookup_no_suggested_alias_is_local_only() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact_suggested("7511", None, 1, 2)).unwrap();
         assert!(lookup("7511").is_some());
         assert!(lookup("anything-else").is_none());
@@ -947,7 +957,7 @@ mod tests {
         // Same VK but a substituted EK must also be rejected, otherwise an
         // attacker who knows the recipient's signing pubkey could swap in
         // their own encryption key under a trusted alias.
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact("alice", 4, 5)).unwrap();
         let err = insert_contact(make_contact("alice", 4, 9))
             .expect_err("different EK should be rejected");
@@ -956,7 +966,7 @@ mod tests {
 
     #[test]
     fn insert_contact_overwrites_when_keys_match() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         let mut c = make_contact("carol", 7, 8);
         insert_contact(c.clone()).unwrap();
         c.description = "updated".into();
@@ -972,7 +982,7 @@ mod tests {
 
     #[test]
     fn lookup_finds_inserted_contact() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact("dave", 11, 12)).unwrap();
         let r = lookup("dave").expect("contact should resolve");
         assert!(!r.is_own);
@@ -987,13 +997,13 @@ mod tests {
 
     #[test]
     fn lookup_misses_for_unknown_alias() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         assert!(lookup("nobody").is_none());
     }
 
     #[test]
     fn remove_contact_clears_lookup() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact("eve", 13, 14)).unwrap();
         assert!(lookup("eve").is_some());
         remove_contact("eve");
@@ -1002,7 +1012,7 @@ mod tests {
 
     #[test]
     fn filter_contacts_empty_needle_returns_nothing() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact("alice", 1, 2)).unwrap();
         assert!(
             filter_contacts("", 8).is_empty(),
@@ -1012,7 +1022,7 @@ mod tests {
 
     #[test]
     fn filter_contacts_case_insensitive_alias_substring() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         insert_contact(make_contact("Alice", 1, 2)).unwrap();
         insert_contact(make_contact("bob", 3, 4)).unwrap();
         insert_contact(make_contact("alice-work", 5, 6)).unwrap();
@@ -1034,7 +1044,7 @@ mod tests {
     /// fix). A contact whose description contains the needle must not appear.
     #[test]
     fn filter_contacts_does_not_match_description() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         let mut c = make_contact("carol", 7, 8);
         c.description = "work colleague".into();
         insert_contact(c).unwrap();
@@ -1052,7 +1062,7 @@ mod tests {
     /// contacts sort before unverified within the same tier.
     #[test]
     fn filter_contacts_tier_and_verified_sort() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         // "alice" is a prefix match for "ali" — tier 0.
         let mut alice = make_contact("alice", 1, 2);
         alice.verified = true;
@@ -1074,7 +1084,7 @@ mod tests {
 
     #[test]
     fn filter_contacts_respects_limit() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         for i in 0..10u8 {
             insert_contact(make_contact(&format!("user{i}"), i, i.wrapping_add(1))).unwrap();
         }
@@ -1119,7 +1129,7 @@ mod tests {
     #[test]
     fn is_contact_inbox_key_recognises_imported_contact() {
         use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
 
         // Real ML-DSA-65 keypair so vk_from_bytes succeeds.
         let sk = MlDsa65::from_seed(&[7u8; 32].into());
@@ -1149,7 +1159,7 @@ mod tests {
     #[test]
     fn is_contact_inbox_key_returns_false_for_unrelated_key() {
         use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
 
         // Insert one contact.
         let sk_a = MlDsa65::from_seed(&[1u8; 32].into());
@@ -1182,7 +1192,7 @@ mod tests {
     #[test]
     fn lookup_by_bs58_finds_imported_contact() {
         use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
 
         let sk = MlDsa65::from_seed(&[9u8; 32].into());
         let vk = MlDsaKeypair::verifying_key(&sk);
@@ -1216,8 +1226,7 @@ mod tests {
     #[test]
     fn lookup_by_bs58_cache_invalidates_on_remove_255() {
         use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
-        bump_address_book_gen();
+        reset_address_book();
 
         let sk = MlDsa65::from_seed(&[11u8; 32].into());
         let vk = MlDsaKeypair::verifying_key(&sk);
@@ -1256,7 +1265,7 @@ mod tests {
 
     #[test]
     fn lookup_by_bs58_returns_none_for_unknown_address() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         // Valid bs58 32-byte string but no matching contact.
         let id = freenet_stdlib::prelude::ContractInstanceId::new([7u8; 32]);
         assert!(lookup_by_bs58(&id.encode()).is_none());
@@ -1264,14 +1273,14 @@ mod tests {
 
     #[test]
     fn lookup_by_bs58_returns_none_for_invalid_address() {
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
         assert!(lookup_by_bs58("not bs58 at all").is_none());
     }
 
     #[test]
     fn is_contact_inbox_key_empty_book_returns_false() {
         use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
 
         let sk = MlDsa65::from_seed(&[3u8; 32].into());
         let vk = MlDsaKeypair::verifying_key(&sk);
@@ -1297,7 +1306,7 @@ mod tests {
     #[test]
     fn lookup_misses_when_contact_imported_under_different_nickname_289() {
         use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
 
         // Alice sends under her own alias "alice-from-work". The recipient
         // imports her contact card but labels it locally as "ally".
@@ -1334,7 +1343,7 @@ mod tests {
     #[test]
     fn lookup_resolves_by_sender_alias_when_suggested_preserved_289() {
         use ml_dsa::{KeyGen, MlDsa65, signature::Keypair as MlDsaKeypair};
-        ADDRESS_BOOK.with(|ab| ab.borrow_mut().clear());
+        reset_address_book();
 
         // Same scenario as the miss test above, but the import preserved
         // the sender's advertised alias ("alice-from-work") as

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -1073,10 +1073,13 @@ impl InboxModel {
             self.settings.ml_dsa_signing_key.as_ref(),
             settings,
             messages,
-            // TODO: this path is dead-coded (see TODO above); fill ek
-            // properly when `to_state` is wired up. Empty ek would fail
-            // signature verify on the contract host today.
-            Vec::new(),
+            // #256: the model already carries the owner's ML-KEM ek on its
+            // settings (populated by `from_state` / `InboxModel::new`), so
+            // stamp it here. An empty ek produced a state importers/senders
+            // reject — they'd have no key to encapsulate to. No `INBOX_TO_ID`
+            // identity lookup is needed for the ek (only message re-encryption,
+            // still unimplemented above, needs the ML-KEM decapsulation key).
+            self.settings.owner_ek_bytes.clone(),
         );
         let serialized = serde_json::to_vec(&inbox)?;
         Ok(serialized.into())
@@ -1696,6 +1699,35 @@ mod tests {
             seed.into()
         });
         InboxModel::new(ml_dsa_key, ml_kem_dk).unwrap()
+    }
+
+    /// #256: `to_state` must carry the owner's ML-KEM ek so the produced
+    /// state advertises a usable encryption key. The dead-coded path passed
+    /// `Vec::new()`, which produces a state importers/senders reject (they
+    /// have no ek to encapsulate to). Empty inbox so the unimplemented
+    /// message-re-encryption map (which returns Err for any message) doesn't
+    /// short-circuit before the ek is stamped.
+    #[test]
+    fn to_state_carries_owner_ek_256() {
+        let sk = Arc::new(fresh_signing_key());
+        let inbox = make_test_inbox(sk);
+        assert!(
+            inbox.messages.is_empty(),
+            "test precondition: empty inbox reaches the ek-stamping path",
+        );
+        let expected_ek = inbox.settings.owner_ek_bytes.clone();
+        assert!(
+            !expected_ek.is_empty(),
+            "test precondition: the model holds a non-empty owner ek",
+        );
+
+        let state = inbox.to_state().expect("to_state on empty inbox");
+        let decoded: StoredInbox = serde_json::from_slice(state.as_ref())
+            .expect("to_state output must deserialize as StoredInbox");
+        assert_eq!(
+            decoded.owner_ek_bytes, expected_ek,
+            "to_state must advertise the owner's ek, not an empty vec (#256)",
+        );
     }
 
     /// `update_verified_bypass_prepare` with a single verified VK must flip


### PR DESCRIPTION
Batch of four #249 followups. All in `ui/src/{inbox,api,app/address_book}.rs`.

## #256 — `to_state` dead path passed empty owner_ek
`Inbox::to_state` stamped `Vec::new()` as `owner_ek_bytes`, producing a state importers/senders reject (no ek to encapsulate to). Now stamps `settings.owner_ek_bytes` (already carried on the model).
- **Red proven**: `to_state_carries_owner_ek_256` failed pre-fix (`left: []`), green after.

## #254 — migration writer could clobber on-chain ek on re-key
If a user re-keyed their ML-KEM keypair between the original PUT and a hash-migration, the writer could overwrite the chain-advertised ek with the local one, breaking senders who imported the old ek. Extracted `select_owner_ek`: stamp-local for legacy empty, reuse matching on-chain, **preserve diverged on-chain** + loud log + Warning toast (re-key is a separate explicit action).
- Tests cover all 3 branches. **No pre-fix red** — the byte-selection already preferred on-chain; the gap was the missing divergence signal (additive guard).

## #255 — per-keystroke O(N·ML-DSA) lookup
`lookup_by_bs58` ran an ML-DSA-65 decode + key derivation for every contact on every compose-form keystroke. Added a `ContractInstanceId -> Recipient` cache rebuilt lazily on an address-book generation counter (bumped by the 3 mutators). Hash-aware by construction. **Perf optimization — no correctness bug, no pre-fix red** (per request). Invalidation test added; existing equivalence tests still green.

## #260 — pending-migration marker cleared before PUT ack
`put_migrated_{inbox,aft_record}` returned `Ok` on PUT **enqueue**, and the GetResponse arm cleared the persistent pending-migration marker immediately. A PUT that enqueued then never landed left the marker cleared + hash stamped = **migration silently abandoned forever** — the exact failure the persistent-retry design was meant to prevent. Now defers the clear to the matching `PutResponse`: records `(alias, new_key)` in `AWAITING_MIGRATION_ACK`/`AWAITING_AFT_MIGRATION_ACK` on enqueue, clears via `take_awaiting_ack` only when that key's `PutResponse` lands.
- Mechanism test `awaiting_ack_only_clears_on_matching_key_260` (no pre-fix red — fix is structural; test pins the key-match invariant).

## Tests
195 UI lib tests green, clippy clean (`--features use-node`).

## Repro honesty
Only #256 had a genuine red→green (real correctness bug with a unit seam). #254 is an additive guard, #255 perf-only, #260 structural — flagged in commit + above.

Closes #256, #254, #255, #260.