### PR TITLE
fix(inbox): load own inbox via GET-with-subscribe so the owner durably holds it (#288)

### DIFF
--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -174,14 +174,16 @@ impl AftRecords {
             .map_err(|e| format!("{e}"))?;
         let contract_key =
             ContractKey::from_params(TOKEN_RECORD_CODE_HASH, params).map_err(|e| format!("{e}"))?;
+        // `get_state` is a GET-with-subscribe, so it both fetches state and
+        // registers this node as a subscriber/holder. A separate Subscribe is
+        // unnecessary and would be rejected when the contract isn't cached
+        // locally (issue #288).
+        let _ = contract_to_id;
         Self::get_state(client, contract_key).await?;
         let _alias = identity.alias();
         crate::log::debug!(
-            "subscribing to AFT updates for `{contract_key}`, belonging to alias `{_alias}`"
+            "loading + subscribing to AFT record for `{contract_key}`, belonging to alias `{_alias}`"
         );
-        if !contract_to_id.contains_key(&contract_key) {
-            Self::subscribe(client, contract_key).await?;
-        }
         Ok(contract_key)
     }
 
@@ -638,24 +640,14 @@ impl AftRecords {
         client: &mut WebApiRequestClient,
         key: AftRecord,
     ) -> Result<(), DynError> {
+        // GET-with-subscribe: fetch state and register as subscriber/holder
+        // atomically. A standalone Subscribe is rejected when the node doesn't
+        // already hold the AFT record contract locally (issue #288).
         let request = ContractRequest::Get {
             key: key.into(),
             return_contract_code: false,
-            subscribe: false,
+            subscribe: true,
             blocking_subscribe: false,
-        };
-        client.send(request.into()).await?;
-        Ok(())
-    }
-
-    pub async fn subscribe(
-        client: &mut WebApiRequestClient,
-        key: AftRecord,
-    ) -> Result<(), DynError> {
-        // todo: send the proper summary from the current state
-        let request = ContractRequest::Subscribe {
-            key: key.into(),
-            summary: None,
         };
         client.send(request.into()).await?;
         Ok(())

--- a/ui/src/aft.rs
+++ b/ui/src/aft.rs
@@ -143,16 +143,37 @@ pub(crate) fn build_recipient_criteria(
 }
 
 impl AftRecords {
+    /// Derive an identity's own AFT token-allocation-record contract key
+    /// from its ML-DSA verifying key. The key is deterministic per identity
+    /// (`TokenDelegateParameters::new(&vk)` is byte-stable), so this is the
+    /// authoritative source of truth for "is this my own AFT record" —
+    /// independent of any routing-map population order.
+    pub fn record_key_for(identity: &Identity) -> Result<AftRecord, DynError> {
+        use ml_dsa::signature::Keypair;
+        let vk = identity.ml_dsa_signing_key.as_ref().verifying_key();
+        let params = TokenDelegateParameters::new(&vk)
+            .try_into()
+            .map_err(|e| format!("{e}"))?;
+        ContractKey::from_params(TOKEN_RECORD_CODE_HASH, params).map_err(|e| format!("{e}").into())
+    }
+
     pub async fn load_all(
         client: &mut WebApiRequestClient,
         contracts: &[Identity],
         contract_to_id: &mut HashMap<AftRecord, Identity>,
     ) {
         for identity in contracts {
-            let r = Self::load_contract(client, identity, contract_to_id).await;
-            if let Ok(key) = &r {
-                contract_to_id.insert(*key, identity.clone());
+            // Register the AFT-record → identity routing entry BEFORE the
+            // GET-with-subscribe goes out. `get_state` subscribes, so the
+            // node now echoes our own token-burn UPDATEs back as
+            // UpdateNotifications; the handler must already recognize the
+            // key or it logs "unknown contract key" (#204 regression after
+            // #288). Mirrors `InboxModel::load_all`'s synchronous
+            // `register_routing` for inbox keys.
+            if let Ok(key) = Self::record_key_for(identity) {
+                contract_to_id.insert(key, identity.clone());
             }
+            let r = Self::load_contract(client, identity).await;
             node_response_error_handling(
                 client.clone().into(),
                 r.map(|_| ()),
@@ -165,20 +186,12 @@ impl AftRecords {
     async fn load_contract(
         client: &mut WebApiRequestClient,
         identity: &Identity,
-        contract_to_id: &HashMap<AftRecord, Identity>,
     ) -> Result<AftRecord, DynError> {
-        use ml_dsa::signature::Keypair;
-        let vk = identity.ml_dsa_signing_key.as_ref().verifying_key();
-        let params = TokenDelegateParameters::new(&vk)
-            .try_into()
-            .map_err(|e| format!("{e}"))?;
-        let contract_key =
-            ContractKey::from_params(TOKEN_RECORD_CODE_HASH, params).map_err(|e| format!("{e}"))?;
+        let contract_key = Self::record_key_for(identity)?;
         // `get_state` is a GET-with-subscribe, so it both fetches state and
         // registers this node as a subscriber/holder. A separate Subscribe is
         // unnecessary and would be rejected when the contract isn't cached
         // locally (issue #288).
-        let _ = contract_to_id;
         Self::get_state(client, contract_key).await?;
         let _alias = identity.alias();
         crate::log::debug!(

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -190,6 +190,25 @@ fn take_awaiting_ack(
     Some(awaiting.remove(pos).0)
 }
 
+/// True if `key` addresses an AFT token-allocation-record contract under
+/// the current or any legacy code hash. Used as a race-safe backstop in the
+/// UpdateNotification arm: own-AFT-record echoes (enabled by the #288
+/// GET-with-subscribe) are normally recognized via the `token_rec_to_id`
+/// routing map, but an echo that arrives before `AftRecords::load_all`
+/// inserts the key would otherwise be misclassified as an unknown contract
+/// (#204). The record's `code_hash` is shared by every identity's AFT
+/// record, so this can't distinguish own from foreign — but the only AFT
+/// records this client subscribes to are its own, so a code-hash match is a
+/// sufficient and safe drop condition.
+#[cfg(feature = "use-node")]
+fn is_own_aft_record_key(key: &freenet_stdlib::prelude::ContractKey) -> bool {
+    let key_hash = bs58::encode(key.code_hash().as_ref()).into_string();
+    key_hash == crate::aft::TOKEN_RECORD_CODE_HASH
+        || crate::aft::LEGACY_TOKEN_RECORD_CODE_HASHES
+            .iter()
+            .any(|h| *h == key_hash)
+}
+
 #[cfg(feature = "use-node")]
 mod contract_api {
     use freenet_stdlib::{client_api::ContractRequest, prelude::*};
@@ -2619,6 +2638,21 @@ pub(crate) async fn node_comms(
                                     crate::log::debug!(
                                         "UpdateNotification: contact inbox \
                                         {key} (#198) — drop"
+                                    );
+                                } else if is_own_aft_record_key(&key) {
+                                    // Own AFT-record echo that raced ahead of
+                                    // the `token_rec_to_id` insert (the GET-
+                                    // with-subscribe from #288 means the node
+                                    // echoes our own token-burn UPDATEs). The
+                                    // synchronous registration in
+                                    // `AftRecords::load_all` normally has the
+                                    // key in the map by now; this code-hash
+                                    // check is the race-safe backstop so a
+                                    // pre-load echo is dropped quietly instead
+                                    // of logging "unknown contract key" (#204).
+                                    crate::log::debug!(
+                                        "UpdateNotification: own AFT record {key} \
+                                        before routing insert (#204) — drop"
                                     );
                                 } else {
                                     crate::log::error(

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -206,11 +206,16 @@ mod contract_api {
         let key = contract.key();
         crate::log::debug!("putting contract {key}");
         let state = contract_state.into().into();
+        // `subscribe: true` so the creating node becomes a durable
+        // subscriber/holder of the contract it just PUT. Without this the PUT
+        // seeds the contract at topologically-responsible peers but the
+        // creator keeps no local copy, so once those peers churn the contract
+        // falls off the network and every GET returns NotFound (issue #288).
         let request = ContractRequest::Put {
             contract,
             state,
             related_contracts: Default::default(),
-            subscribe: false,
+            subscribe: true,
             blocking_subscribe: false,
         };
         client.send(request.into()).await?;
@@ -955,30 +960,19 @@ mod identity_management {
             login_controller.write().updated = true;
         }
 
-        // Send contract subscriptions after identity creation.
-        InboxModel::subscribe(&mut client.clone(), inbox_key)
-            .await
-            .unwrap();
-        AftRecords::subscribe(&mut client.clone(), aft_rec.unwrap())
-            .await
-            .unwrap();
-        // Subscriptions only deliver future updates. If state changed
-        // between identity restoration and subscribe (e.g. another node
-        // already pushed a message into our inbox), the UI would silently
-        // miss it until the next state change. Issue an explicit Get for
-        // current state right after subscribe so any pre-existing
-        // messages surface as a one-shot UpdateNotification(State).
+        // Bootstrap the inbox + AFT-record subscriptions via GET-with-subscribe
+        // (`get_state` sets `subscribe: true`). This fetches current state AND
+        // registers this node as a subscriber/holder in one op. The previous
+        // scheme issued a standalone Subscribe first, which the node rejects
+        // when the contract isn't already cached locally ("contract WASM not
+        // cached locally") — so the inbox never loaded and the owner never
+        // held its own inbox (issue #288). The GET also surfaces any
+        // pre-existing messages as a one-shot UpdateNotification(State).
         if let Err(e) = InboxModel::get_state(&mut client.clone(), inbox_key).await {
-            crate::log::error(
-                format!("inbox catch-up Get after subscribe failed: {e}"),
-                None,
-            );
+            crate::log::error(format!("inbox get-with-subscribe failed: {e}"), None);
         }
         if let Err(e) = AftRecords::get_state(&mut client.clone(), aft_rec.unwrap()).await {
-            crate::log::error(
-                format!("aft record catch-up Get after subscribe failed: {e}"),
-                None,
-            );
+            crate::log::error(format!("aft record get-with-subscribe failed: {e}"), None);
         }
 
         match identity_management::create_alias_api_call(

--- a/ui/src/inbox.rs
+++ b/ui/src/inbox.rs
@@ -7,7 +7,6 @@ use std::{
 use chacha20poly1305::{XChaCha20Poly1305, aead::Aead};
 use chrono::{DateTime, Utc};
 use freenet_aft_interface::{Tier, TokenAssignment, TokenAssignmentHash};
-use freenet_stdlib::prelude::StateSummary;
 use freenet_stdlib::{
     client_api::ContractRequest,
     prelude::{
@@ -1032,20 +1031,20 @@ pub(crate) struct InboxModel {
 
 impl InboxModel {
     pub async fn load_all(client: &mut WebApiRequestClient, contracts: &[Identity]) {
-        async fn subscribe(
-            client: &mut WebApiRequestClient,
-            contract_key: &ContractKey,
-            identity: &Identity,
-        ) -> Result<(), DynError> {
+        // Register the inbox → identity routing entry. The actual network
+        // subscription happens via the GET-with-subscribe in `load`
+        // (`get_state`); a standalone `Subscribe` here is rejected when the
+        // node doesn't already hold the contract (issue #288), so we only
+        // populate the routing map synchronously and let the GET bootstrap
+        // both the local copy and the subscription.
+        fn register_routing(contract_key: &ContractKey, identity: &Identity) {
             let alias = identity.alias();
             INBOX_TO_ID.with(|map| {
                 map.borrow_mut().insert(*contract_key, identity.clone());
             });
             crate::log::debug!(
-                "subscribing to inbox updates for `{contract_key}`, belonging to alias `{alias}`"
+                "registering inbox routing for `{contract_key}`, belonging to alias `{alias}`"
             );
-            InboxModel::subscribe(client, *contract_key).await?;
-            Ok(())
         }
 
         fn get_key(identity: &Identity) -> Result<ContractKey, DynError> {
@@ -1073,15 +1072,14 @@ impl InboxModel {
                 }
             };
             // INBOX_TO_ID is the single source of truth for routing
-            // inbox UpdateNotifications back to an Identity. Subscribe
-            // populates it synchronously before the network round trip
-            // so peer-side state pushes that race the GetResponse can
-            // still find their owner.
+            // inbox UpdateNotifications back to an Identity. Populate it
+            // synchronously before the network round trip so peer-side
+            // state pushes that race the GetResponse can still find their
+            // owner. The network subscription is established by the
+            // GET-with-subscribe inside `load` below (issue #288).
             let already = INBOX_TO_ID.with(|map| map.borrow().contains_key(&contract_key));
             if !already {
-                let res = subscribe(&mut client, &contract_key, identity).await;
-                node_response_error_handling(client.clone().into(), res, TryNodeAction::LoadInbox)
-                    .await;
+                register_routing(&contract_key, identity);
             }
             let res = InboxModel::load(&mut client, identity).await;
             node_response_error_handling(client.into(), res.map(|_| ()), TryNodeAction::LoadInbox)
@@ -1380,25 +1378,17 @@ impl InboxModel {
         client: &mut WebApiRequestClient,
         key: ContractKey,
     ) -> Result<(), DynError> {
+        // `subscribe: true` fetches current state AND registers this node as
+        // a subscriber/holder in a single op. A standalone `Subscribe` is
+        // rejected by the node when the contract isn't already cached locally
+        // ("contract WASM not cached locally") — it never fetch-on-subscribes.
+        // GET-with-subscribe bootstraps the local copy regardless, so the
+        // inbox loads and the owner durably holds it (issue #288).
         let request = ContractRequest::Get {
             key: key.into(),
             return_contract_code: false,
-            subscribe: false,
+            subscribe: true,
             blocking_subscribe: false,
-        };
-        client.send(request.into()).await?;
-        Ok(())
-    }
-
-    pub async fn subscribe(
-        client: &mut WebApiRequestClient,
-        key: ContractKey,
-    ) -> Result<(), DynError> {
-        // todo: send the proper summary from the current state
-        let summary: StateSummary = serde_json::to_vec(&InboxSummary::new(HashSet::new()))?.into();
-        let request = ContractRequest::Subscribe {
-            key: key.into(),
-            summary: Some(summary),
         };
         client.send(request.into()).await?;
         Ok(())

--- a/ui/tests/live-node.spec.ts
+++ b/ui/tests/live-node.spec.ts
@@ -82,6 +82,10 @@ const ALIAS_T9_BOB = "bob9";
 // pre-existing identity boots the app into the mailbox with no create button.
 const ALIAS_T10_ALICE = "alice10";
 const ALIAS_T10_BOB = "bob10";
+// #288 own-inbox holding regression: distinct alias so the node hasn't
+// already cached this inbox from an earlier test (which would mask the
+// subscribe-before-get bug — the contract would already be locally held).
+const ALIAS_T11_BOB = "bob11";
 test.describe("Live node E2E", () => {
   test.skip(
     !process.env.FREENET_EMAIL_BASE_URL?.includes("/v1/contract/web/"),
@@ -469,6 +473,92 @@ test.describe("Live node E2E", () => {
       await aliceCtx.close().catch(() => {});
       await bobCtx.close().catch(() => {});
       stopGwPump();
+      stopPeerPump();
+    }
+  });
+
+  // Regression for #288: a node must hold (subscribe to) its OWN inbox.
+  //
+  // The bug: identity load issued a bare `ContractRequest::Subscribe` for
+  // the inbox before any GET. The node rejects a Subscribe for a contract
+  // it doesn't already hold ("contract WASM not cached locally"), so the
+  // owner never cached its own inbox — it rendered empty and, because no
+  // peer held it either, every cross-node GET returned NotFound (recipients
+  // couldn't fetch the inbox at all). Fix: load via GET-with-subscribe so
+  // the node fetches state AND registers as a holder/subscriber in one op.
+  //
+  // The signal is node-local and precedes any send, so this test only
+  // creates an identity on the peer and inspects the peer log. The gate:
+  //   - NEGATIVE: peer log must NOT contain a `Rejecting SUBSCRIBE … not
+  //     cached locally` for bob's inbox (the exact broken symptom).
+  //   - POSITIVE: bob opens his own inbox and the app does not surface a
+  //     `ContractResponse(NotFound)` for it in the console.
+  test("node holds its own inbox — no subscribe-before-get reject (#288)", async ({
+    browser,
+  }) => {
+    test.skip(
+      !PEER_BASE_URL,
+      "requires FREENET_EMAIL_BASE_URL to include the contract id",
+    );
+    const stopPeerPump = startPermissionPump(ISO_PEER_ORIGIN);
+    const bobCtx = await browser.newContext();
+    const bobPage = await bobCtx.newPage();
+    // Capture console so a NotFound for bob's own inbox is observable
+    // (the exact error the live browser repro showed under the bug).
+    const consoleErrors: string[] = [];
+    bobPage.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+
+    try {
+      await bobPage.goto(PEER_BASE_URL);
+      await createIdentity(bobPage, ALIAS_T11_BOB);
+
+      // The load path must NOT bare-Subscribe before GET. On regression the
+      // peer logs `Rejecting SUBSCRIBE: contract WASM not cached locally`.
+      // Poll a little — load is async after the identity row appears.
+      const sawReject = await (async () => {
+        const deadline = Date.now() + 20_000;
+        const re =
+          /Rejecting SUBSCRIBE: contract WASM not cached locally|Cannot subscribe to contract .*: contract WASM\/parameters not cached locally/;
+        while (Date.now() < deadline) {
+          if (grepPeerLog(re)) return true;
+          await new Promise((r) => setTimeout(r, 1_000));
+        }
+        return grepPeerLog(re);
+      })();
+      expect(
+        sawReject,
+        "peer must NOT reject a subscribe-before-get for the inbox (regression for #288)",
+      ).toBe(false);
+
+      // Bob opens his own inbox. The shell renders regardless (identity is
+      // local); the gate is that no NotFound for his inbox fires — i.e. the
+      // GET-with-subscribe actually resolved against a held contract.
+      const bobApp = bobPage.frameLocator("iframe#app");
+      await bobApp
+        .locator(
+          `[data-testid="fm-id-row"][data-alias="${ALIAS_T11_BOB}"] [data-testid="fm-id-open"]`,
+        )
+        .first()
+        .click();
+      await expect(
+        bobApp.locator('[data-testid="fm-compose-btn"]'),
+        "bob's mailbox mounts (compose button visible)",
+      ).toBeVisible({ timeout: 30_000 });
+
+      // Allow the inbox GET round trip to settle, then assert no NotFound
+      // for the inbox surfaced in the console.
+      await bobPage.waitForTimeout(5_000);
+      const notFound = consoleErrors.filter((t) =>
+        /ContractResponse\(NotFound/.test(t),
+      );
+      expect(
+        notFound,
+        `bob's own inbox must not GET NotFound (regression for #288). errors: ${notFound.join(" | ")}`,
+      ).toEqual([]);
+    } finally {
+      await bobCtx.close().catch(() => {});
       stopPeerPump();
     }
   });


### PR DESCRIPTION
Fixes #288.

## Problem

A new report (hsantos) couldn't fetch the inbox: the console showed repeated `ContractResponse(NotFound { instance_id: 5vGcxekx… })` and the inbox rendered empty. This is **not** the freenet-core #4345 transport hang (fixed in v0.2.70) and **not** a stale/migrated key.

### Root cause (live-verified in browser + node logs)

On identity load the UI issued a standalone `ContractRequest::Subscribe` for the inbox **before any GET** (`ui/src/api.rs:958`). A node rejects a Subscribe for a contract it doesn't already hold — it does not fetch-on-subscribe. Captured live at the exact session time:

```
Rejecting SUBSCRIBE: contract WASM not cached locally. PUT the contract or GET the contract first. contract=5vGcxekx…
```

The whole hour: 2× SUBSCRIBE-rejected, **zero network GET** for the key. So:
- the owner's node never cached its own inbox → Subscribe rejected → inbox empty;
- the catch-up GET that followed used `subscribe: false`, so even a successful fetch never registered the node as a holder;
- once the transient holder churned, no peer held the contract → every GET network-wide returned NotFound → first-contact delivery impossible.

The owner's node was serving its other contracts fine from local cache (web-container, delegates, AFT) — the inbox was the one contract it didn't hold, because it's the one that went through subscribe-before-get.

## Fix

- `InboxModel::get_state` / `AftRecords::get_state` now send `Get { subscribe: true }` — fetch state **and** register as subscriber/holder in one op, bootstrapping the local copy whether or not the node already holds the contract.
- Drop the now-redundant standalone `Subscribe` on the load paths (identity load, `InboxModel::load_all`, `AftRecords::load_contract`); keep the synchronous `INBOX_TO_ID` routing-map population.
- Create-time PUT (`create_contract`) now uses `subscribe: true` so the creating node durably holds the contract it just published.
- Remove the dead `InboxModel::subscribe` / `AftRecords::subscribe` helpers + unused `StateSummary` import.

### #204 follow-on (second commit)

Flipping the own-AFT-record load to GET-with-subscribe means the node now echoes our own token-burn UPDATEs back as UpdateNotifications — a class that never arrived before (the old standalone Subscribe was rejected). The handler only recognized an own AFT record if its key was in the `token_rec_to_id` map at notification time, which races the async load → a pre-load echo logged "UpdateNotification for unknown contract key" and failed the #204 guard. Fixed by:
- registering the AFT-record→identity routing entry synchronously in `AftRecords::load_all` (new `record_key_for`) **before** the GET goes out (mirrors the inbox `register_routing`);
- a race-safe backstop `is_own_aft_record_key` in the UpdateNotification arm that debug-drops a pre-registration own-record echo instead of erroring.

## Verification

- `cargo clippy -p freenet-email-ui --target wasm32-unknown-unknown -- -D warnings` clean; 202 unit tests pass.
- `cargo make test-e2e-real-node` (iso 2-node, `FREENET_LIVE_E2E_SEND=1`): **10 passed, 1 skipped, 0 failed**, including:
  - new regression `node holds its own inbox — no subscribe-before-get reject (#288)`,
  - `alice → bob across nodes: send + receive end-to-end (#81)`,
  - `contact import + reload + UpdateNotification stays sane (#204)`.

## Test added

`ui/tests/live-node.spec.ts`: a #288 regression that creates an identity on the peer node and asserts (a) the peer log has no subscribe-before-get reject for the inbox, and (b) the owner's inbox does not GET NotFound.