### PR TITLE
fix(send): surface failed message send instead of spinning Pending (#288)

### DIFF
--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -186,24 +186,28 @@ impl AftRecords {
     }
 
     /// Drain pending confirmations older than `timeout_secs` and return
-    /// the expired records so the caller can surface the failure to the
-    /// UI. Also clears the matching entry in `PENDING_INBOXES_UPDATES`
-    /// so a retry can re-queue without colliding with a stale entry.
+    /// the expired `(record, inbox)` pairs so the caller can surface the
+    /// failure to the UI *and* flip the corresponding Sent row to Failed
+    /// immediately (#288 — without the inbox key the row only failed later
+    /// via the 60s send-sweep, leaving a ~30s window where the AFT-timeout
+    /// toast showed but the row still spun Pending). Also clears the
+    /// matching entry in `PENDING_INBOXES_UPDATES` so a retry can re-queue
+    /// without colliding with a stale entry.
     ///
     /// Without this sweep, a `confirm_allocation` that never arrives
     /// (host crash, network drop, malformed summary) leaves the user's
     /// send hanging forever with no UI feedback — see #1 in the AFT
     /// audit.
-    pub fn expire_stale(timeout_secs: i64) -> Vec<TokenAssignment> {
+    pub fn expire_stale(timeout_secs: i64) -> Vec<(TokenAssignment, InboxContract)> {
         let now = Utc::now();
-        let mut expired: Vec<TokenAssignment> = Vec::new();
+        let mut expired: Vec<(TokenAssignment, InboxContract)> = Vec::new();
         PENDING_CONFIRMED_ASSIGNMENTS.with(|pending| {
             let mut pending = pending.borrow_mut();
             for registers in pending.values_mut() {
                 registers.retain(|r| {
                     let elapsed = now.signed_duration_since(r.start).num_seconds();
                     if elapsed >= timeout_secs {
-                        expired.push(r.record.clone());
+                        expired.push((r.record.clone(), r.inbox));
                         false
                     } else {
                         true
@@ -213,8 +217,10 @@ impl AftRecords {
             pending.retain(|_, v| !v.is_empty());
         });
         if !expired.is_empty() {
-            let expired_hashes: HashMap<AssignmentHash, ()> =
-                expired.iter().map(|r| (r.assignment_hash, ())).collect();
+            let expired_hashes: HashMap<AssignmentHash, ()> = expired
+                .iter()
+                .map(|(r, _)| (r.assignment_hash, ()))
+                .collect();
             PENDING_INBOXES_UPDATES.with(|queue| {
                 queue
                     .borrow_mut()

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -2646,26 +2646,32 @@ pub(crate) async fn node_comms(
                 if let Some((sender_alias, sent_id)) =
                     crate::inbox::take_next_pending_sent_ack(&key)
                 {
-                    crate::local_state::local_set_sent_delivery_state(
+                    // Only persist the Delivered flip if the row actually
+                    // transitioned from Pending. A late UpdateResponse that
+                    // arrives after the stale-send sweep already failed this
+                    // (or mis-pairs onto a sibling already terminal) must not
+                    // resurrect a Failed row to Delivered (#288).
+                    if crate::local_state::local_set_sent_delivery_state(
                         &sender_alias,
                         &sent_id,
                         mail_local_state::DeliveryState::Delivered,
-                    );
-                    let mut client_clone = client.clone();
-                    let alias_async = sender_alias;
-                    let id_async = sent_id;
-                    wasm_bindgen_futures::spawn_local(async move {
-                        if let Err(e) = crate::local_state::set_sent_delivery_state(
-                            &mut client_clone,
-                            alias_async,
-                            id_async,
-                            mail_local_state::DeliveryState::Delivered,
-                        )
-                        .await
-                        {
-                            crate::log::local_state_failure("update delivery state", e);
-                        }
-                    });
+                    ) {
+                        let mut client_clone = client.clone();
+                        let alias_async = sender_alias;
+                        let id_async = sent_id;
+                        wasm_bindgen_futures::spawn_local(async move {
+                            if let Err(e) = crate::local_state::set_sent_delivery_state(
+                                &mut client_clone,
+                                alias_async,
+                                id_async,
+                                mail_local_state::DeliveryState::Delivered,
+                            )
+                            .await
+                            {
+                                crate::log::local_state_failure("update delivery state", e);
+                            }
+                        });
+                    }
                 }
 
                 if let Some(identity) = token_rec_to_id.remove(&key) {

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -3560,7 +3560,8 @@ pub(crate) async fn node_comms(
                 let expired = AftRecords::expire_stale(
                     crate::aft::PENDING_ASSIGNMENT_TIMEOUT_SECS,
                 );
-                for assignment in expired {
+                let mut aft_failed_inboxes: Vec<ContractKey> = Vec::new();
+                for (assignment, inbox) in expired {
                     crate::log::error(
                         format!(
                             "AFT assignment confirmation timed out (>{}s) for tier={} slot={} hash={}",
@@ -3575,6 +3576,16 @@ pub(crate) async fn node_comms(
                         crate::aft::format_expired_assignment_toast(assignment.tier),
                         crate::toast::ToastLevel::Error,
                     );
+                    if !aft_failed_inboxes.contains(&inbox) {
+                        aft_failed_inboxes.push(inbox);
+                    }
+                }
+                // Flip the Sent rows for AFT-timed-out sends to Failed right
+                // away rather than waiting out the longer send-sweep window
+                // (#288 review): an AFT stall is terminal for that send.
+                for inbox in aft_failed_inboxes {
+                    let mut aft_client = WEB_API_SENDER.get().unwrap().clone();
+                    crate::inbox::fail_pending_sent_for_inbox(&mut aft_client, inbox).await;
                 }
 
                 // #288 "no terminal reply at all": a send whose recipient

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -2051,11 +2051,8 @@ pub(crate) async fn node_comms(
                                         ),
                                         crate::toast::ToastLevel::Error,
                                     );
-                                    crate::inbox::fail_pending_sent_for_inbox(
-                                        &mut client,
-                                        *key,
-                                    )
-                                    .await;
+                                    crate::inbox::fail_pending_sent_for_inbox(&mut client, *key)
+                                        .await;
                                 }
                             }
                             RequestError::ContractError(ContractError::Get { key, cause }) => {
@@ -3570,6 +3567,31 @@ pub(crate) async fn node_comms(
                     );
                     crate::toast::push_toast(
                         crate::aft::format_expired_assignment_toast(assignment.tier),
+                        crate::toast::ToastLevel::Error,
+                    );
+                }
+
+                // #288 "no terminal reply at all": a send whose recipient
+                // inbox UPDATE got neither an `UpdateResponse` nor a
+                // `ContractError::Update` (e.g. the recipient node hung and
+                // the request was silently dropped) would otherwise leave
+                // the Sent row spinning Pending forever. Fail rows older
+                // than `PENDING_SENT_TIMEOUT_SECS` and toast once.
+                let mut sweep_client = WEB_API_SENDER.get().unwrap().clone();
+                let now_ms = chrono::Utc::now().timestamp_millis();
+                let expired_sends = crate::inbox::expire_stale_pending_sent(
+                    &mut sweep_client,
+                    crate::inbox::PENDING_SENT_TIMEOUT_SECS,
+                    now_ms,
+                )
+                .await;
+                if !expired_sends.is_empty() {
+                    crate::toast::push_toast(
+                        format!(
+                            "{} message(s) got no delivery confirmation within {}s and were marked failed. The recipient's node may be unreachable — try sending again.",
+                            expired_sends.len(),
+                            crate::inbox::PENDING_SENT_TIMEOUT_SECS,
+                        ),
                         crate::toast::ToastLevel::Error,
                     );
                 }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -2028,15 +2028,34 @@ pub(crate) async fn node_comms(
                                         None,
                                     );
                                 } else if let Some(id) = InboxModel::contract_identity(key) {
-                                    // FIXME: in case this is for an inbox contract we were trying to update, this means that
-                                    // the message wasn't sent and should propgate that to the UI
+                                    // A failed UPDATE to a recipient inbox is the
+                                    // terminal signal that the send didn't land
+                                    // (e.g. the recipient-node hang / GET-starvation
+                                    // of freenet-core#4345, or any other UPDATE
+                                    // rejection). Mirror the AFT-`Failure` path
+                                    // (#85) and the import-`Get` path (#302): flip
+                                    // every Sent row queued against this inbox from
+                                    // Pending → Failed and toast the user, instead
+                                    // of leaving the row spinning Pending forever
+                                    // (#288).
                                     let alias = id.alias();
                                     crate::log::error(
                                         format!(
-                                            "the message for {alias} (inbox contract: {key}) wasn't delievered succesffully, so may need to try again and/or notify the user"
+                                            "message for {alias} (inbox contract: {key}) wasn't delivered — flipping queued sends to Failed"
                                         ),
-                                        None,
+                                        Some(TryNodeAction::SendMessage),
                                     );
+                                    crate::toast::push_toast(
+                                        format!(
+                                            "Message to {alias} wasn't delivered. The recipient's node may be temporarily unreachable — try sending again."
+                                        ),
+                                        crate::toast::ToastLevel::Error,
+                                    );
+                                    crate::inbox::fail_pending_sent_for_inbox(
+                                        &mut client,
+                                        *key,
+                                    )
+                                    .await;
                                 }
                             }
                             RequestError::ContractError(ContractError::Get { key, cause }) => {

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -4997,13 +4997,14 @@ fn ComposeSheet() -> Element {
             #[cfg(not(feature = "use-node"))]
             let initial_state = mail_local_state::DeliveryState::Delivered;
 
+            let sent_at_ms = chrono::Utc::now().timestamp_millis();
             let sent = mail_local_state::SentMessage {
                 to: to_val.clone(),
                 recipient_fingerprint: recipient.fingerprint_short(),
                 recipient_fingerprint_full: recipient.fingerprint_full(),
                 subject: title_val.clone(),
                 body: content_val.clone(),
-                sent_at: chrono::Utc::now().timestamp_millis(),
+                sent_at: sent_at_ms,
                 delivery_state: initial_state,
                 // #270: mirror the threading linkage onto the local Sent row
                 // so the Sent folder + reply-from-Sent stay in the thread.
@@ -5022,6 +5023,7 @@ fn ComposeSheet() -> Element {
                         inbox_key,
                         sender_alias.clone(),
                         sent_id.clone(),
+                        sent_at_ms,
                     );
                 }
                 Err(e) => {

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -453,21 +453,22 @@ impl InboxView {
                     // recipient should be unaffected) and flip the row
                     // to Failed so the user sees the truth.
                     crate::inbox::remove_pending_sent_ack(&inbox_key, &sender_alias, &sent_id);
-                    crate::local_state::local_set_sent_delivery_state(
+                    if crate::local_state::local_set_sent_delivery_state(
                         &sender_alias,
                         &sent_id,
                         mail_local_state::DeliveryState::Failed,
-                    );
-                    let mut client_clone = client.clone();
-                    if let Err(e) = crate::local_state::set_sent_delivery_state(
-                        &mut client_clone,
-                        sender_alias,
-                        sent_id,
-                        mail_local_state::DeliveryState::Failed,
-                    )
-                    .await
-                    {
-                        crate::log::local_state_failure("update delivery state", e);
+                    ) {
+                        let mut client_clone = client.clone();
+                        if let Err(e) = crate::local_state::set_sent_delivery_state(
+                            &mut client_clone,
+                            sender_alias,
+                            sent_id,
+                            mail_local_state::DeliveryState::Failed,
+                        )
+                        .await
+                        {
+                            crate::log::local_state_failure("update delivery state", e);
+                        }
                     }
                 }
             };

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -231,16 +231,22 @@ thread_local! {
 /// terminal reply at all" case).
 ///
 /// The clock starts at row construction (`sent_at_ms`), i.e. BEFORE the
-/// async AFT assignment round trip, so this budget is shared: up to
+/// async AFT assignment round trip, so the budget is shared: up to
 /// `PENDING_ASSIGNMENT_TIMEOUT_SECS` (30s) can be spent minting the token
-/// before the recipient-inbox UPDATE is even dispatched. 60s therefore
-/// leaves the UPDATE round trip a worst-case ~30s window — chosen to be
-/// generous enough to avoid false-failing a slow-but-healthy send while
-/// still bounding the stuck-Pending UX. (An AFT-phase stall is normally
-/// surfaced earlier by the AFT sweep / `Failure` arm; this is the
-/// backstop for the case where nothing else fires at all.)
+/// before the recipient-inbox UPDATE is even dispatched. The value is set
+/// to 90s so the UPDATE round trip always gets a full ≥60s window
+/// regardless of how long the AFT phase took — generous enough to avoid
+/// false-failing a slow-but-healthy send while still bounding the
+/// stuck-Pending UX.
+///
+/// This sweep is a backstop. An AFT-phase stall is failed earlier (at
+/// `PENDING_ASSIGNMENT_TIMEOUT_SECS`) by `AftRecords::expire_stale`, which
+/// now flips the Sent row directly; the `Failure` arm (#85) covers
+/// delegate refusals. This 90s sweep only fires when the UPDATE itself got
+/// neither an `UpdateResponse` nor a `ContractError::Update` — the
+/// silent-drop case of freenet-core#4345.
 #[cfg(feature = "use-node")]
-pub(crate) const PENDING_SENT_TIMEOUT_SECS: i64 = 60;
+pub(crate) const PENDING_SENT_TIMEOUT_SECS: i64 = 90;
 
 /// One outgoing Sent row awaiting an `UpdateResponse`. Carries the
 /// `(sender_alias, sent_id)` the UI assigned plus the wall-clock millis

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -212,22 +212,33 @@ thread_local! {
     /// drained FIFO when an `UpdateResponse` arrives for that inbox key
     /// (api.rs flips the corresponding row to `Delivered`).
     ///
-    /// FIFO is "good enough" — the network does not promise that responses
-    /// for sequential sends to the same inbox land in submission order, but
-    /// every successful send will get acked, and a wrong pairing only
-    /// affects the timing of the UI flip, not the correctness of which rows
-    /// end up Delivered.
+    /// FIFO pairing is approximate — the network doesn't promise responses
+    /// for sequential sends to the same inbox land in submission order, and
+    /// the stale-send sweep (#288) can drain an entry that NEVER gets a
+    /// response, so the old "#responses == #entries" invariant no longer
+    /// holds. A mis-paired or post-sweep-late `UpdateResponse` could pop a
+    /// sibling entry and try to flip the wrong row to `Delivered`; that is
+    /// made safe by the terminal-state guard in
+    /// `local_state::local_set_sent_delivery_state` — once a row is
+    /// `Delivered`/`Failed` it never flips again, so the worst case is a
+    /// dropped (no-op) flip, not a wrong terminal state.
     pub(crate) static PENDING_SENT_ACK: RefCell<HashMap<InboxContract, std::collections::VecDeque<PendingSentEntry>>> =
         RefCell::new(HashMap::new());
 }
 
-/// A Sent row whose recipient-inbox `UpdateResponse` hasn't arrived
-/// within this many seconds of enqueue is failed by the stale-send sweep
-/// (#288, "no terminal reply at all" case). Deliberately more generous
-/// than the AFT-assignment timeout (`PENDING_ASSIGNMENT_TIMEOUT_SECS` =
-/// 30s): a send's UPDATE is the full recipient-side round trip, which can
-/// legitimately run longer than a local token confirmation, so 60s avoids
-/// false-failing slow-but-healthy sends.
+/// A Sent row whose `UpdateResponse` hasn't arrived within this many
+/// seconds of enqueue is failed by the stale-send sweep (#288, "no
+/// terminal reply at all" case).
+///
+/// The clock starts at row construction (`sent_at_ms`), i.e. BEFORE the
+/// async AFT assignment round trip, so this budget is shared: up to
+/// `PENDING_ASSIGNMENT_TIMEOUT_SECS` (30s) can be spent minting the token
+/// before the recipient-inbox UPDATE is even dispatched. 60s therefore
+/// leaves the UPDATE round trip a worst-case ~30s window — chosen to be
+/// generous enough to avoid false-failing a slow-but-healthy send while
+/// still bounding the stuck-Pending UX. (An AFT-phase stall is normally
+/// surfaced earlier by the AFT sweep / `Failure` arm; this is the
+/// backstop for the case where nothing else fires at all.)
 #[cfg(feature = "use-node")]
 pub(crate) const PENDING_SENT_TIMEOUT_SECS: i64 = 60;
 
@@ -313,11 +324,16 @@ async fn fail_one_sent(
     sender_alias: &str,
     sent_id: &str,
 ) {
-    crate::local_state::local_set_sent_delivery_state(
+    // Skip the delegate write when the row was already terminal — the local
+    // guard suppressed the in-memory flip, and persisting again would let a
+    // stale value clobber the true terminal state on reload (#288).
+    if !crate::local_state::local_set_sent_delivery_state(
         sender_alias,
         sent_id,
         mail_local_state::DeliveryState::Failed,
-    );
+    ) {
+        return;
+    }
     if let Err(e) = crate::local_state::set_sent_delivery_state(
         client,
         sender_alias.to_string(),
@@ -333,18 +349,11 @@ async fn fail_one_sent(
     }
 }
 
-/// Sweep every pending Sent row across all inboxes and fail those whose
-/// `UpdateResponse` never arrived within `timeout_secs` of enqueue — the
-/// "no terminal reply at all" case (no error, no `UpdateResponse`), the
-/// last uncovered send-failure mode of #288. `now_ms` is the current wall
-/// clock (`chrono::Utc::now().timestamp_millis()`), injected for testability.
-/// Returns the `(sender_alias, sent_id)` pairs that were expired so the
-/// caller can toast the user.
 /// Pure step of the stale-send sweep: remove every pending entry older
 /// than `timeout_secs` from `PENDING_SENT_ACK` and return the drained
-/// `(sender_alias, sent_id)` pairs, newest-handling aside. No I/O, no
-/// client — `now_ms` is injected so the age logic is unit-testable.
-/// Empty per-inbox queues are pruned so the map doesn't accumulate keys.
+/// `(sender_alias, sent_id)` pairs. No I/O, no client — `now_ms` is
+/// injected so the age logic is unit-testable. Empty per-inbox queues are
+/// pruned so the map doesn't accumulate keys.
 fn drain_stale_pending_sent(timeout_secs: i64, now_ms: i64) -> Vec<(String, String)> {
     let cutoff_ms = timeout_secs.saturating_mul(1000);
     PENDING_SENT_ACK.with(|m| {
@@ -366,6 +375,13 @@ fn drain_stale_pending_sent(timeout_secs: i64, now_ms: i64) -> Vec<(String, Stri
     })
 }
 
+/// Sweep every pending Sent row across all inboxes and fail those whose
+/// `UpdateResponse` never arrived within `timeout_secs` of enqueue — the
+/// "no terminal reply at all" case (no error, no `UpdateResponse`), the
+/// last uncovered send-failure mode of #288. `now_ms` is the current wall
+/// clock (`chrono::Utc::now().timestamp_millis()`), injected for testability.
+/// Returns the `(sender_alias, sent_id)` pairs that were expired so the
+/// caller can toast the user.
 #[cfg(feature = "use-node")]
 pub(crate) async fn expire_stale_pending_sent(
     client: &mut crate::api::WebApiRequestClient,

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -217,22 +217,51 @@ thread_local! {
     /// every successful send will get acked, and a wrong pairing only
     /// affects the timing of the UI flip, not the correctness of which rows
     /// end up Delivered.
-    pub(crate) static PENDING_SENT_ACK: RefCell<HashMap<InboxContract, std::collections::VecDeque<(String, String)>>> =
+    pub(crate) static PENDING_SENT_ACK: RefCell<HashMap<InboxContract, std::collections::VecDeque<PendingSentEntry>>> =
         RefCell::new(HashMap::new());
+}
+
+/// A Sent row whose recipient-inbox `UpdateResponse` hasn't arrived
+/// within this many seconds of enqueue is failed by the stale-send sweep
+/// (#288, "no terminal reply at all" case). Deliberately more generous
+/// than the AFT-assignment timeout (`PENDING_ASSIGNMENT_TIMEOUT_SECS` =
+/// 30s): a send's UPDATE is the full recipient-side round trip, which can
+/// legitimately run longer than a local token confirmation, so 60s avoids
+/// false-failing slow-but-healthy sends.
+#[cfg(feature = "use-node")]
+pub(crate) const PENDING_SENT_TIMEOUT_SECS: i64 = 60;
+
+/// One outgoing Sent row awaiting an `UpdateResponse`. Carries the
+/// `(sender_alias, sent_id)` the UI assigned plus the wall-clock millis
+/// when it was enqueued, so a periodic sweep can fail rows whose ack
+/// never arrives at all — no error, no `UpdateResponse` (#288).
+#[derive(Clone)]
+pub(crate) struct PendingSentEntry {
+    pub sender_alias: String,
+    pub sent_id: String,
+    /// `chrono::Utc::now().timestamp_millis()` at enqueue time.
+    pub enqueued_at_ms: i64,
 }
 
 /// Record that a send to `inbox_key` is awaiting an UpdateResponse to flip
 /// the Sent row identified by `(sender_alias, sent_id)` to Delivered.
+/// `enqueued_at_ms` is the send-time wall clock (same source as the Sent
+/// row's `sent_at`), used by the stale-send sweep.
 pub(crate) fn enqueue_pending_sent_ack(
     inbox_key: InboxContract,
     sender_alias: String,
     sent_id: String,
+    enqueued_at_ms: i64,
 ) {
     PENDING_SENT_ACK.with(|m| {
         m.borrow_mut()
             .entry(inbox_key)
             .or_default()
-            .push_back((sender_alias, sent_id));
+            .push_back(PendingSentEntry {
+                sender_alias,
+                sent_id,
+                enqueued_at_ms,
+            });
     });
 }
 
@@ -245,7 +274,7 @@ pub(crate) fn take_next_pending_sent_ack(inbox_key: &InboxContract) -> Option<(S
         if q.is_empty() {
             map.remove(inbox_key);
         }
-        item
+        item.map(|e| (e.sender_alias, e.sent_id))
     })
 }
 
@@ -263,33 +292,99 @@ pub(crate) async fn fail_pending_sent_for_inbox(
     let entries: Vec<(String, String)> = PENDING_SENT_ACK.with(|m| {
         let mut map = m.borrow_mut();
         match map.remove(&inbox_key) {
-            Some(q) => q.into_iter().collect(),
+            Some(q) => q.into_iter().map(|e| (e.sender_alias, e.sent_id)).collect(),
             None => Vec::new(),
         }
     });
     for (sender_alias, sent_id) in entries {
-        crate::local_state::local_set_sent_delivery_state(
-            &sender_alias,
-            &sent_id,
-            mail_local_state::DeliveryState::Failed,
-        );
-        if let Err(e) = crate::local_state::set_sent_delivery_state(
-            client,
-            sender_alias.clone(),
-            sent_id.clone(),
-            mail_local_state::DeliveryState::Failed,
-        )
-        .await
-        {
-            crate::log::error(
-                format!("set_sent_delivery_state(Failed) for {sender_alias}/{sent_id}: {e}"),
-                None,
-            );
-        }
+        fail_one_sent(client, &sender_alias, &sent_id).await;
     }
     PENDING_INBOXES_UPDATE.with(|m| {
         m.borrow_mut().remove(&inbox_key);
     });
+}
+
+/// Flip a single Sent row to `Failed`, both in the in-memory local stash
+/// and via the local-state delegate so the change survives reload. Shared
+/// by `fail_pending_sent_for_inbox` (#85/#288) and `expire_stale_pending_sent`.
+#[cfg(feature = "use-node")]
+async fn fail_one_sent(
+    client: &mut crate::api::WebApiRequestClient,
+    sender_alias: &str,
+    sent_id: &str,
+) {
+    crate::local_state::local_set_sent_delivery_state(
+        sender_alias,
+        sent_id,
+        mail_local_state::DeliveryState::Failed,
+    );
+    if let Err(e) = crate::local_state::set_sent_delivery_state(
+        client,
+        sender_alias.to_string(),
+        sent_id.to_string(),
+        mail_local_state::DeliveryState::Failed,
+    )
+    .await
+    {
+        crate::log::error(
+            format!("set_sent_delivery_state(Failed) for {sender_alias}/{sent_id}: {e}"),
+            None,
+        );
+    }
+}
+
+/// Sweep every pending Sent row across all inboxes and fail those whose
+/// `UpdateResponse` never arrived within `timeout_secs` of enqueue — the
+/// "no terminal reply at all" case (no error, no `UpdateResponse`), the
+/// last uncovered send-failure mode of #288. `now_ms` is the current wall
+/// clock (`chrono::Utc::now().timestamp_millis()`), injected for testability.
+/// Returns the `(sender_alias, sent_id)` pairs that were expired so the
+/// caller can toast the user.
+/// Pure step of the stale-send sweep: remove every pending entry older
+/// than `timeout_secs` from `PENDING_SENT_ACK` and return the drained
+/// `(sender_alias, sent_id)` pairs, newest-handling aside. No I/O, no
+/// client — `now_ms` is injected so the age logic is unit-testable.
+/// Empty per-inbox queues are pruned so the map doesn't accumulate keys.
+fn drain_stale_pending_sent(timeout_secs: i64, now_ms: i64) -> Vec<(String, String)> {
+    let cutoff_ms = timeout_secs.saturating_mul(1000);
+    PENDING_SENT_ACK.with(|m| {
+        let mut map = m.borrow_mut();
+        let mut out = Vec::new();
+        for q in map.values_mut() {
+            q.retain(|e| {
+                let age = now_ms.saturating_sub(e.enqueued_at_ms);
+                if age >= cutoff_ms {
+                    out.push((e.sender_alias.clone(), e.sent_id.clone()));
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        map.retain(|_, q| !q.is_empty());
+        out
+    })
+}
+
+#[cfg(feature = "use-node")]
+pub(crate) async fn expire_stale_pending_sent(
+    client: &mut crate::api::WebApiRequestClient,
+    timeout_secs: i64,
+    now_ms: i64,
+) -> Vec<(String, String)> {
+    // Drain the stale entries out of the map first (sync borrow), then do
+    // the async delegate writes without holding the RefCell across await.
+    let stale = drain_stale_pending_sent(timeout_secs, now_ms);
+    for (sender_alias, sent_id) in &stale {
+        crate::log::error(
+            format!(
+                "send to {sender_alias} (sent_id {sent_id}) got no UpdateResponse within {timeout_secs}s — marking Failed"
+            ),
+            Some(crate::api::TryNodeAction::SendMessage),
+        );
+        fail_one_sent(client, sender_alias, sent_id).await;
+    }
+    stale
 }
 
 /// Remove a specific pending sent record from the queue (e.g. on
@@ -305,7 +400,7 @@ pub(crate) fn remove_pending_sent_ack(
         let Some(q) = map.get_mut(inbox_key) else {
             return;
         };
-        q.retain(|(a, id)| !(a == sender_alias && id == sent_id));
+        q.retain(|e| !(e.sender_alias == sender_alias && e.sent_id == sent_id));
         if q.is_empty() {
             map.remove(inbox_key);
         }
@@ -1979,5 +2074,65 @@ mod tests {
                 "lowercased bs58 must NOT roundtrip — proves the workaround is load-bearing",
             );
         }
+    }
+
+    // ----- #288: stale-send sweep (drain_stale_pending_sent) -----
+
+    use freenet_stdlib::prelude::Parameters;
+
+    fn pending_sent_key(n: u8) -> InboxContract {
+        ContractKey::from_params_and_code(Parameters::from(vec![n]), ContractCode::from(vec![0u8]))
+    }
+
+    fn clear_pending_sent_ack() {
+        PENDING_SENT_ACK.with(|m| m.borrow_mut().clear());
+    }
+
+    #[test]
+    fn drain_stale_pending_sent_fails_only_aged_entries_288() {
+        clear_pending_sent_ack();
+        let key = pending_sent_key(1);
+        // Two sends to the same inbox: one old (enqueued at t=0), one fresh
+        // (enqueued at t=59_000ms). Sweep at now=60_000ms with a 60s timeout.
+        enqueue_pending_sent_ack(key, "alice".into(), "old".into(), 0);
+        enqueue_pending_sent_ack(key, "alice".into(), "fresh".into(), 59_000);
+
+        let drained = drain_stale_pending_sent(60, 60_000);
+
+        // Old (age 60s == cutoff) expires; fresh (age 1s) survives.
+        assert_eq!(drained, vec![("alice".to_string(), "old".to_string())]);
+        // The fresh entry is still queued (will flip Delivered when its ack lands).
+        let remaining = take_next_pending_sent_ack(&key);
+        assert_eq!(remaining, Some(("alice".to_string(), "fresh".to_string())));
+        clear_pending_sent_ack();
+    }
+
+    #[test]
+    fn drain_stale_pending_sent_prunes_empty_inbox_queues_288() {
+        clear_pending_sent_ack();
+        let key = pending_sent_key(2);
+        enqueue_pending_sent_ack(key, "bob".into(), "s1".into(), 0);
+
+        let drained = drain_stale_pending_sent(60, 1_000_000);
+        assert_eq!(drained.len(), 1);
+        // After draining the only entry, the inbox key must not linger in the map.
+        let count = PENDING_SENT_ACK.with(|m| m.borrow().len());
+        assert_eq!(count, 0, "empty per-inbox queue should be pruned");
+        clear_pending_sent_ack();
+    }
+
+    #[test]
+    fn drain_stale_pending_sent_noop_when_all_fresh_288() {
+        clear_pending_sent_ack();
+        let key = pending_sent_key(3);
+        enqueue_pending_sent_ack(key, "carol".into(), "s1".into(), 90_000);
+        // now only 10s past enqueue → under the 60s cutoff.
+        let drained = drain_stale_pending_sent(60, 100_000);
+        assert!(drained.is_empty(), "no entry past cutoff → nothing failed");
+        assert_eq!(
+            take_next_pending_sent_ack(&key),
+            Some(("carol".into(), "s1".into()))
+        );
+        clear_pending_sent_ack();
     }
 }

--- a/ui/src/local_state.rs
+++ b/ui/src/local_state.rs
@@ -512,16 +512,43 @@ pub(crate) fn local_delete_sent(alias: &str, id: &str) {
     bump();
 }
 
-pub(crate) fn local_set_sent_delivery_state(alias: &str, id: &str, state: DeliveryState) {
-    SNAPSHOT.with(|s| {
+/// Returns whether the row actually transitioned. `false` means the row
+/// was already terminal (or absent) and the caller should NOT issue the
+/// follow-up delegate write — otherwise the persisted state could flap on
+/// reload even though the in-memory render was correctly suppressed (#288).
+#[must_use]
+pub(crate) fn local_set_sent_delivery_state(alias: &str, id: &str, state: DeliveryState) -> bool {
+    let changed = SNAPSHOT.with(|s| {
         let mut snap = s.borrow_mut();
         if let Some(entry) = snap.aliases_mut().get_mut(alias)
             && let Some(sent) = entry.sent.get_mut(id)
         {
+            // Pending is the only non-terminal state. Once a row reaches
+            // Delivered or Failed it must NOT flip again (#288): the
+            // stale-send timeout sweep can drain a Pending entry and flip it
+            // Failed, after which a late `UpdateResponse` would otherwise
+            // mis-pair (FIFO pop) and resurrect the wrong row to Delivered —
+            // or flap a delivered row back to Failed. Terminal states stick.
+            if delivery_state_is_terminal(sent.delivery_state) {
+                return false;
+            }
             sent.delivery_state = state;
+            true
+        } else {
+            false
         }
     });
-    bump();
+    if changed {
+        bump();
+    }
+    changed
+}
+
+/// `Delivered` and `Failed` are terminal; `Pending` is the only state a
+/// later transition may overwrite. Centralised so the local stash and the
+/// delegate writer agree on the guard.
+pub(crate) fn delivery_state_is_terminal(state: DeliveryState) -> bool {
+    matches!(state, DeliveryState::Delivered | DeliveryState::Failed)
 }
 
 pub(crate) fn local_archive_message(alias: &str, msg_id: MessageId, archived: ArchivedMessage) {
@@ -1213,5 +1240,94 @@ mod tests {
         // Sanity: expected order is ids descending (6,5,4,3,2,1) because
         // kept_at is identical for all and we tie-break by id descending.
         assert_eq!(expected, vec![6, 5, 4, 3, 2, 1]);
+    }
+
+    // ----- #288: terminal-state guard on the Sent delivery-state setter -----
+
+    fn sent_row(to: &str) -> SentMessage {
+        SentMessage {
+            to: to.into(),
+            ..Default::default()
+        }
+    }
+
+    fn delivery_state_of(alias: &str, id: &str) -> DeliveryState {
+        sent_for(alias)
+            .into_iter()
+            .find(|(i, _)| i == id)
+            .map(|(_, m)| m.delivery_state)
+            .expect("sent row present")
+    }
+
+    #[test]
+    fn pending_can_transition_to_either_terminal_288() {
+        fresh_snapshot();
+        local_save_sent("alice", "s1", sent_row("bob"));
+        local_save_sent("alice", "s2", sent_row("carol"));
+        assert_eq!(delivery_state_of("alice", "s1"), DeliveryState::Pending);
+
+        assert!(local_set_sent_delivery_state(
+            "alice",
+            "s1",
+            DeliveryState::Delivered
+        ));
+        assert!(local_set_sent_delivery_state(
+            "alice",
+            "s2",
+            DeliveryState::Failed
+        ));
+        assert_eq!(delivery_state_of("alice", "s1"), DeliveryState::Delivered);
+        assert_eq!(delivery_state_of("alice", "s2"), DeliveryState::Failed);
+    }
+
+    #[test]
+    fn failed_row_never_resurrects_to_delivered_288() {
+        // The core race the sweep introduces: timeout flips a row Failed,
+        // then a late mis-paired UpdateResponse tries Delivered. Must no-op.
+        fresh_snapshot();
+        local_save_sent("alice", "s1", sent_row("bob"));
+        assert!(local_set_sent_delivery_state(
+            "alice",
+            "s1",
+            DeliveryState::Failed
+        ));
+
+        let changed = local_set_sent_delivery_state("alice", "s1", DeliveryState::Delivered);
+        assert!(
+            !changed,
+            "terminal Failed must not transition; caller skips delegate write"
+        );
+        assert_eq!(
+            delivery_state_of("alice", "s1"),
+            DeliveryState::Failed,
+            "row stays Failed"
+        );
+    }
+
+    #[test]
+    fn delivered_row_never_flaps_to_failed_288() {
+        // Symmetric: a delivered send must not be flipped Failed by a late
+        // stale-send sweep that mis-targets it.
+        fresh_snapshot();
+        local_save_sent("alice", "s1", sent_row("bob"));
+        assert!(local_set_sent_delivery_state(
+            "alice",
+            "s1",
+            DeliveryState::Delivered
+        ));
+
+        let changed = local_set_sent_delivery_state("alice", "s1", DeliveryState::Failed);
+        assert!(!changed, "terminal Delivered must not transition");
+        assert_eq!(delivery_state_of("alice", "s1"), DeliveryState::Delivered);
+    }
+
+    #[test]
+    fn set_delivery_state_on_absent_row_is_noop_288() {
+        fresh_snapshot();
+        let changed = local_set_sent_delivery_state("ghost", "nope", DeliveryState::Failed);
+        assert!(
+            !changed,
+            "absent row → false, caller must skip delegate write"
+        );
     }
 }


### PR DESCRIPTION
## Problem

When a message send's UPDATE to the recipient inbox failed, the Sent row
spun **Pending forever**. The UPDATE-error arm in `ui/src/api.rs` had an
inbox-contract branch that only logged a `FIXME` and never propagated the
failure to the UI.

This is the **send-path face** of freenet/freenet-core#4345: the recipient
node's multi-fragment GET-starvation makes the inbox UPDATE fail, core
surfaces a `ContractError::Update`, and the UI dropped it at that branch —
the same shape of bug #302 fixed for the contact-import modal's `Get`.

## Fix

`ui/src/api.rs` — on an inbox UPDATE error, mirror the existing
AFT-`Failure` path (#85) and import-`Get` path (#302):
- `crate::inbox::fail_pending_sent_for_inbox(&mut client, *key)` drains every
  Sent row queued against that inbox and flips it Pending → Failed (locally
  **and** via the local-state delegate).
- Toast the user (`"Message to <alias> wasn't delivered… try sending again"`)
  so the failure is visible, not just a silent sidebar state change.

## Scope / non-goals

- Does **not** fix the underlying recipient-node hang — that's
  freenet/freenet-core#4345 (`E-hard`/`P-high`). This **bounds the send-side
  UX**, the analog of what #302 did for import.
- **Remaining gap (follow-up):** a send that receives *no terminal reply at
  all* (no error, no `UpdateResponse`) still has no client-side timeout.
  Covering it needs new per-send wall-clock machinery (a periodic sweep over
  Pending Sent rows by send-start time), rather than wiring an existing error
  arm — deferred as a separate change.

## Send-path failure coverage after this PR

| Failure | Handled |
|---|---|
| Sync envelope-construction error | ✅ toast (app.rs) |
| Async `start_sending` error pre-UPDATE | ✅ row → Failed (app.rs) |
| AFT delegate `Failure` | ✅ drain + Failed + toast (#85) |
| **Inbox UPDATE error from node** | ✅ **this PR** |
| No terminal reply ever (true silence) | ⬜ follow-up (send timeout) |

## Test

- `cargo check -p freenet-email-ui --no-default-features --features use-node` — clean.
- `cargo clippy …` — clean.
- `cargo test -p freenet-email-ui --lib --no-default-features --features use-node` — 195 passed.
- The error arm is driven by a node-surfaced `ContractError::Update`; the
  real-net repro is freenet-core#4345.

Refs freenet/freenet-core#4345
