### PR TITLE
fix(ui): mobile settings scrolls as one page

### DIFF
--- a/ui/public/vendor/css/components/responsive.css
+++ b/ui/public/vendor/css/components/responsive.css
@@ -100,13 +100,22 @@
   @scope (.fm-app) {
     @media (max-width: 768px) {
 
-      /* ---- Settings shell: 2-col grid (240px 1fr) -> vertical stack ----
-         Desktop keeps position:absolute inset:50px 0 0 0 + overflow:hidden
-         from settings.css; we only change the inner flow to flex-column so
-         the body gets full width instead of ~150px. */
+      /* ---- Settings shell: 2-col grid (240px 1fr) -> single scroll column ----
+         Desktop pins the shell to the viewport (position:absolute inset:50px
+         0 0 0 + overflow:hidden) and gives each pane its OWN inner scroll. On
+         a phone that nested scroll trapped the content behind the full-height
+         nav block (#mobile-settings-scroll). The app root (.fm-app) is
+         position:fixed; overflow:hidden, so the document can't scroll — the
+         shell must own the scroll itself. Keep the viewport-pinned box but
+         make the SHELL the single scroll container (overflow-y:auto) and let
+         both panes flow naturally inside it, so nav + content read as one
+         scrollable page. */
       .fm-settings {
         display: flex;
         flex-direction: column;
+        overflow-y: auto;
+        overflow-x: hidden;
+        -webkit-overflow-scrolling: touch;
       }
 
       /* Sidebar -> full-width top region; sizes to content, does not scroll. */
@@ -173,12 +182,13 @@
       }
       .fm-set-nav-item.is-active { border-color: transparent; }
 
-      /* ---- Main pane: fills remaining height, scrolls internally so the
-         sticky .fm-set-bar (height:50px; position:sticky; top:0) stays pinned. */
+      /* ---- Main pane: grows to fit content (no inner scroll); the document
+         owns the scroll now. The sticky .fm-set-bar sticks to the viewport
+         top while you scroll the page rather than to an inner scroll box. */
       .fm-set-main {
-        flex: 1 1 auto;
+        flex: 0 0 auto;
         min-height: 0;
-        overflow: auto;
+        overflow: visible;
         width: 100%;
       }
 


### PR DESCRIPTION
## Problem

On mobile the Settings screen was unusable: the 2-column nav-card grid filled the viewport and the content below it was unreachable — you couldn't scroll past the menus. (Reported with iPhone screenshot IMG_1382.)

## Cause

The mobile override flipped the shell from grid to flex-column but kept desktop's `overflow:hidden` plus a nested inner scroll on `.fm-set-main`. The full-height nav block (`.fm-set-side`) took its natural height and ate the viewport, leaving the main pane a tiny scroll sliver. `.fm-app` is `position:fixed; overflow:hidden`, so the document can't scroll either — content was trapped.

## Fix

Make `.fm-settings` itself the single scroll container (`overflow-y:auto`) and let `.fm-set-main` grow naturally inside it (`flex:0 0 auto; overflow:visible`). Nav + content now read as one scrollable page; the sticky `.fm-set-bar` still pins.

CSS-only, `responsive.css` only. Every rule lives inside `@media (max-width:768px)` — **desktop (>768px) is byte-for-byte unchanged**.

## Verification

Static harness (faithful DOM + real CSS) at 390×700:
- `scrollHeight 1304 > clientHeight 650` → scrollable
- bottom textarea reachable after scroll
- sticky bar stays pinned
- desktop @1200px: still `grid 240px 1fr`, nested scroll — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)