### PR TITLE
fix(ui): thread-actions a11y order + touch regression test (#317 follow-ups)

### DIFF
--- a/ui/public/vendor/css/components/responsive.css
+++ b/ui/public/vendor/css/components/responsive.css
@@ -89,17 +89,12 @@
      pin it visible below the message body as a normal wrapping row. */
   @scope (.fm-app) {
     @media (hover: none) {
-      /* .ft-nest-actions is the FIRST child of .ft-nest-inner; desktop lifts it
-         out of flow (position:absolute) so source order is irrelevant. Once it's
-         static it would render ABOVE the head/body — so make the card a flex
-         column and order the action cluster last, below the message body. */
-      .ft-nest-inner {
-        display: flex;
-        flex-direction: column;
-      }
+      /* .ft-nest-actions is the LAST child of .ft-nest-inner (app.rs), so once
+         it drops out of absolute flow it naturally renders below the message
+         body — no flex/order hack needed, and DOM order == visual order keeps
+         tab order sane. Desktop keeps the absolute hover-reveal untouched. */
       .ft-nest-inner .ft-nest-actions {
         position: static;
-        order: 10;
         opacity: 1;
         transform: none;
         margin-top: 12px;

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -4274,13 +4274,6 @@ fn ThreadNested(group: crate::app::threads::ThreadGroup) -> Element {
                         "data-testid": testid::FM_THREAD_ROW,
                         "data-msg-id": "{id}",
                         div { class: "ft-nest-inner",
-                            div { class: "ft-nest-actions",
-                                ThreadRowActions {
-                                    msg: actions_msg,
-                                    root_id,
-                                    thread_total,
-                                }
-                            }
                             div { class: "ft-msg-head",
                                 div { class: "ft-face sm", "{from_initial}" }
                                 div { class: "ft-msg-id",
@@ -4322,6 +4315,17 @@ fn ThreadNested(group: crate::app::threads::ThreadGroup) -> Element {
                             if body_open {
                                 div { class: "ft-body-text", style: "margin-top:10px",
                                     {content.split("\n\n").map(|para| rsx! { p { "{para}" } })}
+                                }
+                            }
+                            // #317: actions are LAST in source order. Desktop pins
+                            // them absolute (order-independent); on touch they flow
+                            // statically below the body, so DOM order == visual order
+                            // and tab order reaches them after the message content.
+                            div { class: "ft-nest-actions",
+                                ThreadRowActions {
+                                    msg: actions_msg,
+                                    root_id,
+                                    thread_total,
                                 }
                             }
                         }

--- a/ui/tests/threads.spec.ts
+++ b/ui/tests/threads.spec.ts
@@ -256,6 +256,49 @@ test.describe("Nested thread view (#270)", () => {
     await toggle.dispatchEvent("click");
     await expect(quoteText).toHaveCount(0);
   });
+
+  // #317: on touch (no-hover) devices the per-message action cluster
+  // (.ft-nest-actions) must NOT stay absolute-pinned + opacity:0 — that left a
+  // faded ghost of Reply/Archive/Delete overlapping the sender name, since the
+  // hover-reveal never fires. On (hover: none) the cluster goes static + fully
+  // opaque, in normal flow below the message body. This locks the responsive.css
+  // override against future stylesheet-order regressions. The assertion is
+  // pointer-aware: it checks whichever state matches the running profile's
+  // (hover) media — `static`/opaque on mobile-chrome (Pixel 5), absolute/hidden
+  // on the hover-capable chromium (Desktop Chrome) project.
+  test("touch devices show thread actions in flow, not as an absolute hidden overlay", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectIdentity(page, "address1");
+
+    await openSeededThread(page);
+    const container = page.locator(`[data-testid="${TID.fmThreadContainer}"]`);
+    await expect(container.locator(".ft-nest")).toHaveCount(1);
+
+    const actions = container.locator(".ft-nest-actions").first();
+    await expect(actions).toHaveCount(1);
+
+    const computed = await actions.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return {
+        noHover: window.matchMedia("(hover: none)").matches,
+        position: cs.position,
+        opacity: cs.opacity,
+      };
+    });
+
+    if (computed.noHover) {
+      // Touch profile: cluster pulled into flow, always visible.
+      expect(computed.position).toBe("static");
+      expect(Number(computed.opacity)).toBeGreaterThan(0);
+    } else {
+      // Hover-capable profile: untouched desktop hover-reveal.
+      expect(computed.position).toBe("absolute");
+      expect(Number(computed.opacity)).toBe(0);
+    }
+  });
 });
 
 // ─── Compact view ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-ups from the [#317 review](https://github.com/freenet/mail/pull/317).

## 1. DOM/visual order mismatch (a11y)

#317 pushed the first-child `.ft-nest-actions` cluster below the message body on touch using a `display:flex; flex-direction:column` + `order:10` hack. That fixed the *visual* order but left the cluster **first in DOM / tab order** — keyboard users hit Reply/Archive/Delete before the message content.

Fix: move `.ft-nest-actions` to be the **last child** of `.ft-nest-inner` in the markup (`app.rs`). Desktop pins it `position:absolute` (order-independent), so the reorder is invisible there; on touch it now flows naturally below the body **and** tab order matches. The flex/order hack is dropped from `responsive.css` — only `position:static; opacity:1` + spacing remain.

## 2. Regression test

Pointer-aware assertion added to `threads.spec.ts`, runs on both CI projects:

| Profile | `(hover)` | asserts |
|---|---|---|
| mobile-chrome (Pixel 5) | `none` | `position:static`, opacity > 0 |
| chromium (Desktop Chrome) | `hover` | `position:absolute`, opacity == 0 |

Locks the behaviour against future stylesheet-reorder regressions. Full `threads.spec.ts` (20 tests, both projects) passes locally.

## 3. Not fixed (intentional)

Review note: *"touchscreen laptop with mouse-primary reports `hover:hover`, keeps desktop behaviour."* Inherent `(hover)` media-query limitation, not a regression — keying off the **primary** pointer is the correct default. No change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)