### PR TITLE
fix(ui): route hardcoded light colors through theme tokens for dark mode

### DIFF
--- a/ui/public/vendor/css/components/detail.css
+++ b/ui/public/vendor/css/components/detail.css
@@ -62,8 +62,8 @@
       transition: background .12s ease, color .12s ease, border-color .12s ease;
       cursor: default;
     }
-    .btn-primary { background: var(--ink0); color: #f8fafc; }
-    .btn-primary:hover { background: #000; }
+    .btn-primary { background: var(--btn-solid-bg); color: var(--btn-solid-ink); }
+    .btn-primary:hover { background: var(--btn-solid-bg-hover); }
     .btn-secondary { background: transparent; color: var(--ink2); border: 1px solid var(--line); }
     .btn-secondary:hover { background: var(--hover); border-color: var(--c3); }
     .btn-ghost { background: transparent; color: var(--ink3); border: 0; padding: 6px 12px; }

--- a/ui/public/vendor/css/components/settings.css
+++ b/ui/public/vendor/css/components/settings.css
@@ -236,12 +236,12 @@
     /* Buttons */
     .fm-btn-primary {
       height: 30px; padding: 0 14px; border-radius: 7px;
-      background: var(--ink0); color: #fff;
+      background: var(--btn-solid-bg); color: var(--btn-solid-ink);
       font-size: 13px; font-weight: 500; letter-spacing: -0.005em;
       border: 0;
       transition: background 0.15s ease;
     }
-    .fm-btn-primary:hover { background: var(--ink1); }
+    .fm-btn-primary:hover { background: var(--btn-solid-bg-hover); }
     .fm-btn-secondary {
       height: 30px; padding: 0 12px; border-radius: 7px;
       background: var(--bg-card); color: var(--ink1);
@@ -338,7 +338,7 @@
     .fm-tier.is-active {
       border-color: var(--accent);
       box-shadow: var(--sh-sm), inset 0 -2px 0 var(--accent);
-      background: linear-gradient(180deg, var(--bg-card) 0%, rgba(239, 246, 255, 0.5) 100%);
+      background: linear-gradient(180deg, var(--bg-card) 0%, var(--tint-bg) 100%);
     }
     .fm-tier-name {
       font-family: "Geist Mono", monospace; font-size: 12px;
@@ -552,7 +552,7 @@
       transition: background 0.15s ease;
     }
     .fm-id-pop-row:hover { background: var(--hover); }
-    .fm-id-pop-row.is-active { background: rgba(239, 246, 255, 0.7); }
+    .fm-id-pop-row.is-active { background: var(--tint-bg); }
     .fm-id-pop-row.add { color: var(--accent); font-size: 13.5px; }
 
     /* Diagnostics terminal */
@@ -687,7 +687,7 @@
     }
 
     .verify-words {
-      background: linear-gradient(180deg, rgba(239, 246, 255, 0.6), rgba(220, 252, 231, 0.4));
+      background: linear-gradient(180deg, var(--tint-bg), var(--trust-bg));
       border: 1px solid var(--line2);
       border-radius: 10px; padding: 18px 20px;
       margin: 6px 0 18px;
@@ -732,7 +732,7 @@
     .verify-check:hover { border-color: var(--c3); }
     .verify-check.checked {
       border-color: var(--trust);
-      background: linear-gradient(180deg, rgba(220, 252, 231, 0.4), rgba(220, 252, 231, 0.15));
+      background: var(--trust-bg);
     }
     .verify-check input { appearance: none; display: none; }
     .verify-box {

--- a/ui/public/vendor/css/components/sidebar.css
+++ b/ui/public/vendor/css/components/sidebar.css
@@ -14,7 +14,7 @@
     }
     .compose-btn {
       appearance: none; border: 0;
-      background: var(--ink0); color: #f8fafc;
+      background: var(--btn-solid-bg); color: var(--btn-solid-ink);
       border-radius: 8px; height: 36px;
       display: flex; align-items: center; justify-content: center; gap: 7px;
       font-family: "Fraunces", serif; font-style: italic; font-weight: 400;
@@ -22,7 +22,7 @@
       box-shadow: var(--sh-sm);
       transition: transform .08s ease, background .15s ease;
     }
-    .compose-btn:hover { background: #000; }
+    .compose-btn:hover { background: var(--btn-solid-bg-hover); }
     .compose-btn:active { transform: translateY(1px); }
     .compose-btn .pen { font-size: 13px; opacity: .85; }
 
@@ -60,7 +60,7 @@
 
     .sidebar-bottom { margin-top: auto; display: flex; flex-direction: column; gap: 6px; }
     .conn-card {
-      background: rgba(239, 246, 255, 0.85);
+      background: var(--tint-bg);
       border: 1px solid var(--line2);
       border-radius: 7px;
       padding: 9px 11px;

--- a/ui/public/vendor/css/components/toast.css
+++ b/ui/public/vendor/css/components/toast.css
@@ -15,7 +15,7 @@
 
     /* TOAST */
     .toast {
-      background: var(--ink0); color: #f8fafc;
+      background: var(--btn-solid-bg); color: var(--btn-solid-ink);
       padding: 10px 14px; border-radius: 8px;
       font-size: 13.5px; letter-spacing: -0.005em;
       box-shadow: var(--sh-lg);

--- a/ui/public/vendor/css/components/tokens.css
+++ b/ui/public/vendor/css/components/tokens.css
@@ -39,6 +39,19 @@
       /* Card / popover surface (sheet, dropdown, modal backgrounds). */
       --bg-card: #ffffff;
 
+      /* Solid/inverted button (New message, Reply, primary actions). Light
+         theme: near-black surface with light ink. Must NOT be driven by
+         --ink0 directly — that flips to near-white in dark mode, producing
+         an invisible white-on-white button. Dark theme remaps below. */
+      --btn-solid-bg: var(--ink0);
+      --btn-solid-bg-hover: #000;
+      --btn-solid-ink: #f8fafc;
+
+      /* Tinted surface wash (active rows, soft gradients). Light theme uses
+         the accent-blue tint; dark theme remaps to a dark wash so it doesn't
+         render as a white patch. */
+      --tint-bg: rgba(239, 246, 255, 0.85);
+
       /* Hover film over a surface — light theme: white wash; dark: light wash. */
       --hover: rgba(255, 255, 255, 0.6);
 
@@ -102,6 +115,10 @@
     --unread: #fbbf24;
     --bg-card: #111a2e;
     --hover: rgba(148, 163, 184, 0.12);
+    --btn-solid-bg: var(--accent);
+    --btn-solid-bg-hover: #2563eb;
+    --btn-solid-ink: #f8fafc;
+    --tint-bg: rgba(59, 130, 246, 0.14);
     --amber-bg: rgba(217, 119, 6, 0.12);
     --amber-border: rgba(251, 191, 36, 0.3);
     --amber-ink: #fbbf24;
@@ -130,6 +147,10 @@
       --unread: #fbbf24;
       --bg-card: #111a2e;
       --hover: rgba(148, 163, 184, 0.12);
+      --btn-solid-bg: var(--accent);
+      --btn-solid-bg-hover: #2563eb;
+      --btn-solid-ink: #f8fafc;
+      --tint-bg: rgba(59, 130, 246, 0.14);
       --amber-bg: rgba(217, 119, 6, 0.12);
       --amber-border: rgba(251, 191, 36, 0.3);
       --amber-ink: #fbbf24;


### PR DESCRIPTION
## Problem

Several themed-scope (`.fm-app`) CSS rules hardcoded light surfaces instead of theme tokens, so they never flipped under `data-theme="dark"` and rendered as white patches:

- **New message** button (sidebar)
- **Reply / Forward / Resend** primary buttons (detail toolbar)
- **Connection card** (bottom-left)
- Toasts
- A few settings washes (active tier/identity rows, verify-words panel, verify-check)

Reported from a dark-mode screenshot showing white boxes on the connection card and primary buttons.

### Root cause

The primary buttons used `background: var(--ink0)` — the *ink* token. In dark mode `--ink0` remaps to near-white (`#f1f5f9`), so the button became white-on-white (light `#f8fafc` text). The connection card and several washes used literal `rgba(239, 246, 255, …)` / `#fff` that don't adapt.

## Fix

Add four tokens to `tokens.css`, defined in the `:scope` (light) block and remapped in both dark blocks (`[data-theme="dark"]` and `[data-theme="system"]` + `prefers-color-scheme: dark`):

| token | light | dark |
|---|---|---|
| `--btn-solid-bg` | `var(--ink0)` (near-black) | `var(--accent)` (blue) |
| `--btn-solid-bg-hover` | `#000` | `#2563eb` |
| `--btn-solid-ink` | `#f8fafc` | `#f8fafc` |
| `--tint-bg` | `rgba(239,246,255,.85)` | `rgba(59,130,246,.14)` |

Route the broken rules through these; fold the green washes onto the existing `--trust-bg`.

`login.css` (`.fm-pre` scope — never dark-themed) is intentionally left untouched. The `PENDING` badge already used `var(--c2)`, which flips correctly, so it was not a bug.

## Verification

Built the offline UI (`dx serve --features example-data,no-sync`), forced `data-theme="dark"`, and confirmed in-browser:

- New message button → blue, light text ✓
- Reply button → blue ✓
- Connection card → dark blue tint, readable ✓

(Files changed: `tokens.css`, `sidebar.css`, `detail.css`, `toast.css`, `settings.css`.)