### PR TITLE
fix(import): surface failed inbox GET instead of hanging the import modal

### DIFF
--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1938,10 +1938,9 @@ pub(crate) async fn node_comms(
                                         m.borrow_mut().insert(
                                             addr,
                                             contact_import::ImportFetched {
-                                                outcome:
-                                                    contact_import::ImportFetchOutcome::Failed(
-                                                        format!("fetch from node failed: {cause}"),
-                                                    ),
+                                                outcome: contact_import::ImportFetchOutcome::Failed(
+                                                    format!("fetch from node failed: {cause}"),
+                                                ),
                                             },
                                         );
                                     });

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1915,6 +1915,43 @@ pub(crate) async fn node_comms(
                                     );
                                 }
                             }
+                            RequestError::ContractError(ContractError::Get { key, cause }) => {
+                                // A failed inbox GET is the terminal signal for
+                                // an in-flight contact import (the modal issued
+                                // `FetchContactKeys` → Get). Core surfaces a
+                                // stream-assembly timeout / not-found as
+                                // `ContractError::Get`; without resolving the
+                                // pending entry here the import modal's poll loop
+                                // (login.rs) spins on "Fetching keys…" forever.
+                                // Drain PENDING by instance id and publish a
+                                // Failed outcome under the address string the
+                                // modal polls on.
+                                let inbox_id = *key.id();
+                                let import_addr = contact_import::PENDING
+                                    .with(|m| m.borrow_mut().remove(&inbox_id));
+                                if let Some(addr) = import_addr {
+                                    crate::log::error(
+                                        format!("inbox GET failed for {key}: {cause}"),
+                                        None,
+                                    );
+                                    contact_import::RESULTS.with(|m| {
+                                        m.borrow_mut().insert(
+                                            addr,
+                                            contact_import::ImportFetched {
+                                                outcome:
+                                                    contact_import::ImportFetchOutcome::Failed(
+                                                        format!("fetch from node failed: {cause}"),
+                                                    ),
+                                            },
+                                        );
+                                    });
+                                } else {
+                                    crate::log::error(
+                                        format!("GET error for contract {key}: {cause}"),
+                                        None,
+                                    );
+                                }
+                            }
                             RequestError::ContractError(err) => {
                                 crate::log::error(format!("FIXME: {err}"), None)
                             }

--- a/ui/src/app/login.rs
+++ b/ui/src/app/login.rs
@@ -1968,6 +1968,13 @@ pub(super) fn ImportContactForm() -> Element {
     let mut fetching = use_signal(|| false);
     let mut pending_address: Signal<Option<String>> = use_signal(|| None);
     let mut verify_phrase: Signal<Option<String>> = use_signal(|| None);
+    // Count of 150ms poll ticks since the current fetch began. Drives the
+    // escalating "taking longer than expected" copy and a client-side
+    // timeout, so a node that never replies at all (not even an error —
+    // distinct from the core stream-assembly failure that does surface a
+    // `ContractError::Get`) still releases the modal instead of spinning
+    // forever. 0 while idle.
+    let mut fetch_ticks = use_signal(|| 0u32);
 
     // Poll the api.rs result table for the address we asked about. Runs
     // while the modal is mounted; the fetch completes in well under a
@@ -2012,6 +2019,29 @@ pub(super) fn ImportContactForm() -> Element {
                         }
                         fetching.set(false);
                         pending_address.set(None);
+                        fetch_ticks.set(0);
+                    } else {
+                        // No result yet — advance the elapsed clock. At
+                        // ~30s (200 × 150ms) give up client-side; the node
+                        // is unreachable or silently dropping the GET.
+                        let t = fetch_ticks.read().saturating_add(1);
+                        fetch_ticks.set(t);
+                        if t >= 200 {
+                            crate::api::contact_import::RESULTS
+                                .with(|m| m.borrow_mut().remove(&addr));
+                            error_msg.set(
+                                "Could not fetch inbox: timed out after 30s. \
+                                 The recipient's node may be offline, or their \
+                                 inbox hasn't propagated to the network yet. \
+                                 Ask them to open their inbox, then retry."
+                                    .into(),
+                            );
+                            fingerprint_words.set(None);
+                            fetched_keys.set(None);
+                            fetching.set(false);
+                            pending_address.set(None);
+                            fetch_ticks.set(0);
+                        }
                     }
                 }
             }
@@ -2200,8 +2230,29 @@ pub(super) fn ImportContactForm() -> Element {
                         }
                     }
                     if *fetching.read() {
-                        div { class: "field-help",
-                            "Fetching keys from the recipient's inbox…"
+                        {
+                            // ~150ms per tick. Escalate the copy so the user
+                            // sees the fetch is alive and how far along it is,
+                            // rather than a static line that looks hung.
+                            let ticks = *fetch_ticks.read();
+                            let secs = (ticks as f32 * 0.15) as u32;
+                            let msg = if ticks < 33 {
+                                "Fetching keys from the recipient's inbox…".to_string()
+                            } else if ticks < 100 {
+                                format!("Still fetching from the network… ({secs}s)")
+                            } else {
+                                format!(
+                                    "Taking longer than usual ({secs}s). The recipient's \
+                                     node may be slow to respond — will time out at 30s."
+                                )
+                            };
+                            rsx! {
+                                div { class: "field-help",
+                                    style: "display:flex; align-items:center; gap:8px;",
+                                    span { class: "pulse-dot" }
+                                    span { "{msg}" }
+                                }
+                            }
                         }
                     }
                     if let Some(ref words) = *fingerprint_words.read() {


### PR DESCRIPTION
## Problem

Contact import hangs forever on "Fetching keys from the recipient's inbox…"
when the recipient's inbox GET fails on the network.

Two real users on two real-net nodes couldn't import each other. Diagnosis from
the node log: **not a connectivity failure** — both nodes had 29 ring peers and
NAT traversal succeeded. The actual failure is in freenet-core's GET-response
fragment streaming:

```
get: stream assembly failed — state will not be cached locally
  key=GCdTw11g... error=stream assembly: no fragments received within inactivity timeout
get: terminal reply classified success but local store lookup returned no state;
  synthesizing client error
```

The inbox state is multi-fragment (encrypted messages + ML-KEM/ML-DSA keys),
reassembly times out, the contract never caches, and core synthesizes a
`ClientError(ContractError::Get)`. Peak 109 simultaneous orphan inbound streams
— sustained fragment loss. Tracked upstream as **freenet/freenet-core#4345**.

The core transport bug is upstream. **This PR fixes the freenet-email side**: the
UI should *surface* that failure, not hang on it.

## Fix

- **`ui/src/api.rs`** — the error arm had no `ContractError::Get` match, so the
  synthesized GET error dropped at the `_ => {}` catch-all and never resolved the
  import modal's `PENDING`/`RESULTS` poll state. Add a `Get` arm that drains
  `PENDING` by instance id and publishes a `Failed` outcome under the address the
  modal polls on → modal shows "Could not fetch inbox: \<cause\>".

- **`ui/src/app/login.rs`** — add a client-side elapsed clock + 30s timeout so a
  node that never replies *at all* (no error either) still releases the modal.
  Plus a live visual cue: spinner dot + escalating status copy
  (`Fetching keys…` → `Still fetching from the network… (Ns)` →
  `Taking longer than usual…`) so the user sees the fetch is alive and how far
  along it is, instead of one static line that reads as hung.

## Scope / non-goals

- Does **not** fix the underlying fragment loss — that needs freenet-core#4345.
  This makes the failure *visible and bounded* instead of an infinite spinner.
- No behavior change on the happy path (keys arrive → fingerprint shows as before).

## Test

- `cargo check -p freenet-email-ui --no-default-features --features use-node` — clean.
- Manual: the timeout/escalation path is wall-clock driven; exercised by the
  real-net repro above (import a contact whose inbox doesn't stream).

Refs freenet/freenet-core#4345
