### PR TITLE
fix(e2e): block freenet auto-update probe in iso-node harness

### DIFF
--- a/scripts/run-isolated-nodes.sh
+++ b/scripts/run-isolated-nodes.sh
@@ -46,6 +46,28 @@ GW_PGIDFILE="$ROOT/gw.pgid"
 PEER_PGIDFILE="$ROOT/peer.pgid"
 GW_PUBKEY_FILE="$ROOT/gw.pubkey"
 
+# Block freenet's startup auto-update probe.
+#
+# At boot freenet (a clean release build) hits
+# https://api.github.com/repos/freenet/freenet-core/releases/latest and,
+# if a newer release exists, gracefully shuts itself down to auto-update
+# (crates/core/src/bin/freenet.rs — gated only on a dirty git build, with
+# no env knob to disable). That self-shutdown kills the iso gateway
+# mid-E2E whenever the local binary trails the latest freenet-core
+# release, which broke a production release run (the gw on :7510 died
+# seconds after bind → publish hit connection-refused).
+#
+# The update check uses `reqwest::Client` with no `.no_proxy()`, so it
+# honors HTTPS_PROXY. Point it at a dead local port: the probe's
+# `send()` errors, `startup_update_check` returns None, and the node
+# fails-open and stays up. The P2P transport is raw UDP (no reqwest) and
+# the public-gateway-index fetch is already suppressed by
+# `gateways = []` + `--skip-load-from-network`, so nothing load-bearing
+# routes through this proxy. CI achieves the same effect by routing
+# api.github.com → 127.0.0.1 in /etc/hosts (e2e-real-node.yml), which
+# needs sudo; the proxy approach keeps this harness root-free.
+NO_AUTOUPDATE_ENV=(HTTPS_PROXY=http://127.0.0.1:1 HTTP_PROXY=http://127.0.0.1:1 NO_PROXY=)
+
 # spawn_setsid <pidfile> <pgidfile> <stdout-log> <env-prefix> <cmd...>
 #
 # Spawns cmd in its own POSIX session via perl, so the entire process
@@ -113,6 +135,7 @@ up() {
     else
         echo "starting gateway on ws://127.0.0.1:$GW_PORT_WS (net :$GW_PORT_NET)"
         HOME="$GW_HOME" spawn_setsid "$GW_PIDFILE" "$GW_PGIDFILE" "$GW_LOGS/stdout.log" \
+            env "${NO_AUTOUPDATE_ENV[@]}" \
             freenet network \
             --network-port "$GW_PORT_NET" \
             --ws-api-port "$GW_PORT_WS" \
@@ -151,6 +174,7 @@ up() {
     else
         echo "starting peer on ws://127.0.0.1:$PEER_PORT_WS (net :$PEER_PORT_NET) → gateway 127.0.0.1:$GW_PORT_NET"
         HOME="$PEER_HOME" spawn_setsid "$PEER_PIDFILE" "$PEER_PGIDFILE" "$PEER_LOGS/stdout.log" \
+            env "${NO_AUTOUPDATE_ENV[@]}" \
             freenet network \
             --network-port "$PEER_PORT_NET" \
             --ws-api-port "$PEER_PORT_WS" \


### PR DESCRIPTION
## Problem

The iso-node harness (`scripts/run-isolated-nodes.sh`) launches a clean release `freenet` binary. At boot, freenet probes `api.github.com/repos/freenet/freenet-core/releases/latest` and **gracefully self-shuts-down to auto-update** whenever a newer freenet-core release exists. `crates/core/src/bin/freenet.rs` gates this only on a dirty git build — there is **no env knob** to disable it.

That self-shutdown **killed the iso gateway seconds after bind during a production release run**: `cargo make test-e2e-real-node` (the pre-tag smoke in `scripts/release.sh`) brought the gw up on :7510, the local binary (0.2.68) saw 0.2.69 on GitHub and exited, and the subsequent `publish-email-iso` hit `Connection refused (os error 61)`. The release aborted at the e2e gate.

(Discovered cutting v0.2.1 — released by skipping e2e with `FREENET_RELEASE_E2E=0`; this restores the gate.)

## Fix

Route the iso freenet processes' `HTTPS_PROXY`/`HTTP_PROXY` at a dead local port (`127.0.0.1:1`). The update check uses `reqwest::Client` with no `.no_proxy()`, so its request fails-open (`Continuing with current binary`) and the node stays up.

**Why nothing load-bearing breaks:**
- P2P transport is raw UDP — no reqwest, unaffected by HTTP proxy env.
- The public-gateway-index fetch (`config.rs` → `freenet.org/keys/gateways.toml`) is already suppressed by `gateways = []` + `--skip-load-from-network`; the proxy is belt-and-suspenders there.
- The local ws/http gateway is a *server*, not an HTTP client.

CI (`e2e-real-node.yml`) already dodges this by routing `api.github.com → 127.0.0.1` in `/etc/hosts`, which needs **sudo**. The proxy approach keeps the local harness **root-free** and gives `release.sh`'s pre-tag e2e the same protection CI has.

## Validation

Brought both iso nodes up with the patch (separate `FREENET_E2E_ROOT`, real :7509 untouched):

```
WARN auto_update: Startup update check: failed to fetch latest version:
  error sending request for url (https://api.github.com/...).
  Continuing with current binary.
```

- ✅ `HTTPS_PROXY` confirmed reaching the process (`ps eww`)
- ✅ update probe fails-open, **zero** auto-update shutdowns
- ✅ gw :7510 + peer :7511 both serve 200 past the 0-60s jitter window
- ✅ `bash -n` clean