### PR TITLE
feat(ui): responsive mobile layout — collapse 3-pane into navigable single pane

### DIFF
--- a/ui/branding/testids.json
+++ b/ui/branding/testids.json
@@ -4,6 +4,8 @@
   "fmLogout": "fm-logout",
   "fmSearch": "fm-search",
   "fmComposeBtn": "fm-compose-btn",
+  "fmHamburger": "fm-hamburger",
+  "fmBack": "fm-back",
   "fmList": "fm-list",
   "fmMsgCard": "fm-msg-card",
   "fmMsgTime": "fm-msg-time",

--- a/ui/index.html
+++ b/ui/index.html
@@ -31,6 +31,9 @@
     <link rel="stylesheet" href="vendor/css/components/toast.css" />
     <link rel="stylesheet" href="vendor/css/components/login.css" />
     <link rel="stylesheet" href="vendor/css/components/settings.css" />
+    <!-- Loaded LAST so its width/flex overrides win the @layer components
+         source-order tie-break. Mobile-only; desktop (>768px) unchanged. -->
+    <link rel="stylesheet" href="vendor/css/components/responsive.css" />
   </head>
   <body>
     <div id="main"></div>

--- a/ui/public/vendor/css/components/responsive.css
+++ b/ui/public/vendor/css/components/responsive.css
@@ -1,0 +1,88 @@
+/* Responsive / mobile layout overrides (#mobile-layout).
+ *
+ * Loaded LAST among the component partials so its width/flex overrides win
+ * the @layer components source-order tie-break (see ui/index.html).
+ *
+ * Desktop (>768px) is byte-for-byte unchanged: every layout rule lives
+ * inside @media (max-width: 768px). The only rules outside the query are
+ * three display:none declarations that hide mobile-only elements
+ * (.fm-hamburger / .sidebar-scrim / .fm-back-btn) on desktop — those
+ * elements do not exist in the desktop layout, so hiding them is inert.
+ *
+ * The .fm-app[data-view=...] attribute is always emitted by app.rs but is
+ * inert on desktop because no desktop rule keys off it.
+ */
+
+@layer components {
+  @scope (.fm-app) {
+
+    /* Desktop default: mobile-only affordances hidden. */
+    .fm-hamburger { display: none; }
+    .sidebar-scrim { display: none; }
+    .fm-back-btn { display: none; }
+
+    @media (max-width: 768px) {
+      /* --- TOPBAR --- */
+      .brand { width: auto; flex: 0 0 auto; padding: 0 10px; gap: 6px; }
+      .brand-tag { display: none; }            /* keep logo + name only */
+      .topbar-mid { padding: 0 8px; min-width: 0; }
+      .search { max-width: none; }             /* let search shrink to fill */
+      .topbar-right { padding: 0 10px; gap: 8px; }
+      .fm-hamburger {
+        display: flex; align-items: center; justify-content: center;
+        width: 34px; height: 34px; border: 0; background: transparent;
+        color: var(--ink2); font-size: 18px; flex: 0 0 34px;
+        cursor: pointer;
+      }
+
+      /* --- SIDEBAR off-canvas drawer --- */
+      .sidebar {
+        position: fixed; top: 50px; left: 0; bottom: 0; width: 264px; z-index: 40;
+        transform: translateX(-100%);
+        transition: transform .22s ease;
+        box-shadow: var(--sh-lg);
+      }
+      /* Inside @scope (.fm-app) the scope root is .fm-app itself, so a
+         selector that re-names `.fm-app` matches only a NESTED .fm-app
+         (a descendant of the root) — which never exists. Reference the
+         scope root with :scope so the drawer/view-swap rules actually
+         match the single .fm-app element. */
+      :scope.drawer-open .sidebar { transform: translateX(0); }
+      .sidebar-scrim {
+        display: block; position: fixed; inset: 50px 0 0 0; z-index: 39;
+        background: rgba(0,0,0,0.4); opacity: 0; pointer-events: none;
+        transition: opacity .22s ease;
+      }
+      :scope.drawer-open .sidebar-scrim { opacity: 1; pointer-events: auto; }
+
+      /* --- LIST / DETAIL single-pane swap --- */
+      .list-col { width: 100%; flex: 1 1 auto; border-right: 0; }
+      .detail-col { width: 100%; flex: 1 1 auto; min-width: 0; }
+      :scope[data-view="list"]   .detail-col { display: none; }
+      :scope[data-view="detail"] .list-col   { display: none; }
+
+      /* --- detail padding/typography shrink --- */
+      .detail-head   { padding: 16px 16px 12px; }
+      .toolbar       { padding: 10px 16px; }
+      .detail-scroll { padding: 16px 16px 48px; }
+      .detail-subj   { font-size: 20px; }
+      .ft-head       { padding-left: 16px; padding-right: 16px; }
+
+      /* --- mobile back button in detail --- */
+      .fm-back-btn {
+        display: inline-flex; align-items: center; gap: 4px;
+        background: transparent; border: 0; color: var(--ink2);
+        font-size: 14px; padding: 6px 8px; margin-right: 4px;
+        cursor: pointer;
+      }
+    }
+  }
+
+  @scope (.fm-pre) {
+    @media (max-width: 768px) {
+      .id-row { flex-wrap: wrap; gap: 12px; }
+      .id-meta { flex: 1 1 100%; min-width: 0; }
+      .id-actions { flex: 0 0 auto; margin-left: auto; }
+    }
+  }
+}

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -2626,7 +2626,32 @@ fn UserInbox() -> Element {
     } else {
         ""
     };
-    let app_class = format!("fm-app{serif_class}");
+
+    // Mobile off-canvas drawer state. Single source of truth, shared with
+    // Topbar (hamburger toggle) and Sidebar (auto-close on nav) via context.
+    // Inert on desktop: the `drawer-open` class only drives rules inside the
+    // max-width:768px media query.
+    let mut drawer_open = use_signal(|| false);
+    use_context_provider(|| drawer_open);
+    let drawer_class = if drawer_open() { " drawer-open" } else { "" };
+    let app_class = format!("fm-app{serif_class}{drawer_class}");
+
+    // Single-pane mobile swap: which of list/detail is showing. Pure derive
+    // from the selection model — no extra signal. Inert on desktop (no
+    // desktop rule keys off data-view). Settings/new-msg overlay everything
+    // as siblings of .main, so they're intentionally excluded here.
+    let data_view = {
+        let sel = menu_selection.read();
+        if sel.email().is_some()
+            || sel.thread_root().is_some()
+            || sel.sent_id().is_some()
+            || sel.archived_id().is_some()
+        {
+            "detail"
+        } else {
+            "list"
+        }
+    };
 
     let import_contact = use_context::<Signal<crate::app::login::ImportContact>>();
     let share_contact = use_context::<Signal<crate::app::login::ShareContact>>();
@@ -2638,11 +2663,13 @@ fn UserInbox() -> Element {
             "data-theme": theme_attr,
             "data-density": density_attr,
             "data-font-size": font_size_attr,
+            "data-view": data_view,
             Topbar {}
             div { class: "main",
                 Sidebar {}
                 MessageList {}
                 DetailPanel {}
+                div { class: "sidebar-scrim", onclick: move |_| drawer_open.set(false) }
             }
             if settings_open {
                 { settings::SettingsShell() }
@@ -2704,8 +2731,19 @@ fn Topbar() -> Element {
         .unwrap_or_else(|| "·".to_string());
     let search = menu_selection.read().search().to_string();
     let app_name = crate::app_name();
+    let mut drawer_open = use_context::<Signal<bool>>();
     rsx! {
         div { class: "topbar",
+            button {
+                class: "fm-hamburger",
+                "data-testid": testid::FM_HAMBURGER,
+                "aria-label": "Menu",
+                onclick: move |_| {
+                    let v = drawer_open();
+                    drawer_open.set(!v);
+                },
+                "\u{2630}"
+            }
             div { class: "brand",
                 {brand_logo()}
                 div { class: "brand-text",
@@ -2751,6 +2789,7 @@ fn Topbar() -> Element {
 fn Sidebar() -> Element {
     let mut user = use_context::<Signal<User>>();
     let mut menu_selection = use_context::<Signal<menu::MenuSelection>>();
+    let mut drawer_open = use_context::<Signal<bool>>();
     let inbox = use_context::<Signal<InboxView>>();
     let emails_snapshot: Vec<Message> = inbox.read().messages.borrow().clone();
     let active = menu_selection.read().folder();
@@ -2778,10 +2817,13 @@ fn Sidebar() -> Element {
                 class: "compose-btn",
                 "data-testid": testid::FM_COMPOSE_BTN,
                 onclick: move |_| {
-                    let mut sel = menu_selection.write();
-                    if !sel.is_new_msg() {
-                        sel.at_new_msg();
+                    {
+                        let mut sel = menu_selection.write();
+                        if !sel.is_new_msg() {
+                            sel.at_new_msg();
+                        }
                     }
+                    drawer_open.set(false);
                 },
                 span { class: "pen", "✎" }
                 "New message"
@@ -2820,7 +2862,10 @@ fn Sidebar() -> Element {
                                 button {
                                     class: "{cls}",
                                     "data-testid": "{testid}",
-                                    onclick: move |_| { menu_selection.write().set_folder(f); },
+                                    onclick: move |_| {
+                                        menu_selection.write().set_folder(f);
+                                        drawer_open.set(false);
+                                    },
                                     span { class: "icon", "{f.icon()}" }
                                     span { class: "label", "{f.label()}" }
                                     span { class: "count", "{count_text}" }
@@ -2836,6 +2881,7 @@ fn Sidebar() -> Element {
                     "data-testid": testid::FM_SIDEBAR_CONTACTS,
                     onclick: move |_| {
                         menu_selection.write().open_settings(menu::SettingsScreen::Contacts);
+                        drawer_open.set(false);
                     },
                     span { class: "icon", "☺" }
                     span { class: "label", "Contacts" }
@@ -2876,13 +2922,16 @@ fn Sidebar() -> Element {
                     class: "nav-item",
                     "data-testid": testid::FM_LOGOUT,
                     onclick: move |_| {
-                        let mut state = user.write();
-                        state.logged = false;
-                        state.active_id = None;
-                        // Clear the per-identity message cache so the next
-                        // login re-runs `load_example_messages` instead of
-                        // hitting the idempotency guard with stale rows.
-                        inbox.read().messages.borrow_mut().clear();
+                        {
+                            let mut state = user.write();
+                            state.logged = false;
+                            state.active_id = None;
+                            // Clear the per-identity message cache so the next
+                            // login re-runs `load_example_messages` instead of
+                            // hitting the idempotency guard with stale rows.
+                            inbox.read().messages.borrow_mut().clear();
+                        }
+                        drawer_open.set(false);
                     },
                     span { class: "icon", "⏏" }
                     span { class: "label", "Log out" }
@@ -3602,6 +3651,13 @@ fn ThreadDetail(group: crate::app::threads::ThreadGroup) -> Element {
                     }
                 }
                 div { class: "toolbar",
+                    button {
+                        class: "fm-back-btn",
+                        "data-testid": testid::FM_BACK,
+                        "aria-label": "Back",
+                        onclick: move |_| { menu_selection.write().at_inbox_list(); },
+                        "\u{2039} Back"
+                    }
                     div { class: "spacer" }
                     button {
                         class: "btn btn-primary",
@@ -3996,6 +4052,13 @@ fn OpenArchivedMessage(msg_id: u64, msg: mail_local_state::ArchivedMessage) -> E
             }
             div { class: "toolbar",
                 button {
+                    class: "fm-back-btn",
+                    "data-testid": testid::FM_BACK,
+                    "aria-label": "Back",
+                    onclick: move |_| { menu_selection.write().at_inbox_list(); },
+                    "\u{2039} Back"
+                }
+                button {
                     class: "btn btn-primary",
                     "data-testid": testid::FM_ARCHIVE_REPLY,
                     onclick: move |_| {
@@ -4159,6 +4222,13 @@ fn OpenSentMessage(msg: mail_local_state::SentMessage) -> Element {
                 }
             }
             div { class: "toolbar",
+                button {
+                    class: "fm-back-btn",
+                    "data-testid": testid::FM_BACK,
+                    "aria-label": "Back",
+                    onclick: move |_| { menu_selection.write().at_inbox_list(); },
+                    "\u{2039} Back"
+                }
                 button {
                     class: "btn btn-primary",
                     "data-testid": testid::FM_SENT_REPLY,
@@ -4546,6 +4616,13 @@ fn OpenMessage(msg: Message) -> Element {
                 }
             }
             div { class: "toolbar",
+                button {
+                    class: "fm-back-btn",
+                    "data-testid": testid::FM_BACK,
+                    "aria-label": "Back",
+                    onclick: move |_| { menu_selection.write().at_inbox_list(); },
+                    "\u{2039} Back"
+                }
                 if show_add_to_ab {
                     button {
                         class: "btn btn-secondary",

--- a/ui/src/testid.rs
+++ b/ui/src/testid.rs
@@ -22,6 +22,12 @@ pub(crate) const FM_SEARCH: &str = "fm-search";
 
 // Sidebar / folders
 pub(crate) const FM_COMPOSE_BTN: &str = "fm-compose-btn";
+// Mobile-only topbar control that opens the off-canvas sidebar drawer
+// (<=768px). Hidden on desktop. Playwright's mobile-chrome profile must
+// click this before any sidebar interaction.
+pub(crate) const FM_HAMBURGER: &str = "fm-hamburger";
+// Mobile-only "back to list" control in the detail toolbars (<=768px).
+pub(crate) const FM_BACK: &str = "fm-back";
 
 // Message list
 pub(crate) const FM_LIST: &str = "fm-list";
@@ -160,6 +166,8 @@ mod tests {
             ("fmLogout", super::FM_LOGOUT),
             ("fmSearch", super::FM_SEARCH),
             ("fmComposeBtn", super::FM_COMPOSE_BTN),
+            ("fmHamburger", super::FM_HAMBURGER),
+            ("fmBack", super::FM_BACK),
             ("fmList", super::FM_LIST),
             ("fmMsgCard", super::FM_MSG_CARD),
             ("fmMsgTime", super::FM_MSG_TIME),

--- a/ui/tests/compose-autocomplete.spec.ts
+++ b/ui/tests/compose-autocomplete.spec.ts
@@ -29,7 +29,20 @@ async function selectIdentity(page: Page, alias: string) {
   await page.locator(`[data-testid="${TID.fmApp}"]`).waitFor({ timeout: 10_000 });
 }
 
+// Opens the off-canvas sidebar drawer when running on a mobile viewport
+// (<=768px). On desktop the hamburger is display:none, so this is a no-op.
+async function openNav(page: Page) {
+  const burger = page.locator(`[data-testid="${TID.fmHamburger}"]`);
+  if (await burger.isVisible().catch(() => false)) {
+    await burger.click();
+    await page
+      .locator(`[data-testid="${TID.fmComposeBtn}"]`)
+      .waitFor({ state: "visible" });
+  }
+}
+
 async function openCompose(page: Page) {
+  await openNav(page);
   await page.locator(`[data-testid="${TID.fmComposeBtn}"]`).click();
   await page
     .locator(`[data-testid="${TID.fmComposeSheet}"]`)
@@ -211,6 +224,7 @@ test.describe("Compose autocomplete — touch long-press (Pixel 5)", () => {
       )
       .click();
     await page.locator(`[data-testid="${TID.fmApp}"]`).waitFor({ timeout: 10_000 });
+    await openNav(page);
     await page.locator(`[data-testid="${TID.fmComposeBtn}"]`).click();
     await page
       .locator(`[data-testid="${TID.fmComposeSheet}"]`)

--- a/ui/tests/email-app.spec.ts
+++ b/ui/tests/email-app.spec.ts
@@ -17,6 +17,21 @@ async function waitForApp(page: Page) {
   await expect(page.locator(".brand-name").first()).toContainText(APP_NAME);
 }
 
+// Opens the off-canvas sidebar drawer when running on a mobile viewport
+// (<=768px). On desktop the hamburger is display:none, so this is a no-op.
+// The drawer auto-closes when a nav item is tapped, so call this before
+// EACH sidebar interaction.
+async function openNav(page: Page) {
+  const burger = page.locator('[data-testid="fm-hamburger"]');
+  if (await burger.isVisible().catch(() => false)) {
+    await burger.click();
+    // wait for the drawer to be on-screen (sidebar transform settled)
+    await page
+      .locator('[data-testid="fm-compose-btn"]')
+      .waitFor({ state: "visible" });
+  }
+}
+
 // Helper: select an identity by clicking its row's "Open inbox"
 // button. Identity rows are now structural (id-row), so clicking the
 // alias text alone no longer logs in.
@@ -32,11 +47,13 @@ async function selectIdentity(page: Page, alias: string) {
 
 // Helper: click the redesigned sidebar logout.
 async function logout(page: Page) {
+  await openNav(page);
   await page.locator('[data-testid="fm-logout"]').click();
 }
 
 // Helper: open the compose sheet via the sidebar's "New message" button.
 async function openCompose(page: Page) {
+  await openNav(page);
   await page.locator('[data-testid="fm-compose-btn"]').click();
   await page
     .locator('[data-testid="fm-compose-sheet"]')
@@ -145,6 +162,7 @@ test.describe("Inbox view", () => {
     await waitForApp(page);
     await selectIdentity(page, "address1");
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-sent"]').click();
     // 47b changed the empty Sent detail-panel hint to "Select a sent message"
     // because Sent now backs a real list. The list-col still says "Sent is
@@ -152,11 +170,13 @@ test.describe("Inbox view", () => {
     // assert against here.
     await expect(page.locator(".empty-hint")).toContainText("Select a sent message");
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-drafts"]').click();
     await expect(page.locator(".empty-hint")).toContainText(
       "Drafts is empty",
     );
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-archive"]').click();
     // 47c: Archive backs a real list; empty detail prompt mirrors Sent.
     await expect(page.locator(".empty-hint")).toContainText(
@@ -208,6 +228,7 @@ test.describe("Quarantine folder", () => {
     await expect(quarantineBtn.locator(".count")).toHaveText("2");
 
     // Inbox is now empty — every example sender is unknown.
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-inbox"]').click();
     await expect(page.getByText("Lunch tomorrow?")).toHaveCount(0);
 
@@ -216,6 +237,7 @@ test.describe("Quarantine folder", () => {
     // testid is now only carried as the `data-msg-card-testid` ATTRIBUTE, not a
     // real testid). The 5 unverified messages group into 3 rows: the seeded
     // "Lunch tomorrow?" conversation + the 2 standalone messages.
+    await openNav(page);
     await quarantineBtn.click();
     const rows = page.locator('[data-testid="fm-thread-group"]');
     await expect(rows).toHaveCount(3);
@@ -826,6 +848,7 @@ test.describe("Drafts folder (#47a)", () => {
     await expect(sheet).toHaveCount(0);
 
     // Switch to Drafts. The card carries the typed To/subject/body.
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-drafts"]').click();
     const draftCard = page
       .locator('[data-testid="fm-draft-card"]')
@@ -868,6 +891,7 @@ test.describe("Drafts folder (#47a)", () => {
     await expect(sheet).toHaveCount(0);
 
     // Drafts folder is empty again.
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-drafts"]').click();
     await expect(page.locator('[data-testid="fm-draft-card"]')).toHaveCount(0);
   });
@@ -885,6 +909,7 @@ test.describe("Drafts folder (#47a)", () => {
       clickSend(page),
     ]);
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-drafts"]').click();
     await expect(page.locator('[data-testid="fm-draft-card"]')).toHaveCount(0);
   });
@@ -916,6 +941,7 @@ test.describe("Drafts folder (#47a)", () => {
     ]);
 
     // Positive side: the message is in Sent.
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-sent"]').click();
     const sentCards = page.locator('[data-testid="fm-sent-card"]');
     await expect(
@@ -928,6 +954,7 @@ test.describe("Drafts folder (#47a)", () => {
     ).toContainText("routing subj");
 
     // Negative side: Drafts holds nothing (no leak, count badge empty).
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-drafts"]').click();
     await expect(
       page.locator('[data-testid="fm-draft-card"]'),
@@ -1211,6 +1238,7 @@ test.describe("Sent folder (#47b)", () => {
       clickSend(page),
     ]);
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-sent"]').click();
     const card = page.locator('[data-testid="fm-sent-card"]').first();
     await expect(card).toBeVisible();
@@ -1261,6 +1289,7 @@ test.describe("Sent folder (#47b)", () => {
       clickSend(page),
     ]);
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-sent"]').click();
     await page.locator('[data-testid="fm-sent-card"]').first().click();
     // Mobile viewports stack columns and the message list overlays the
@@ -1302,6 +1331,7 @@ test.describe("Sent folder (#47b)", () => {
       clickSend(page),
     ]);
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-sent"]').click();
     await page.locator('[data-testid="fm-sent-card"]').first().click();
     await page.locator('[data-testid="fm-sent-forward"]').dispatchEvent("click");
@@ -1334,6 +1364,7 @@ test.describe("Sent folder (#47b)", () => {
       clickSend(page),
     ]);
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-sent"]').click();
     await page.locator('[data-testid="fm-sent-card"]').first().click();
     await page.locator('[data-testid="fm-sent-resend"]').dispatchEvent("click");
@@ -1493,6 +1524,7 @@ test.describe("Archive folder (#47c)", () => {
     await expect(page.locator("#email-inbox-accessor-3")).toHaveCount(0);
 
     // Archive folder shows the row.
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-archive"]').click();
     const card = page.locator('[data-testid="fm-archive-card"]').first();
     await expect(card).toBeVisible();
@@ -1529,6 +1561,7 @@ test.describe("Archive folder (#47c)", () => {
 
     await expect(page.locator("#email-inbox-accessor-4")).toHaveCount(0);
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-archive"]').click();
     await expect(page.locator('[data-testid="fm-archive-card"]')).toHaveCount(0);
   });
@@ -1588,6 +1621,7 @@ test.describe("Archive folder (#47c)", () => {
     await expect(group.locator(".ft-count")).toHaveText("2");
 
     // The archived reply landed in Archive.
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-archive"]').click();
     await expect(
       page.locator('[data-testid="fm-archive-card"]'),
@@ -1621,6 +1655,7 @@ test.describe("Archive folder (#47c)", () => {
     await expect(group.locator(".ft-count")).toHaveText("2");
 
     // Delete leaves no Archive trace.
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-archive"]').click();
     await expect(
       page.locator('[data-testid="fm-archive-card"]'),
@@ -1643,6 +1678,7 @@ test.describe("Archive folder (#47c)", () => {
       .locator('[data-testid="fm-archive"]')
       .dispatchEvent("click");
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-archive"]').click();
     await page.locator('[data-testid="fm-archive-card"]').first().click();
     await page.locator('[data-testid="fm-archive-delete"]').dispatchEvent("click");
@@ -1726,6 +1762,7 @@ test.describe("Sender trust badge (#51)", () => {
     await page.goto("/");
     await waitForApp(page);
     await selectIdentity(page, "address1");
+    await openNav(page);
     await page.locator('[data-testid="fm-compose-btn"]').click();
 
     const label = page.locator('[data-testid="fm-compose-sending-as"]');
@@ -1765,6 +1802,7 @@ test.describe("Sidebar fingerprint (#48)", () => {
     const fp = page.locator('[data-testid="fm-sidebar-fingerprint"]');
     const fpA = await fp.textContent();
 
+    await openNav(page);
     await page.locator('[data-testid="fm-logout"]').click();
     await selectIdentity(page, "address2");
 
@@ -1794,6 +1832,7 @@ test.describe("Sent delivery state (#58)", () => {
       clickSend(page),
     ]);
 
+    await openNav(page);
     await page.locator('[data-testid="fm-folder-sent"]').click();
     const card = page.locator('[data-testid="fm-sent-card"]').first();
     await expect(card).toBeVisible();
@@ -1894,6 +1933,7 @@ test.describe("Regression #158: contact modals mount inside inbox", () => {
     await selectIdentity(page, "address1");
 
     // Open Settings → Contacts via the sidebar button.
+    await openNav(page);
     await page.locator('[data-testid="fm-sidebar-contacts"]').click();
     await page
       .locator('[data-testid="fm-settings-shell"]')
@@ -1915,6 +1955,7 @@ test.describe("Regression #158: contact modals mount inside inbox", () => {
     await selectIdentity(page, "address1");
 
     // Open Settings → Contacts via the sidebar button.
+    await openNav(page);
     await page.locator('[data-testid="fm-sidebar-contacts"]').click();
     await page
       .locator('[data-testid="fm-settings-shell"]')

--- a/ui/tests/repro-106-107.spec.ts
+++ b/ui/tests/repro-106-107.spec.ts
@@ -118,12 +118,25 @@ async function openIdentity(app: FrameLocator, alias: string) {
     .click();
 }
 
+// Opens the off-canvas sidebar drawer when running on a mobile viewport
+// (<=768px). On desktop the hamburger is display:none, so this is a no-op.
+async function openNav(app: FrameLocator) {
+  const burger = app.locator('[data-testid="fm-hamburger"]');
+  if (await burger.isVisible().catch(() => false)) {
+    await burger.click();
+    await app
+      .locator('[data-testid="fm-compose-btn"]')
+      .waitFor({ state: "visible" });
+  }
+}
+
 async function compose(
   app: FrameLocator,
   to: string,
   subject: string,
   body: string,
 ) {
+  await openNav(app);
   await app.locator('[data-testid="fm-compose-btn"]').click();
   const sheet = app.locator('[data-testid="fm-compose-sheet"]');
   await sheet.locator('input[placeholder="alias or address"]').fill(to);

--- a/ui/tests/testids.ts
+++ b/ui/tests/testids.ts
@@ -15,6 +15,8 @@ interface TestIds {
   fmLogout: string;
   fmSearch: string;
   fmComposeBtn: string;
+  fmHamburger: string;
+  fmBack: string;
   fmList: string;
   fmMsgCard: string;
   fmDraftCard: string;


### PR DESCRIPTION
## Problem

The UI was desktop-only. On a 390px phone the fixed 3-column grid (sidebar 218px + list-col 300px + flex detail) under a 50px topbar with a fixed 218px brand meant:

- Sidebar ate **56%** of the screen width.
- Message list **overflowed offscreen** — subjects clipped.
- Detail pane was **entirely unreachable** (no horizontal scroll).
- Login identity-card action buttons (✎ ↓ ↗ 🗑) **overlapped** the description text.

The whole 2517-line stylesheet had **no width breakpoints** anywhere.

## Fix

Mobile (`<=768px`) collapses the 3-pane into a single navigable pane:

- **New `responsive.css`** with every layout rule inside `@media (max-width:768px)`. **Desktop (>768px) is byte-for-byte unchanged** — the only rules outside the query hide three mobile-only affordances that don't exist in the desktop layout.
- **`data-view` attr** on `div.fm-app` (`"detail"` when a message/thread/sent/archived item is selected, else `"list"`) — a pure derive from the existing `MenuSelection`, **no new selection state**. CSS swaps which of `.list-col` / `.detail-col` shows.
- **Off-canvas sidebar drawer** toggled by a topbar hamburger; a scrim and every nav-tap close it (one new `use_signal`, provided via context).
- **Mobile-only "‹ Back"** button in each detail toolbar (`at_inbox_list`) so single-pane mode never strands the user.

### `:scope` subtlety
Because the `@scope (.fm-app)` root *is* `.fm-app`, the view-swap / drawer rules reference the scope root with `:scope`. A re-named `.fm-app[data-view] …` selector would only match a *nested* `.fm-app` (a descendant of the scope root), which never exists — caught live in-browser, not by static review.

## Tests

- New testids `fm-hamburger` + `fm-back` wired through `testid.rs` / `testids.json` / `testids.ts` (drift guard passes).
- Playwright's `mobile-chrome` profile (Pixel 5, 393px) was failing on off-canvas sidebar clicks; added an `openNav()` helper that opens the drawer before each sidebar interaction (no-op on desktop, where the hamburger is `display:none`).

## Verification

- **In-browser at 390px**: login (no overlap), inbox list (full-width, no clipping), detail + Back, hamburger drawer + scrim — all confirmed via Chrome devtools + computed-style assertions.
- **In-browser at 1280px**: 3-pane intact (sidebar 218px static, list 300px, no hamburger, brand-tag visible).
- `cargo check -p freenet-email-ui` clean.
- Playwright **chromium 73/73** + **mobile-chrome 73/73** (was 5/5 failing on Sent-folder before).

UI presentation only — no contract / API / crypto code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)