### PR TITLE
test(qa): offline send-routing guard + refresh stale thread annotations (#291)

### DIFF
--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -545,12 +545,23 @@ test.describe("Cross-identity threaded back-and-forth (#270)", () => {
     // group" path is exercised by the seeded thread + the unit test
     // `chronological_interleave_of_sent_and_received`, not here. Real-node
     // multi-arrival grouping is deferred to live-node.spec.ts / CI.
+    // #287 (one-sided thread render) and #270 (back-and-forth grouping)
+    // are both CLOSED — the grouping key is normalized to subject-only
+    // (guarded by threads.spec.ts) so both halves fold into one group when
+    // they share an inbox. What remains is an offline-harness limitation,
+    // not a product bug: the mock mailbox drains per-alias on load and a
+    // sender's own sent message never enters that sender's inbox Vec, so no
+    // single identity's inbox accumulates BOTH halves in one offline load.
+    // The ">=2 messages fold into one group" path is therefore exercised by
+    // the seeded thread + unit tests here, and the real multi-arrival fold
+    // by live-node.spec.ts — neither blocked on any open issue.
     testInfo.annotations.push({
       type: "known-limitation",
       description:
-        "Offline mock mailbox drains per-alias on load and sender-side sent " +
-        "messages don't enter the sender's own inbox; multi-arrival fold is " +
-        "covered by the seeded thread + unit tests, not this cross-identity spec.",
+        "Offline-harness only (not a product bug; #270/#287 closed): the mock " +
+        "mailbox drains per-alias on load and sender-side sent messages don't " +
+        "enter the sender's own inbox, so multi-arrival fold is covered by the " +
+        "seeded thread + unit tests here and by live-node.spec.ts, not this spec.",
     });
 
     await page.goto("/");
@@ -876,6 +887,56 @@ test.describe("Drafts folder (#47a)", () => {
 
     await page.locator('[data-testid="fm-folder-drafts"]').click();
     await expect(page.locator('[data-testid="fm-draft-card"]')).toHaveCount(0);
+  });
+
+  // In-session folder-routing guard (#291): send → message lands in Sent,
+  // NOT Drafts. The "Send removes the draft" test above only asserts the
+  // Drafts side (the row vanishes); this asserts the positive half — Sent
+  // gains exactly the message we just sent — so a regression that drops a
+  // sent message on the floor (no Sent card) is caught, not just a leak
+  // back into Drafts. No reload: offline mode has no persistence layer
+  // (#291 §"Persistence is iso-only"), so this is an in-session routing
+  // assert by design. The across-reload variant lives in
+  // live-node.spec.ts ("sent message stays in Sent ... across reload").
+  test("send routes the message into Sent, not Drafts (#291)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    await openCompose(page);
+    await fillCompose(page, "address2", "routing subj", "routing body");
+
+    await Promise.all([
+      page
+        .locator('[data-testid="fm-compose-sheet"]')
+        .waitFor({ state: "detached", timeout: 10_000 }),
+      clickSend(page),
+    ]);
+
+    // Positive side: the message is in Sent.
+    await page.locator('[data-testid="fm-folder-sent"]').click();
+    const sentCards = page.locator('[data-testid="fm-sent-card"]');
+    await expect(
+      sentCards,
+      "sent message lands in Sent (#291 routing guard)",
+    ).toHaveCount(1);
+    await expect(
+      sentCards.first(),
+      "the Sent card is the message we just sent",
+    ).toContainText("routing subj");
+
+    // Negative side: Drafts holds nothing (no leak, count badge empty).
+    await page.locator('[data-testid="fm-folder-drafts"]').click();
+    await expect(
+      page.locator('[data-testid="fm-draft-card"]'),
+      "no draft left behind after send (#291)",
+    ).toHaveCount(0);
+    await expect(
+      page.locator('[data-testid="fm-folder-drafts"] .count'),
+      "Drafts count badge empty after send (#291)",
+    ).toHaveText("");
   });
 
   test("draft folder count badge reflects pending drafts", async ({ page }) => {

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -726,15 +726,21 @@ test.describe("Live node E2E", () => {
       // threads correctly as far as the data model allows — not a fabricated
       // multi-message grouping that does not occur. Sender-side sent-folding
       // is tracked as the #270 sent↔received data-model gap.
+      // #270/#287 are CLOSED: when two messages share an inbox AND a
+      // subject, they fold into one group (subject-only key). This test
+      // simply doesn't construct that case — a fresh-compose alice→bob
+      // exchange puts exactly one half in each side's inbox and mints a new
+      // thread_id per message, so the per-side standalone-group below is the
+      // genuine, correct rendering, not a fold regression. Not blocked on
+      // any open issue.
       test.info().annotations.push({
         type: "known-limitation",
         description:
-          "#270: a real-node alice↔bob exchange does NOT render as one " +
-          "multi-message thread — sent messages are not folded into the " +
-          "sender's inbox view, and fresh-compose mints a new thread_id per " +
-          "message. Cross-version/cross-node threading requires the Reply " +
-          "button (shared thread_id) AND both halves in one inbox; neither " +
-          "holds here. Asserting the per-side standalone-group reality only.",
+          "Not blocked on any open issue (#270/#287 closed): a fresh-compose " +
+          "real-node alice↔bob exchange puts one half in each inbox with a " +
+          "distinct thread_id, so it renders as per-side standalone groups by " +
+          "design. Multi-message fold requires both halves in one inbox under a " +
+          "shared subject (covered elsewhere); asserting the per-side reality.",
       });
       const bobRoundOneGroup = bobApp
         .locator('[data-testid="fm-thread-group"]')


### PR DESCRIPTION
Knocks out the easy/well-defined #291 coverage gaps. The harder items (iso draft-survives-reload, the #5 delete+regen `test.fixme` delivery step, process/skill rules) stay open in #291 — they need the iso harness or a separate docs pass.

## Changes

**1. New offline in-session routing test** — `send routes the message into Sent, not Drafts (#291)`
The existing `Send removes the draft` test only asserts the Drafts side (the row vanishes). This adds the positive half: Sent gains exactly the message we sent (count == 1, contains the subject), and Drafts stays empty (no card, empty count badge). A regression that drops a sent message on the floor — no Sent card — now fails, not just a Drafts leak.

In-session, no reload: offline mode has no persistence layer (#291 §"Persistence is iso-only"), so the across-reload variant correctly stays iso-only (`live-node.spec.ts` → `sent message stays in Sent ... across reload`).

**2. Refreshed two stale `known-limitation` annotations**
Both `email-app.spec.ts` and `live-node.spec.ts` carried annotations citing **#270 / #287 as open data-model gaps**. Both issues are now **CLOSED** (grouping key normalized to subject-only; guarded by `threads.spec.ts`). Rewrote both to state the per-side standalone-group rendering is correct-by-design and not blocked on any open issue, and dropped the misleading open-issue references + drifted line numbers.

## Test

```
✓ send routes the message into Sent, not Drafts (#291)   (chromium)
✓ Drafts folder (#47a) — all 5                            (chromium)
✓ Cross-identity threaded back-and-forth (#270)           (chromium)
6 passed
```

(`live-node.spec.ts` change is comment-only — annotation strings; no runtime change.)

## Not in scope (still open in #291)
- [ ] Draft-survives-reload inverse guard (**iso** — no offline persistence)
- [ ] #5 delete+regen `test.fixme` — needs the cross-node delivery step wired in
- [ ] Process: ban `auto` without a linked `test("…")`; `freenet-mail-qa` skill reload-reassert rule