### PR TITLE
fix(inbox): self-heal own inbox/AFT on GET NotFound; route import NotFound

### DIFF
--- a/docs/qa/manual-test-inventory.md
+++ b/docs/qa/manual-test-inventory.md
@@ -220,6 +220,8 @@ add/remove protocol.
 |---|---|---|
 | Peer down mid-send | manual | iso harness up, kill peer, alice sends, expect graceful failure (toast / Sent Failed) |
 | WebSocket reconnect | manual | Drop ws (devtools or kill node), reconnect, confirm UI recovers |
+| Own inbox durably held + fetchable cross-node (#288) | auto (iso) | `live-node.spec.ts` → `node holds its own inbox — no subscribe-before-get reject (#288)` (node-local: no NotFound for own inbox) + `alice → bob across nodes: send + receive end-to-end (#81)` / `reply resolves after add-from-message under a different nickname (#289)` (cross-node import resolves `fm-verify-check` ⇒ recipient inbox fetchable from the other node). |
+| Own inbox **self-heal re-PUT** after it fell off the network (NotFound → reconstruct + PUT-with-subscribe) | blocked (iso) | The re-PUT arm (`ui/src/api.rs` `ContractResponse::NotFound`) only fires when an own inbox/AFT key GETs NotFound. The iso 2-node net has **no churn**, so a freshly-PUT inbox never falls off — the NotFound branch cannot be naturally triggered. Reproducing needs a churn/expiry hook or a debug "drop my inbox from the network" affordance. Routing logic covered by the `notfound_routing` host unit tests in `ui/src/api.rs`. Manual recipe: identity created on an old build (pre-`subscribe:true`) → upgrade → open inbox → telemetry shows a fresh `put_request` for the inbox key + recipients can import. |
 | AFT slot exhaustion (day-1 cap, #85) | blocked | Issue #85 — needs tier configurability |
 | Concurrent same-alias sends from 2 devices | manual | Restore backup on second browser, both compose-and-send simultaneously, observe Sent rows |
 

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -209,6 +209,94 @@ fn is_own_aft_record_key(key: &freenet_stdlib::prelude::ContractKey) -> bool {
             .any(|h| *h == key_hash)
 }
 
+/// How a `ContractResponse::NotFound` should be handled, decided purely from
+/// which routing table the not-found key belongs to. Kept separate from the
+/// (async, thread-local-touching) arm so the priority ordering is unit
+/// testable without a live node — see `notfound_routing` tests.
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(feature = "use-node"), allow(dead_code))]
+enum NotFoundRoute {
+    /// Key is a pending contact-import fetch: resolve the modal with a
+    /// failure immediately instead of waiting out the 30s GET timeout.
+    ContactImport,
+    /// Key is this client's own inbox: reconstruct + re-PUT to self-heal an
+    /// inbox that fell off the network (#288).
+    OwnInbox,
+    /// Key is this client's own AFT token-allocation-record: same self-heal.
+    OwnAftRecord,
+    /// Not attributable to any of the above — log quietly, do not re-PUT.
+    Unattributed,
+}
+
+/// Pure routing decision for a NotFound. The three sources are mutually
+/// exclusive in practice, so the order encodes priority: import first
+/// (cheapest, definitive), then own-inbox, then own-AFT, else unattributed.
+#[cfg_attr(not(feature = "use-node"), allow(dead_code))]
+fn classify_notfound(
+    in_import_pending: bool,
+    is_own_inbox: bool,
+    is_own_aft: bool,
+) -> NotFoundRoute {
+    if in_import_pending {
+        NotFoundRoute::ContactImport
+    } else if is_own_inbox {
+        NotFoundRoute::OwnInbox
+    } else if is_own_aft {
+        NotFoundRoute::OwnAftRecord
+    } else {
+        NotFoundRoute::Unattributed
+    }
+}
+
+#[cfg(test)]
+mod notfound_routing {
+    use super::{classify_notfound, NotFoundRoute};
+
+    #[test]
+    fn import_pending_wins_over_everything() {
+        // A pending import key can never collide with an own key in
+        // practice, but priority must still favour resolving the modal.
+        assert_eq!(
+            classify_notfound(true, true, true),
+            NotFoundRoute::ContactImport
+        );
+        assert_eq!(
+            classify_notfound(true, false, false),
+            NotFoundRoute::ContactImport
+        );
+    }
+
+    #[test]
+    fn own_inbox_when_not_import() {
+        assert_eq!(
+            classify_notfound(false, true, false),
+            NotFoundRoute::OwnInbox
+        );
+        // Inbox takes priority over AFT if both somehow matched.
+        assert_eq!(
+            classify_notfound(false, true, true),
+            NotFoundRoute::OwnInbox
+        );
+    }
+
+    #[test]
+    fn own_aft_when_only_aft() {
+        assert_eq!(
+            classify_notfound(false, false, true),
+            NotFoundRoute::OwnAftRecord
+        );
+    }
+
+    #[test]
+    fn unattributed_when_no_table_owns_it() {
+        // The case that previously fell through to "message not handled".
+        assert_eq!(
+            classify_notfound(false, false, false),
+            NotFoundRoute::Unattributed
+        );
+    }
+}
+
 #[cfg(feature = "use-node")]
 mod contract_api {
     use freenet_stdlib::{client_api::ContractRequest, prelude::*};
@@ -3512,6 +3600,106 @@ pub(crate) async fn node_comms(
                 // Confirms a subscription bookkeeping ack; nothing to drive
                 // off it on the UI side. Logging produces a noisy "message
                 // not handled" line every time we subscribe to inbox/AFT.
+            }
+            HostResponse::ContractResponse(ContractResponse::NotFound { instance_id }) => {
+                // A GET resolved to NotFound: the contract isn't on the
+                // network. Three distinct sources land here, handled in
+                // priority order. They're mutually exclusive in practice
+                // (an own-inbox/own-AFT key is never in the import PENDING
+                // map, and an import key is never in INBOX_TO_ID /
+                // token_rec_to_id), so the first match wins.
+                //
+                // `ContractKey`'s `PartialEq`/`Hash` are keyed only on the
+                // instance id (the code hash is ignored), so a key built
+                // with a placeholder code hash matches the real key in the
+                // INBOX_TO_ID / token_rec_to_id maps.
+                let key = ContractKey::from_id_and_code(instance_id, CodeHash::new([0u8; 32]));
+
+                // Resolve which routing table owns this key, then act. The
+                // import-PENDING removal is also the side effect for the
+                // ContactImport branch, so take it here and feed the boolean
+                // into the pure classifier (see `notfound_routing` tests).
+                let import_addr =
+                    contact_import::PENDING.with(|m| m.borrow_mut().remove(&instance_id));
+                let own_identity = InboxModel::contract_identity(&key);
+                let own_aft_identity = token_rec_to_id.get(&key).cloned();
+                let route = classify_notfound(
+                    import_addr.is_some(),
+                    own_identity.is_some(),
+                    own_aft_identity.is_some(),
+                );
+                match route {
+                    NotFoundRoute::ContactImport => {
+                        // Resolve the import modal immediately with a failure
+                        // instead of letting it spin for the full 30s GET
+                        // timeout (#302).
+                        let inbox_address = import_addr.expect("classified ContactImport");
+                        contact_import::RESULTS.with(|m| {
+                            m.borrow_mut().insert(
+                                inbox_address,
+                                contact_import::ImportFetched {
+                                    outcome: contact_import::ImportFetchOutcome::Failed(
+                                        "inbox not found on the network — the recipient may be \
+                                         offline or their inbox has not propagated yet"
+                                            .into(),
+                                    ),
+                                },
+                            );
+                        });
+                    }
+                    NotFoundRoute::OwnInbox => {
+                        // Own-inbox NotFound -> reconstruct + re-PUT (#288
+                        // self-heal). An identity that loads via GET-with-
+                        // subscribe never durably PUT its inbox, so the
+                        // contract fell off the network. Reconstruct
+                        // `Inbox::new` state and PUT with subscribe:true.
+                        let identity = own_identity.expect("classified OwnInbox");
+                        crate::log::info(format!(
+                            "own inbox not found on the network (key={key}, alias=`{}`) — re-PUTting to self-heal (#288)",
+                            identity.alias()
+                        ));
+                        if let Err(e) = inbox_management::create_contract(
+                            &mut client.clone(),
+                            identity.ml_dsa_signing_key.clone(),
+                            identity.ml_kem_ek_bytes(),
+                            identity.required_tier,
+                            identity.max_age_secs,
+                        )
+                        .await
+                        {
+                            crate::log::error(
+                                format!("own-inbox re-PUT failed for `{}`: {e} (#288)", identity.alias()),
+                                None,
+                            );
+                        }
+                    }
+                    NotFoundRoute::OwnAftRecord => {
+                        // Same self-heal shape for the identity's
+                        // token-allocation-record contract.
+                        let identity = own_aft_identity.expect("classified OwnAftRecord");
+                        crate::log::info(format!(
+                            "own AFT record not found on the network (key={key}, alias=`{}`) — re-PUTting to self-heal (#288)",
+                            identity.alias()
+                        ));
+                        if let Err(e) = token_record_management::create_contract(
+                            &mut client.clone(),
+                            identity.ml_dsa_signing_key.clone(),
+                        )
+                        .await
+                        {
+                            crate::log::error(
+                                format!("own-AFT-record re-PUT failed for `{}`: {e} (#288)", identity.alias()),
+                                None,
+                            );
+                        }
+                    }
+                    NotFoundRoute::Unattributed => {
+                        // Not an import, own inbox, or own AFT record. Log
+                        // quietly so we stop misreporting it as "message not
+                        // handled" via the catch-all (#288).
+                        crate::log::debug!("GET NotFound for unattributed key {instance_id}");
+                    }
+                }
             }
             other => {
                 crate::log::error(format!("message not handled: {other:?}"), None);

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -250,7 +250,7 @@ fn classify_notfound(
 
 #[cfg(test)]
 mod notfound_routing {
-    use super::{classify_notfound, NotFoundRoute};
+    use super::{NotFoundRoute, classify_notfound};
 
     #[test]
     fn import_pending_wins_over_everything() {
@@ -3668,7 +3668,10 @@ pub(crate) async fn node_comms(
                         .await
                         {
                             crate::log::error(
-                                format!("own-inbox re-PUT failed for `{}`: {e} (#288)", identity.alias()),
+                                format!(
+                                    "own-inbox re-PUT failed for `{}`: {e} (#288)",
+                                    identity.alias()
+                                ),
                                 None,
                             );
                         }
@@ -3688,7 +3691,10 @@ pub(crate) async fn node_comms(
                         .await
                         {
                             crate::log::error(
-                                format!("own-AFT-record re-PUT failed for `{}`: {e} (#288)", identity.alias()),
+                                format!(
+                                    "own-AFT-record re-PUT failed for `{}`: {e} (#288)",
+                                    identity.alias()
+                                ),
                                 None,
                             );
                         }


### PR DESCRIPTION
## Problem

A `ContractResponse::NotFound` had **no match arm** in `handle_response` (`ui/src/api.rs`) and fell through to the `message not handled` catch-all. Three real failures landed there:

1. **Own inbox never durably PUT to the network.** Existing identities load via `InboxModel::get_state` (GET-with-subscribe), which can't *create* a contract that isn't on the network — only first-time `create_contract` PUTs with `subscribe:true`. A pre-fix identity (or one whose inbox fell off the network through peer churn) GETs `NotFound` on load and **nothing re-PUTs it**. The owner never holds its own inbox; every cross-node GET returns `NotFound`.

   **Telemetry-confirmed** on a live inbox (`5vGcxekx…DUCRQ`): **662 `get_request` / 665 `get_not_found`, zero `put`** across the network. Remote peers (incl. the reporting user at 79.150.235.155) propagate GETs 8-9 hops, all not_found. `fdev execute get` against the local node: `Contract not found`. Recipients can't import the contact or receive mail.

2. **Contact-import fetch NotFound was unhandled** → the import modal spun the full **30s** GET timeout instead of erroring immediately.

3. The NotFound was logged as `error: message not handled` — noise.

## Fix

Add a `ContractResponse::NotFound { instance_id }` arm that routes by which table owns the key:

| Source | Action |
|---|---|
| Own inbox (`INBOX_TO_ID`) | Reconstruct `Inbox::new` state + re-PUT with `subscribe:true` — **self-heal** (#288) |
| Own AFT-record (`token_rec_to_id`) | Re-PUT the token-allocation-record |
| Pending contact-import key | Resolve the modal with a clear failure **immediately** (no 30s spin) |
| Else | Quiet `debug` log (stops the catch-all error noise) |

`ContractKey`'s `PartialEq`/`Hash` are **instance-id-only** (code hash ignored — verified in freenet-stdlib 0.6.0 `key.rs:200-210`), so the not-found key (which carries only the `ContractInstanceId`) is built with a placeholder code hash and still matches the routing maps.

The priority decision is extracted into a pure `classify_notfound` helper with `notfound_routing` host unit tests (4, passing).

## Self-heal safety

- A re-PUT reconstructs **empty** `Inbox::new` state. Safe here because `NotFound` means the network genuinely lacks the contract — there are no stored messages to clobber (nothing was ever durably PUT).
- `inbox_management::create_contract` re-stamps `PENDING_CONFIRMATION` but does **not** push `CREATED_INBOX`; the PUT-success confirmation gate (`api.rs:2750`) keys on `CREATED_INBOX`, so the re-stamped entry stays inert and never re-triggers `alias_creation`.

## Tests

- `notfound_routing` host unit tests — priority ordering of the classifier.
- QA matrix (`docs/qa/manual-test-inventory.md`): added the cross-node inbox-durability row (`auto` via existing iso tests `#288` / `#81` / `#289`); marked the **self-heal-after-churn** variant `blocked` — the iso 2-node net has no churn, so the `NotFound` branch can't be triggered there naturally (honors the #291 no-false-green rule).

## Verification

- `cargo clippy -p freenet-email-ui --no-default-features --features use-node --target wasm32-unknown-unknown -- -D warnings` → clean
- `cargo test -p freenet-email-ui --features use-node notfound_routing` → 4 passed